### PR TITLE
docs: complete documentation suite in docs/ for all user levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
 | **Skill** | A reusable module invoked by agents to perform a focused, composable task |
 | **Prompt** | A single-shot LLM instruction for one well-defined workflow |
 
+## Documentation
+
+Full documentation lives in [`docs/`](docs/README.md) — covering installation, core concepts, a step-by-step quickstart, CLI reference, configuration, providers, MCP integration, the chat REPL, cost ledger, registry, writing definitions, and package internals.
+
 ## Quickstart
 
 ```bash
@@ -41,33 +45,7 @@ my-project/
     └── prompts/  my-prompt.prompt.md
 ```
 
-A minimal agent definition:
-
-```markdown
----
-name: My Agent
-description: Does something useful.
-complexity: small
----
-
-# Agent Persona: My Agent
-
-Your task is to …
-```
-
-## Bundled examples
-
-`uio init --examples` installs these ready-to-run definitions:
-
-| Name | Type | What it does |
-|---|---|---|
-| `shell-helper` | agent | Suggest a shell command for a task and optionally run it |
-| `repo-health` | agent | Run tests, lint, TODO count, stale branches, open PRs |
-| `summarise` | skill | Summarise text or a file |
-| `explain-code` | skill | Explain a source file in plain English |
-| `changelog-entry` | skill | Turn a `git diff` into a conventional-commit changelog entry |
-| `debug-traceback` | skill | Explain a Python traceback and suggest a fix |
-| `ask-docs` | prompt | Ask a focused question about a codebase |
+See [Writing Definitions](docs/12-writing-definitions.md) for the full file format and authoring guide.
 
 ## Registry
 

--- a/docs/01-installation.md
+++ b/docs/01-installation.md
@@ -1,0 +1,142 @@
+# Installation
+
+## Prerequisites
+
+- **Python 3.11 or later.** uio uses `tomllib` from the standard library (added in 3.11) and type annotation syntax that requires 3.11+. Check your version with `python3 --version`.
+- **pip.** Comes with every standard Python installation.
+
+You do not need Node.js to use uio's core features. Node.js is only needed if you want GitHub MCP server integration (see [MCP integration](08-mcp.md)).
+
+---
+
+## Install from PyPI
+
+```bash
+pip install uio
+```
+
+Verify the installation:
+
+```bash
+uio --version
+# uio, version 0.1.0
+```
+
+---
+
+## Optional: dev extras
+
+The `dev` extras add the test runner and linter used during development:
+
+```bash
+pip install "uio[dev]"
+```
+
+This installs `pytest` and `ruff`. You only need this if you are running the test suite or contributing to uio itself.
+
+---
+
+## Install from source
+
+For contributors or to run unreleased code:
+
+```bash
+git clone https://github.com/jomkz/uio.git
+cd uio
+pip install -e ".[dev]"
+```
+
+The `-e` flag installs in editable mode — changes to the source tree take effect immediately without reinstalling.
+
+Verify the test suite passes:
+
+```bash
+pytest
+# 150+ tests, no API keys required
+```
+
+---
+
+## Shell completion
+
+uio can generate completion scripts for bash, zsh, and fish. Add the appropriate line to your shell's startup file.
+
+**bash** — add to `~/.bashrc`:
+```bash
+eval "$(uio completion bash)"
+```
+
+**zsh** — add to `~/.zshrc`:
+```bash
+eval "$(uio completion zsh)"
+```
+
+**fish** — add to `~/.config/fish/config.fish`:
+```fish
+uio completion fish | source
+```
+
+Restart your shell or `source` the file to activate completion. You can then press Tab to complete `uio` subcommands, agent names, and flags.
+
+---
+
+## First-time setup
+
+After installing, run `uio config show` to see what providers are available:
+
+```
+$ uio config show
+
+  Provider chain (auto-routing order):
+    gemini    GEMINI_API_KEY       ✗ not set
+    openai    OPENAI_API_KEY       ✗ not set
+    ollama    (no key required)    ✓ always available
+
+  Default provider : (none — uses routing chain)
+  Default model    : (none — inferred from provider)
+  MCP github       : ✗ GITHUB_PERSONAL_ACCESS_TOKEN not set
+  Cost ledger      : uio_cost.jsonl
+  Timeout          : 300s
+```
+
+A `✗` next to a provider means its API key is not set — that provider is skipped in the auto-routing chain. Ollama is always available as a fallback (it needs no key, but the Ollama process must be running locally).
+
+Set at least one API key before running agents:
+
+```bash
+export GEMINI_API_KEY=your-key-here
+```
+
+See [Providers](07-providers.md) for detailed setup instructions for each provider.
+
+---
+
+## Troubleshooting
+
+**`ModuleNotFoundError: No module named 'google.genai'`**
+
+The `google-genai` package is a dependency of uio and should install automatically. If it didn't:
+
+```bash
+pip install google-genai
+```
+
+**`ModuleNotFoundError: No module named 'openai'`**
+
+```bash
+pip install openai
+```
+
+**`uio chat` connects but Ollama returns a connection error**
+
+The Ollama process must be running. Start it with `ollama serve`. The default endpoint is `http://localhost:11434/v1`. If your Ollama instance runs elsewhere, set `OLLAMA_BASE_URL`.
+
+**`uio: command not found`**
+
+The `uio` script is installed into your Python environment's `bin/` directory. If that directory is not on your `PATH`, either:
+- Activate a virtual environment: `source .venv/bin/activate`
+- Or add the directory to PATH: `export PATH="$HOME/.local/bin:$PATH"` (for user-level installs)
+
+**Python version is 3.10 or older**
+
+uio requires Python 3.11+. Install a newer version via your OS package manager, `pyenv`, or `deadsnakes` PPA (Ubuntu).

--- a/docs/02-concepts.md
+++ b/docs/02-concepts.md
@@ -1,0 +1,92 @@
+# Core Concepts
+
+## The UIO analogy
+
+The name `uio` comes from Linux's **Userspace I/O** framework. In Linux, UIO lets a kernel device driver export its interface directly to a userspace application — the application calls the device's logic without the kernel needing to know about each specific device type. There is no per-device kernel module, just a generic bridge.
+
+`uio` applies the same idea to AI automation. Your agent and prompt definitions — plain markdown files with YAML frontmatter — export their logic directly to the `uio` CLI. The CLI does not need to know anything about your specific workflow. There is no per-project integration to write; just drop a file into `.uio/` and it becomes a runnable command.
+
+---
+
+## The three definition types
+
+Every `uio` definition is a markdown file. The file type is encoded in the filename extension, and the YAML frontmatter at the top controls how the runtime handles it.
+
+### Agents (`.agent.md`)
+
+An agent runs in a **multi-turn tool-use loop**. The definition body becomes the system prompt. The runtime sends the system prompt and an initial user message to the model, then alternates between letting the model call tools and feeding tool results back until the model produces a response with no tool calls (or the 10-iteration cap is reached).
+
+The only built-in tool is `run_command`, which runs any shell command and returns stdout + stderr. If a GitHub token is set, MCP tools are also available (see [MCP integration](08-mcp.md)).
+
+Use an agent when the task requires **intermediate decisions** — reading a file to decide what to do next, running a test to see if a fix worked, querying an API before generating a report.
+
+Example: `repo-health.agent.md` runs tests, counts TODOs, checks for stale branches, and compiles a health report — all in one agentic loop.
+
+### Skills (`.skill.md`)
+
+A skill runs the **same tool-use loop as an agent** but is scoped to a single, focused task intended to be composable. There is no runtime difference between an agent and a skill — the distinction is a convention that communicates intent: skills are small, reusable building blocks; agents are higher-level workflows.
+
+Use a skill when you want something that does one thing well and can be referenced by name in another definition's body.
+
+Example: `summarise.skill.md` takes text (passed as an argument or via stdin) and returns a concise summary.
+
+### Prompts (`.prompt.md`)
+
+A prompt is **single-shot**: the definition body is sent to the model once, the response is printed, and the process exits. There is no tool-use loop.
+
+When `invokable: true` is set in frontmatter, the `uio prompt run <name> <arg>` command appends `arg` to the prompt body before sending. The body should read naturally with the appended argument.
+
+Use a prompt for well-defined, one-shot queries where you want the model to respond directly without needing to run shell commands.
+
+Example: `ask-docs.prompt.md` answers a focused question about a codebase by appending the question as a final line.
+
+---
+
+## Comparison table
+
+| | **Agent** | **Skill** | **Prompt** |
+|---|---|---|---|
+| Tool-use loop | Yes | Yes | No |
+| `run_command` access | Yes | Yes | No |
+| MCP tool access | Yes | Yes | No |
+| Iteration cap | 10 | 10 | — |
+| Complexity tier | `small` / `large` | `small` / `large` | — |
+| `invokable` frontmatter | No | No | Optional |
+| Typical use | Multi-step workflow | Focused subtask | One-shot query |
+
+---
+
+## The `.uio/` directory
+
+`.uio/` is your project's AI configuration layer — analogous to `.github/` for GitHub Actions or `.vscode/` for editor settings. It lives at the root of your project and contains your definitions:
+
+```
+my-project/
+├── .uio/
+│   ├── agents/    *.agent.md
+│   ├── skills/    *.skill.md
+│   └── prompts/   *.prompt.md
+├── uio.toml       # optional project config
+└── uio_cost.jsonl # cost ledger (add to .gitignore)
+```
+
+Run `uio init` to scaffold this structure. Run `uio init --examples` to also install the bundled example definitions.
+
+The directories are configurable via `uio.toml` (see [Configuration](06-configuration.md)).
+
+---
+
+## How a definition becomes a run
+
+Every `uio agent run` / `uio skill run` / `uio prompt run` invocation:
+
+1. Reads the definition file fresh from disk (no caching — edits take effect immediately)
+2. Parses the YAML frontmatter block
+3. Validates required fields (`name`, `description`)
+4. Constructs the system prompt (runtime preamble + definition body)
+5. Selects a provider and model via the routing chain
+6. Optionally starts the GitHub MCP server
+7. Runs the tool-use loop (agents/skills) or single-shot request (prompts)
+8. Appends a cost entry to `uio_cost.jsonl`
+
+The definition file is the single source of truth for behaviour. Moving, editing, or deleting it immediately affects the next run.

--- a/docs/03-quickstart.md
+++ b/docs/03-quickstart.md
@@ -1,0 +1,199 @@
+# Quickstart
+
+This tutorial takes you from a fresh install to running your first agent and reading a cost report. It assumes you have already installed uio (see [Installation](01-installation.md)).
+
+Total time: about ten minutes.
+
+---
+
+## Step 1 — Set an API key
+
+uio needs at least one LLM provider. Gemini is the cheapest and easiest to start with:
+
+1. Go to [Google AI Studio](https://aistudio.google.com/apikey) and create an API key.
+2. Export it in your terminal:
+
+```bash
+export GEMINI_API_KEY=your-key-here
+```
+
+To make this permanent, add the export line to your `~/.bashrc` (or `~/.zshrc`).
+
+If you prefer OpenAI, use `export OPENAI_API_KEY=your-key-here` instead. For a fully offline option, see [Providers — Ollama](07-providers.md#ollama) — no API key required.
+
+Confirm uio can see the key:
+
+```bash
+uio config show
+# gemini  GEMINI_API_KEY  ✓ set
+```
+
+---
+
+## Step 2 — Scaffold your project
+
+Navigate to any directory (a git repo works well):
+
+```bash
+cd ~/my-project
+uio init --examples
+```
+
+Expected output:
+
+```
+  Created directory: .uio/agents/
+  Created directory: .uio/skills/
+  Created directory: .uio/prompts/
+  Created: .uio/agents/example.agent.md
+  Created: .uio/skills/example.skill.md
+  Created: .uio/prompts/example.prompt.md
+  Created: .uio/agents/shell-helper.agent.md
+  Created: .uio/agents/repo-health.agent.md
+  Created: .uio/skills/summarise.skill.md
+  Created: .uio/skills/explain-code.skill.md
+  Created: .uio/skills/changelog-entry.skill.md
+  Created: .uio/skills/debug-traceback.skill.md
+  Created: .uio/prompts/ask-docs.prompt.md
+  Added 'uio_cost.jsonl' to .gitignore
+
+Done. Run 'uio agent list' to see available agents.
+```
+
+`--examples` installs seven bundled real-world definitions. Without `--examples`, only the three starter template files (example.agent.md, example.skill.md, example.prompt.md) are created.
+
+---
+
+## Step 3 — Explore available definitions
+
+```bash
+uio agent list
+```
+
+```
+  NAME          COMPLEXITY  DESCRIPTION
+  example       small       A starter agent — edit to fit your workflow.
+  repo-health   large       Run tests, lint, TODO count, stale branches, and open PRs.
+  shell-helper  small       Suggest a shell command for a task and optionally run it.
+```
+
+```bash
+uio skill list
+```
+
+```
+  NAME             DESCRIPTION
+  changelog-entry  Turn a git diff into a conventional-commit changelog entry.
+  debug-traceback  Explain a Python traceback and suggest a fix.
+  example          A starter skill — edit to fit your workflow.
+  explain-code     Explain a source file in plain English.
+  summarise        Summarise text or a file.
+```
+
+---
+
+## Step 4 — Run a skill
+
+Skills are great for quick, focused tasks. Let's summarise some text:
+
+```bash
+uio skill run summarise "Pipes in Unix connect the stdout of one process to the stdin of another, letting you compose small programs into powerful one-liners."
+```
+
+The model responds with a concise summary. You'll see the provider and model used printed at the start:
+
+```
+  [uio] Running skill 'summarise' via gemini/gemini-2.0-flash-lite
+
+Unix pipes connect process outputs to inputs, enabling powerful composition of small programs.
+```
+
+---
+
+## Step 5 — Run an agent with tool use
+
+Agents can execute shell commands. Let's ask `shell-helper` for a command:
+
+```bash
+uio agent run shell-helper "show me all git branches sorted by last commit date"
+```
+
+When the model wants to run a command, uio prints it and asks for your approval:
+
+```
+  [uio] Running agent 'shell-helper' via gemini/gemini-2.0-flash-lite
+
+  $ git branch --sort=-committerdate
+  Execute? [Y/n]
+```
+
+Press Enter (or `y`) to approve. The command runs and the output is fed back to the model, which then produces its final answer.
+
+To skip approval for all commands, use `--auto-approve`:
+
+```bash
+uio agent run shell-helper "show disk usage of the top 5 directories" --auto-approve
+```
+
+---
+
+## Step 6 — Inspect a definition
+
+Before editing, look at what's inside:
+
+```bash
+uio skill inspect summarise
+```
+
+```
+  name        : summarise
+  description : Summarise text or a file
+  ---
+  # Skill: Summarise
+
+  You are a precise summariser. When given text or a file path, produce a
+  concise summary that captures the key points in plain English. Aim for
+  1–3 sentences unless the input is very long.
+  ...
+```
+
+---
+
+## Step 7 — Edit a definition
+
+Open `.uio/skills/summarise.skill.md` in any editor. Change the instruction in the body — for example, ask for bullet points instead of prose. Save the file and re-run the same skill:
+
+```bash
+uio skill run summarise "Unix pipes connect process stdout to stdin."
+```
+
+The change takes effect immediately — there is no reload or restart step.
+
+---
+
+## Step 8 — Check your cost
+
+```bash
+uio cost
+```
+
+```
+  TIMESTAMP            AGENT        PROVIDER  MODEL                     TOKENS  COST
+  ───────────────────────────────────────────────────────────────────────────────────
+  2026-04-30 12:01:05  summarise    gemini    gemini-2.0-flash-lite        892  $0.000089
+  2026-04-30 12:02:14  shell-helper gemini    gemini-2.0-flash-lite       1243  $0.000124
+
+Total: 2 run(s) | 2,135 tokens | $0.000213
+```
+
+The ledger is stored in `uio_cost.jsonl` (already in your `.gitignore`). See [Cost ledger](10-cost.md) for filtering and `jq` recipes.
+
+---
+
+## What's next
+
+- **Write your first agent**: copy `.uio/agents/example.agent.md` and edit the body to describe your task. See [Writing definitions](12-writing-definitions.md).
+- **Configure a different provider**: see [Providers](07-providers.md).
+- **Search for community definitions**: see [Registry](11-registry.md).
+- **Start an interactive chat session**: `uio chat` — see [Chat REPL](09-chat.md).
+- **Understand the full CLI**: see [CLI reference](05-cli.md).

--- a/docs/04-frontmatter.md
+++ b/docs/04-frontmatter.md
@@ -1,0 +1,220 @@
+# Frontmatter Schema Reference
+
+Every uio definition file starts with a YAML frontmatter block delimited by `---`:
+
+```
+---
+name: My Agent
+description: Does something useful.
+complexity: small
+---
+
+# Agent body starts here
+```
+
+The frontmatter is parsed by `uio/schema/parser.py`. Unknown keys produce a warning from `uio validate`; missing required fields produce an error that causes `uio validate` to exit non-zero.
+
+---
+
+## Common fields (all types)
+
+These two fields are required on every definition regardless of type.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | Yes | Display name shown in `list` output and in the cost ledger |
+| `description` | string | Yes | One-line summary shown in `list` output |
+
+---
+
+## Agent fields (`.agent.md`)
+
+```yaml
+---
+name: My Agent
+description: Does something useful.
+complexity: small
+tools:
+  - terminal
+  - github
+timeout: 300
+---
+```
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `name` | string | Yes | — | Display name |
+| `description` | string | Yes | — | One-line summary |
+| `complexity` | `large` \| `small` | No | `small` | Model tier selection — see below |
+| `tools` | list of strings | No | — | Informational only; documents which tool families the agent uses; not enforced by the runtime |
+| `timeout` | integer (seconds) | No | 300 | Per-command shell timeout for `run_command` calls |
+
+### Complexity tier resolution
+
+The complexity tier controls which model is selected for a run. The resolution order is (highest priority first):
+
+1. `--complexity` CLI flag
+2. `complexity:` field in frontmatter
+3. The agent's name appears in `[large_agents].names` in `uio.toml`
+4. Default: `small`
+
+Once the tier is resolved, the model is selected based on the provider:
+
+| Provider | `large` | `small` |
+|---|---|---|
+| `gemini` | `gemini-2.5-flash` | `gemini-2.0-flash-lite` |
+| `openai` | `gpt-4o` | `gpt-4o-mini` |
+| `ollama` | `qwen2.5-coder:32b` | `qwen2.5-coder:7b` |
+
+Use `complexity: large` for multi-step analysis tasks, code review, or anything where reasoning quality matters more than cost. Use `complexity: small` (the default) for most agents.
+
+---
+
+## Skill fields (`.skill.md`)
+
+```yaml
+---
+name: My Skill
+description: Does one focused thing.
+---
+```
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `name` | string | Yes | — | Display name |
+| `description` | string | Yes | — | One-line summary |
+
+Skills do not have a `complexity` field in frontmatter. When run standalone via `uio skill run`, the complexity defaults to `small` (overridable with `--complexity`). Skills are intentionally minimal — their scope should be small enough that the small model tier is appropriate.
+
+---
+
+## Prompt fields (`.prompt.md`)
+
+```yaml
+---
+name: my-prompt
+description: Answers a focused question about a codebase.
+argument-hint: "[topic]"
+invokable: true
+---
+```
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `name` | string | Yes | — | Display name (also used as the CLI argument to `uio prompt run`) |
+| `description` | string | Yes | — | One-line summary |
+| `argument-hint` | string or list | No | — | Shown in `uio prompt list`; describes the expected positional argument |
+| `invokable` | boolean | No | `false` | When `true`, a positional `ARG` passed to `uio prompt run <name> <arg>` is appended to the prompt body |
+
+### `argument-hint` as a list
+
+When a prompt accepts multiple argument forms, `argument-hint` can be a YAML list:
+
+```yaml
+argument-hint:
+  - "[file-path]"
+  - "[question]"
+```
+
+`uio prompt list` displays all variants.
+
+### How `invokable` works
+
+When `invokable: true` and `uio prompt run my-prompt "what is a closure?"` is run, the argument `"what is a closure?"` is appended as a new line at the end of the prompt body before the request is sent. There is no template interpolation — the body and the argument are concatenated literally. Write the body so it reads naturally with or without the appended argument:
+
+```markdown
+---
+name: ask-docs
+description: Ask a focused question about a codebase.
+argument-hint: "[question]"
+invokable: true
+---
+
+You are a precise technical writer. Answer the following question about this
+codebase using only information visible in the source code. Be concise.
+
+Question:
+```
+
+When run as `uio prompt run ask-docs "what does the cost ledger store?"`, the final line becomes `Question:\nwhat does the cost ledger store?`
+
+---
+
+## Validation
+
+`uio validate` parses all definition files in the configured directories and checks:
+
+- **Error** (exits non-zero): `name` or `description` is missing or empty
+- **Warning** (exits zero): an unrecognised frontmatter key is present
+
+Known keys (do not produce warnings):
+
+```
+name  description  complexity  tools  timeout  argument-hint  invokable
+```
+
+Any other key produces a warning. This is intentional — it catches typos like `Complexity: large` (capitalised) that would silently be ignored.
+
+---
+
+## Annotated examples
+
+### Full agent
+
+```markdown
+---
+name: repo-health
+description: Run tests, lint, TODO count, stale branches, and open PRs.
+complexity: large
+tools:
+  - terminal
+  - github
+timeout: 600
+---
+
+# Agent: repo-health
+
+Run a comprehensive health check on this Git repository and produce a
+structured report. Check each of the following in order:
+
+1. Run the test suite and report pass/fail counts and any failures.
+2. Run the linter and report error and warning counts.
+3. Count TODO/FIXME comments across all source files.
+4. List branches with no commits in the last 30 days.
+5. List open pull requests older than 7 days.
+
+Produce a final Markdown report with a section for each item above.
+Use `gh` CLI for GitHub operations.
+```
+
+### Full skill
+
+```markdown
+---
+name: summarise
+description: Summarise text or a file.
+---
+
+# Skill: Summarise
+
+You are a precise summariser. When given text or a file path, produce a
+concise summary in 1–3 sentences that captures the key points. Preserve
+technical accuracy. Do not add information not present in the input.
+```
+
+### Full prompt
+
+```markdown
+---
+name: ask-docs
+description: Ask a focused question about a codebase.
+argument-hint: "[question]"
+invokable: true
+---
+
+You are a precise technical writer. Answer the following question about this
+codebase using only information visible in the source code. Be concise and
+cite the relevant file or function name where possible.
+
+Question:
+```

--- a/docs/05-cli.md
+++ b/docs/05-cli.md
@@ -1,0 +1,345 @@
+# CLI Reference
+
+## Command tree
+
+```
+uio
+├── agent
+│   ├── run <name> [arg]
+│   ├── list
+│   ├── inspect <name>
+│   └── new <name>
+├── skill
+│   ├── run <name> [arg]
+│   ├── list
+│   ├── inspect <name>
+│   └── new <name>
+├── prompt
+│   ├── run <name> [arg]
+│   └── list
+├── chat
+├── cost
+├── config
+│   ├── show
+│   └── init
+├── init
+├── validate
+├── registry
+│   ├── list
+│   ├── search <query>
+│   ├── update
+│   └── install <name>
+└── completion [bash|zsh|fish]
+```
+
+---
+
+## Global flags
+
+| Flag | Description |
+|---|---|
+| `--version` | Print version and exit |
+| `--help` | Print help for any command |
+
+---
+
+## Shared run flags
+
+The following flags apply to `agent run`, `skill run`, and `prompt run`:
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--provider` | `gemini\|openai\|ollama` | auto | Force a specific provider; bypasses the routing chain |
+| `--model` | string | inferred | Model name override; bypasses tier selection entirely |
+| `--complexity` | `large\|small` | inferred | Complexity tier override |
+| `--base-url` | URL | env/config | OpenAI-compatible base URL (LiteLLM, Azure, local proxy) |
+| `--timeout` | integer | 300 | Per-command shell timeout in seconds |
+| `--no-mcp` | flag | off | Disable GitHub MCP server even when token is set |
+
+---
+
+## `uio agent`
+
+### `uio agent run <name> [arg]`
+
+Runs a named agent from `.uio/agents/<name>.agent.md`.
+
+`NAME` is the stem of the filename (without `.agent.md`).
+`ARG` is an optional string appended to the initial user message.
+
+```bash
+uio agent run my-agent
+uio agent run my-agent "focus on the auth module"
+uio agent run my-agent --provider openai --complexity large
+uio agent run my-agent --no-mcp
+```
+
+Exit code: 0 on success, 1 if the definition file is not found or validation fails.
+
+### `uio agent list`
+
+Lists all `.agent.md` files in the configured agents directory.
+
+Output columns: NAME, COMPLEXITY, DESCRIPTION
+
+```bash
+uio agent list
+```
+
+### `uio agent inspect <name>`
+
+Prints the frontmatter fields and the first 20 lines of the body for a named agent.
+
+```bash
+uio agent inspect repo-health
+```
+
+### `uio agent new <name>`
+
+Scaffolds a new `.agent.md` file from a template.
+
+```bash
+uio agent new data-pipeline
+# Creates .uio/agents/data-pipeline.agent.md
+```
+
+---
+
+## `uio skill`
+
+### `uio skill run <name> [arg]`
+
+Runs a named skill from `.uio/skills/<name>.skill.md`. Skills use the same tool-use loop as agents.
+
+```bash
+uio skill run summarise "Unix pipes connect process stdout to stdin."
+uio skill run explain-code src/main.py
+```
+
+Accepts the same shared run flags as `agent run`.
+
+### `uio skill list`
+
+Lists all `.skill.md` files in the configured skills directory.
+
+Output columns: NAME, DESCRIPTION
+
+### `uio skill inspect <name>`
+
+Prints frontmatter and body preview for a named skill.
+
+### `uio skill new <name>`
+
+Scaffolds a new `.skill.md` file from a template.
+
+---
+
+## `uio prompt`
+
+### `uio prompt run <name> [arg]`
+
+Runs a named prompt from `.uio/prompts/<name>.prompt.md`. Single-shot — no tool loop.
+
+`ARG` is only used when `invokable: true` is set in the prompt's frontmatter; it is appended to the prompt body before sending.
+
+```bash
+uio prompt run ask-docs "what does the cost ledger store?"
+```
+
+Accepts `--provider`, `--model`, `--base-url`. Does not accept `--complexity`, `--timeout`, or `--no-mcp` (no tool loop).
+
+### `uio prompt list`
+
+Lists all `.prompt.md` files.
+
+Output columns: NAME, ARGUMENT, DESCRIPTION
+
+---
+
+## `uio chat`
+
+Starts an interactive streaming multi-turn REPL.
+
+```bash
+uio chat
+uio chat --provider ollama
+uio chat --tools
+uio chat --tools --allow 'git *' --deny 'git push*'
+uio chat --auto-approve
+uio chat --system /path/to/system-prompt.txt
+```
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--provider` | string | auto | LLM provider |
+| `--model` | string | inferred | Model override |
+| `--base-url` | URL | env | OpenAI-compatible endpoint |
+| `--system` | path | built-in | File whose contents become the system prompt |
+| `--tools` | flag | off | Expose `run_command` to the model |
+| `--auto-approve` | flag | off | Skip per-command approval prompts; implies `--tools` |
+| `--allow` | glob | — | Auto-approve commands matching this shell glob (repeatable) |
+| `--deny` | glob | — | Always reject commands matching this shell glob (repeatable) |
+
+Slash commands inside the REPL: `/help`, `/clear`, `/cost`, `/exit`, `/quit`
+
+See [Chat REPL](09-chat.md) for full details.
+
+---
+
+## `uio cost`
+
+Summarises token spend from the cost ledger.
+
+```bash
+uio cost
+uio cost --tail 20
+uio cost --since 2026-04-01
+uio cost --since "2026-04-30T10:00:00"
+uio cost --json
+uio cost --json | jq '.estimated_cost_usd'
+uio cost --ledger /path/to/other.jsonl
+```
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--tail` | integer | — | Show only the last N entries |
+| `--since` | ISO 8601 date | — | Show entries on or after this date/datetime |
+| `--json` | flag | off | Emit raw JSON lines (one per entry) instead of a table |
+| `--ledger` | path | from config | Path to the cost ledger file |
+
+See [Cost ledger](10-cost.md) for `jq` recipes and the full ledger schema.
+
+---
+
+## `uio config`
+
+### `uio config show`
+
+Prints the resolved configuration: provider chain with key status, default provider/model, MCP status, cost ledger path, and timeout.
+
+```bash
+uio config show
+```
+
+### `uio config init`
+
+Writes a starter `uio.toml` to the current directory. Does not overwrite an existing file.
+
+```bash
+uio config init
+```
+
+---
+
+## `uio init`
+
+Scaffolds `.uio/agents/`, `.uio/skills/`, and `.uio/prompts/` with one template file each. Also adds the cost ledger filename to `.gitignore` if a `.gitignore` file exists.
+
+```bash
+uio init
+uio init --examples
+```
+
+| Flag | Description |
+|---|---|
+| `--examples` | Also install the seven bundled real-world example definitions |
+
+Existing files are skipped (not overwritten).
+
+---
+
+## `uio validate`
+
+Parses all definition files in the configured directories and checks required frontmatter fields. Warns on unrecognised keys.
+
+```bash
+uio validate
+```
+
+Exit code: 0 if all files are valid, 1 if any errors are found. Warnings do not affect the exit code.
+
+---
+
+## `uio registry`
+
+### `uio registry list`
+
+Lists all registries configured in `uio.toml` with their URL, ref, and enabled status.
+
+### `uio registry search <query>`
+
+Searches across all enabled registries. Matches `name`, `description`, and `tags` (case-insensitive).
+
+```bash
+uio registry search summarise
+uio registry search code --registry official
+```
+
+| Flag | Description |
+|---|---|
+| `--registry` | Restrict search to the named registry |
+
+### `uio registry update`
+
+Force-refreshes all cached registry manifests. Exits 1 if any registry fails.
+
+```bash
+uio registry update
+uio registry update --registry official
+```
+
+### `uio registry install <name>`
+
+Installs a definition from a registry into the appropriate `.uio/` subdirectory. First match across enabled registries wins.
+
+```bash
+uio registry install summarise
+uio registry install repo-health --registry official
+uio registry install repo-health --pin
+uio registry install repo-health --force
+```
+
+| Flag | Description |
+|---|---|
+| `--registry` | Use only this registry when resolving NAME |
+| `--pin` | Resolve the registry ref to a commit SHA and print the `uio.toml` stanza to paste |
+| `--force` | Overwrite an existing local definition |
+
+---
+
+## `uio completion`
+
+Prints a shell completion script.
+
+```bash
+eval "$(uio completion bash)"    # bash
+eval "$(uio completion zsh)"     # zsh
+uio completion fish | source     # fish
+```
+
+---
+
+## Environment variables
+
+| Variable | Purpose | Overridden by |
+|---|---|---|
+| `GEMINI_API_KEY` | Gemini provider authentication | — |
+| `OPENAI_API_KEY` | OpenAI / LiteLLM authentication | — |
+| `OPENAI_BASE_URL` | Override OpenAI base URL | `--base-url` flag |
+| `OLLAMA_BASE_URL` | Ollama base URL (default: `http://localhost:11434/v1`) | `--base-url` flag |
+| `GITHUB_PERSONAL_ACCESS_TOKEN` | Enables GitHub MCP server; used for registry fetches | — |
+| `GITHUB_TOKEN` | Alternative to `GITHUB_PERSONAL_ACCESS_TOKEN` | — |
+| `MCP_GITHUB_COMMAND` | Override MCP server launch command | `[mcp.github].command` in uio.toml |
+| `LLM_PROVIDER` | Default provider | `--provider` flag, `uio.toml` `default_provider` |
+| `LLM_MODEL` | Default model | `--model` flag |
+
+---
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Success |
+| 1 | General error (file not found, validation failed, network error, provider failed) |
+
+All errors are written to stderr. Normal output goes to stdout, making it safe to pipe `uio cost --json`, `uio agent list`, etc.

--- a/docs/06-configuration.md
+++ b/docs/06-configuration.md
@@ -1,0 +1,204 @@
+# Configuration (`uio.toml`)
+
+`uio.toml` is an optional project-level configuration file. When present in the current working directory, it sets defaults for that project without requiring environment variables or repeated CLI flags.
+
+---
+
+## When to create `uio.toml`
+
+You need `uio.toml` when you want to:
+
+- Persist a preferred provider or model for a specific project (so you don't need `--provider` every time)
+- Point `uio` at definition directories other than `.uio/agents/`, `.uio/skills/`, `.uio/prompts/`
+- Mark specific agents as always using the `large` model tier without editing their frontmatter
+- Configure remote registries for the team
+- Change the cost ledger path or default timeout
+
+If you only ever use one project and set everything via environment variables, you may never need this file.
+
+---
+
+## Creating `uio.toml`
+
+```bash
+uio config init
+```
+
+This writes a commented starter file to the current directory. You can then uncomment and edit the relevant sections.
+
+---
+
+## File location
+
+`uio.toml` must be in the **current working directory** when `uio` is invoked. There is no upward directory search. If you have multiple projects, each has its own `uio.toml` at its root.
+
+---
+
+## Precedence order
+
+For every configurable setting, the resolution order is (highest priority first):
+
+1. **CLI flag** — `--provider`, `--model`, `--complexity`, etc.
+2. **Environment variable** — `LLM_PROVIDER`, `LLM_MODEL`, `OPENAI_BASE_URL`, etc.
+3. **`uio.toml`** — `default_provider`, `timeout`, etc.
+4. **Built-in default** — see table below
+
+---
+
+## Complete key reference
+
+### `[dirs]`
+
+Paths to definition directories. Relative paths are resolved from the current working directory.
+
+| Key | Default | Description |
+|---|---|---|
+| `agents` | `.uio/agents` | Directory containing `.agent.md` files |
+| `skills` | `.uio/skills` | Directory containing `.skill.md` files |
+| `prompts` | `.uio/prompts` | Directory containing `.prompt.md` files |
+
+```toml
+[dirs]
+agents  = ".uio/agents"
+skills  = ".uio/skills"
+prompts = ".uio/prompts"
+```
+
+You can use absolute paths if your definitions live outside the project tree:
+
+```toml
+[dirs]
+agents = "/home/alice/shared-agents"
+```
+
+---
+
+### `[runtime]`
+
+| Key | Default | Description |
+|---|---|---|
+| `default_provider` | `null` | Provider to use when no `--provider` flag is given and no `LLM_PROVIDER` env var is set. One of `gemini`, `openai`, `ollama`. |
+| `cost_ledger` | `uio_cost.jsonl` | Path to the cost ledger file (relative to CWD) |
+| `timeout` | `300` | Default per-command shell timeout in seconds for `run_command` calls |
+
+```toml
+[runtime]
+default_provider = "gemini"
+cost_ledger      = "uio_cost.jsonl"
+timeout          = 300
+```
+
+---
+
+### `[large_agents]`
+
+| Key | Default | Description |
+|---|---|---|
+| `names` | `[]` | List of agent names that always use the `large` model tier |
+
+This supplements `complexity: large` in frontmatter — useful when you want to force a tier without editing the definition file:
+
+```toml
+[large_agents]
+names = ["repo-health", "code-review"]
+```
+
+Agent names are matched case-insensitively with hyphens and underscores treated as equivalent (`repo-health` matches `repo_health`).
+
+---
+
+### `[mcp.github]`
+
+| Key | Default | Description |
+|---|---|---|
+| `command` | `npx -y @github/github-mcp-server stdio` | Full shell command to launch the GitHub MCP server |
+
+Override when `npx` is not available or you want a pinned version:
+
+```toml
+[mcp.github]
+command = "bun x @github/github-mcp-server@1.2.0 stdio"
+```
+
+This section only affects the MCP server launch command. The server still requires `GITHUB_PERSONAL_ACCESS_TOKEN` or `GITHUB_TOKEN` to be set.
+
+---
+
+### `[[registries]]`
+
+An array of registry configurations. Each entry is a Git repository with a `registry.yaml` manifest.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `name` | string | required | Identifier used in `uio registry list` and `--registry` filter |
+| `url` | string | required | Git repository URL (GitHub, GitLab, or any HTTPS URL) |
+| `ref` | string | `main` | Branch name, tag, or commit SHA to fetch from |
+| `enabled` | boolean | `true` | When `false`, this registry is skipped by all registry commands |
+| `cache_ttl_hours` | integer | — | How long the cached manifest is considered fresh before re-fetching. Omit to always use the cache if it exists |
+
+```toml
+[[registries]]
+name    = "official"
+url     = "https://github.com/jomkz/uio-registry"
+ref     = "main"
+enabled = true
+cache_ttl_hours = 24
+
+[[registries]]
+name    = "my-team"
+url     = "https://github.com/acme/uio-agents"
+ref     = "v1.2.0"
+enabled = true
+```
+
+See [Registry](11-registry.md) for full registry documentation.
+
+---
+
+## Fully-annotated example `uio.toml`
+
+```toml
+# uio.toml — project-level configuration for uio
+# Run 'uio config init' to scaffold this file.
+
+[dirs]
+# Where uio looks for definition files.
+# Relative to the directory where you run uio.
+agents  = ".uio/agents"
+skills  = ".uio/skills"
+prompts = ".uio/prompts"
+
+[runtime]
+# Default provider when no --provider flag or LLM_PROVIDER env var is set.
+# Uncomment to pin a provider for this project.
+# default_provider = "gemini"
+
+# Path to the cost ledger (append-only JSONL file).
+# Add this to .gitignore — uio init does this automatically.
+cost_ledger = "uio_cost.jsonl"
+
+# Per-command shell timeout in seconds for run_command tool calls.
+# Individual agents can override this with the 'timeout' frontmatter field.
+timeout = 300
+
+[large_agents]
+# Agent names that always use the large model tier, in addition to
+# any agents that set 'complexity: large' in their frontmatter.
+# Names are matched case-insensitively; hyphens and underscores are equivalent.
+names = []
+
+# Uncomment to override the GitHub MCP server launch command.
+# [mcp.github]
+# command = "npx -y @github/github-mcp-server stdio"
+
+# Remote registries — Git repos with a registry.yaml manifest at root.
+# Run 'uio registry search <query>' to find definitions.
+# Run 'uio registry install <name>' to copy a definition into .uio/.
+#
+# [[registries]]
+# name            = "official"
+# url             = "https://github.com/jomkz/uio-registry"
+# ref             = "main"       # branch, tag, or commit SHA
+# enabled         = true
+# cache_ttl_hours = 24           # re-fetch manifest after 24 hours
+```

--- a/docs/07-providers.md
+++ b/docs/07-providers.md
@@ -1,0 +1,194 @@
+# Providers
+
+uio supports three built-in providers and any OpenAI-compatible endpoint. This page explains how to configure each one.
+
+---
+
+## Auto-routing
+
+When no `--provider` flag is given, uio tries providers in this order:
+
+```
+Gemini  →  OpenAI  →  Ollama
+```
+
+A provider is included in the chain if its required API key is present in the environment. Ollama has no key requirement and is always the final fallback (as long as the Ollama process is running).
+
+The first provider in the chain that initialises successfully is used. To see which provider would be selected for the current environment:
+
+```bash
+uio config show
+```
+
+To force a specific provider for a single run:
+
+```bash
+uio agent run my-agent --provider openai
+```
+
+To set a default provider for a project:
+
+```toml
+# uio.toml
+[runtime]
+default_provider = "gemini"
+```
+
+To set it in the environment for all projects:
+
+```bash
+export LLM_PROVIDER=gemini
+```
+
+---
+
+## Gemini
+
+**Key env var:** `GEMINI_API_KEY`
+
+1. Go to [Google AI Studio](https://aistudio.google.com/apikey) and generate an API key.
+2. Export it:
+   ```bash
+   export GEMINI_API_KEY=your-key-here
+   ```
+
+Gemini is the recommended starting point — the small tier (`gemini-2.0-flash-lite`) has very low per-token costs and a generous free tier.
+
+### Models
+
+| Tier | Model | Notes |
+|---|---|---|
+| `small` | `gemini-2.0-flash-lite` | Default; fastest and cheapest |
+| `large` | `gemini-2.5-flash` | Better reasoning; use for complex multi-step agents |
+
+---
+
+## OpenAI
+
+**Key env var:** `OPENAI_API_KEY`
+
+1. Create an API key at [platform.openai.com](https://platform.openai.com/api-keys).
+2. Export it:
+   ```bash
+   export OPENAI_API_KEY=your-key-here
+   ```
+
+### Models
+
+| Tier | Model |
+|---|---|
+| `small` | `gpt-4o-mini` |
+| `large` | `gpt-4o` |
+
+---
+
+## Ollama
+
+**No API key required.** Ollama runs models locally.
+
+1. Install Ollama: see [ollama.com](https://ollama.com)
+2. Pull the default models:
+   ```bash
+   ollama pull qwen2.5-coder:7b
+   ollama pull qwen2.5-coder:32b
+   ```
+3. Ensure the Ollama server is running:
+   ```bash
+   ollama serve
+   ```
+
+By default, uio connects to `http://localhost:11434/v1`. Override with:
+
+```bash
+export OLLAMA_BASE_URL=http://my-server:11434/v1
+```
+
+All Ollama runs are recorded in the cost ledger with `estimated_cost_usd: 0.0`.
+
+### Models
+
+| Tier | Model |
+|---|---|
+| `small` | `qwen2.5-coder:7b` |
+| `large` | `qwen2.5-coder:32b` |
+
+---
+
+## LiteLLM proxy
+
+LiteLLM provides an OpenAI-compatible proxy for 100+ providers (Anthropic, Mistral, Groq, Bedrock, etc.). uio's OpenAI client works with any LiteLLM deployment.
+
+1. Install and start LiteLLM:
+   ```bash
+   pip install litellm
+   litellm --model anthropic/claude-sonnet-4-6
+   # Listening on http://0.0.0.0:4000
+   ```
+2. Configure uio to use it:
+   ```bash
+   export OPENAI_BASE_URL=http://localhost:4000
+   export OPENAI_API_KEY=any-string   # LiteLLM virtual key or "sk-1234"
+   ```
+3. Optionally pin the model:
+   ```bash
+   uio agent run my-agent --model claude-sonnet-4-6
+   ```
+
+When `--model` is set, it bypasses tier selection and is sent directly to the proxy. The model name must match what the proxy expects.
+
+---
+
+## Azure OpenAI
+
+1. Deploy a model in the Azure portal and note:
+   - The endpoint URL: `https://my-resource.openai.azure.com/`
+   - The deployment name: e.g. `gpt-4o-production`
+   - The API key
+2. Configure uio:
+   ```bash
+   export OPENAI_BASE_URL=https://my-resource.openai.azure.com/openai/deployments/gpt-4o-production
+   export OPENAI_API_KEY=your-azure-key
+   ```
+3. Override the model to match the deployment name:
+   ```bash
+   uio agent run my-agent --model gpt-4o-production
+   ```
+
+Note: Azure routing requires specifying `--provider openai` or setting `default_provider = "openai"` in `uio.toml`, otherwise the Gemini key check may select Gemini first.
+
+---
+
+## Model override
+
+To bypass tier selection entirely and use a specific model string:
+
+```bash
+uio agent run my-agent --model gemini-2.5-pro
+uio chat --model gpt-4o-2024-11-20
+```
+
+`--model` is passed directly to the provider client. It overrides the `LLM_MODEL` env var, which in turn overrides the tier-based default.
+
+Resolution order:
+
+1. `--model` CLI flag
+2. `LLM_MODEL` environment variable
+3. Tier-based default (from `--complexity` / frontmatter / `[large_agents]`)
+
+---
+
+## Token cost reference
+
+Costs are in USD per 1 million tokens (input / output).
+
+| Provider | Model | Input ($/1M) | Output ($/1M) |
+|---|---|---|---|
+| `gemini` | `gemini-2.5-flash` | $0.15 | $0.60 |
+| `gemini` | `gemini-2.0-flash-lite` | $0.075 | $0.30 |
+| `openai` | `gpt-4o` | $2.50 | $10.00 |
+| `openai` | `gpt-4o-mini` | $0.15 | $0.60 |
+| `ollama` | any | $0.00 | $0.00 |
+
+These values come from `TOKEN_COSTS_PER_1M` in `uio/core/clients.py`. They reflect published pricing at the time of writing and may diverge from current provider pricing.
+
+When a `--model` override is used with a model not in the table, cost estimation falls back to the provider-level entry if present, otherwise records $0.00.

--- a/docs/08-mcp.md
+++ b/docs/08-mcp.md
@@ -1,0 +1,165 @@
+# MCP Integration
+
+## What is MCP?
+
+**Model Context Protocol (MCP)** is a standardised stdio JSON-RPC 2.0 protocol for exposing typed tools to LLMs. An MCP server is a process that speaks this protocol and exports a set of tools — each with a name, description, and JSON Schema for its parameters.
+
+uio implements the **client side**: it optionally spawns an MCP server subprocess and registers its tools alongside the built-in `run_command` tool. The agent sees all tools in the same schema and can call any of them.
+
+uio itself does not implement any MCP tools — it delegates entirely to the server process.
+
+---
+
+## GitHub MCP server
+
+The most common use case is the official GitHub MCP server (`@github/github-mcp-server`), which exposes ~30 GitHub API operations as typed tools: create/list issues, read file contents, list pull requests, manage branches, and more.
+
+Using the GitHub MCP server instead of `gh` CLI shell commands gives the agent:
+- Typed, structured JSON responses (no shell output parsing)
+- Paginated results without custom shell gymnastics
+- Full GitHub API coverage
+
+When MCP tools are available, uio injects a preamble into the system prompt advising the agent to prefer them over `gh` CLI equivalents.
+
+---
+
+## Prerequisites
+
+- **Node.js** (any recent LTS version) and **npx**. The MCP server is launched as `npx -y @github/github-mcp-server stdio`.
+- A GitHub personal access token with the scopes your agent needs.
+
+---
+
+## Enabling GitHub MCP
+
+Set either of these environment variables:
+
+```bash
+export GITHUB_PERSONAL_ACCESS_TOKEN=ghp_your_token_here
+# or
+export GITHUB_TOKEN=ghp_your_token_here
+```
+
+uio checks both; `GITHUB_PERSONAL_ACCESS_TOKEN` takes precedence. When the token is set, the GitHub MCP server starts automatically on every `agent run` and `skill run` (unless `--no-mcp` is passed).
+
+Verify the setup:
+
+```bash
+uio config show
+# MCP github  ✓ GITHUB_PERSONAL_ACCESS_TOKEN set
+```
+
+---
+
+## Token scopes
+
+Use a fine-grained personal access token scoped to the minimum permissions your agent needs:
+
+| Agent task | Required scopes |
+|---|---|
+| Read issues and PRs | `issues: read`, `pull_requests: read` |
+| Create issues or comments | `issues: write` |
+| Read file contents | `contents: read` |
+| Create or merge PRs | `pull_requests: write`, `contents: write` |
+
+Granting more scopes than needed increases the blast radius of a mistake. Create a separate token per project or per agent role.
+
+---
+
+## Tool naming
+
+All MCP tools are prefixed with `mcp__<server_name>__`. The GitHub server uses `mcp__github__`:
+
+```
+mcp__github__list_issues
+mcp__github__create_issue
+mcp__github__get_file_contents
+mcp__github__list_pull_requests
+mcp__github__create_pull_request
+...
+```
+
+The prefix is added by `MCPClient.list_tools()` and removed transparently by `MCPClient.call_tool()` before forwarding the request to the server.
+
+Agents do not need to know about the naming convention — the model sees the full tool list and calls tools by their prefixed name.
+
+---
+
+## Disabling MCP
+
+To run without the GitHub MCP server even when the token is set:
+
+```bash
+uio agent run my-agent --no-mcp
+```
+
+Use this when:
+- The environment does not have Node.js or npx
+- You want to test the agent's shell-only behaviour
+- Network isolation requirements prevent spawning the server
+- The agent does not need GitHub operations
+
+---
+
+## Overriding the launch command
+
+By default, the server is launched as:
+
+```
+npx -y @github/github-mcp-server stdio
+```
+
+Override with the `MCP_GITHUB_COMMAND` environment variable:
+
+```bash
+export MCP_GITHUB_COMMAND="bun x @github/github-mcp-server stdio"
+```
+
+Or in `uio.toml`:
+
+```toml
+[mcp.github]
+command = "bun x @github/github-mcp-server@1.2.0 stdio"
+```
+
+The `uio.toml` setting takes effect if `MCP_GITHUB_COMMAND` is not set in the environment.
+
+---
+
+## How the MCP client works (internals)
+
+`uio/core/mcp.py` implements a minimal MCP stdio client:
+
+1. **Spawn** — the server process is started with `subprocess.Popen` with stdin/stdout pipes. stderr is discarded.
+2. **Handshake** — `initialize` RPC is sent with the uio client info; the server acknowledges with `initialized` notification.
+3. **Tool discovery** — `tools/list` RPC returns the server's tool schemas. uio prefixes each name.
+4. **Tool calls** — during the agent loop, when the model requests an MCP tool, `MCPClient.call_tool()` strips the prefix and sends a `tools/call` RPC. Text content from the response is joined and returned as a string.
+5. **Shutdown** — `close()` closes the stdin pipe and terminates the process on session end.
+
+Communication uses newline-delimited JSON. Each request includes an incrementing `id`; responses are matched by `id`. The client spins on `stdout.readline()` until the matching response arrives.
+
+---
+
+## Custom MCP servers
+
+The `MCPClient` class in `uio/core/mcp.py` is not GitHub-specific — it speaks the MCP protocol and can work with any compliant server. To integrate a different server, modify `make_mcp_client()` in `mcp.py` to accept a server name and command, or extend the runner to accept multiple MCP clients. This is planned for a future release; the current architecture supports one MCP server per run.
+
+---
+
+## Troubleshooting
+
+**`[mcp] Warning: could not start GitHub MCP server: ...`**
+
+This warning is printed to stderr when the server fails to start. The run continues without MCP tools. Common causes:
+
+- `npx` not found — install Node.js
+- Token is invalid or expired — regenerate it at GitHub
+- Node.js version is too old — upgrade to LTS (18+)
+
+**The agent keeps using `gh` CLI even though MCP is enabled**
+
+The model chooses which tools to call. The preamble advises it to prefer MCP tools but does not enforce it. If the agent consistently uses `gh` CLI, consider adding an explicit instruction to the agent's body: "Use MCP tools (`mcp__github__*`) for all GitHub operations."
+
+**`Unknown tool: mcp__github__some_tool`**
+
+The server was not started (either `--no-mcp` was passed or the token was missing). Verify with `uio config show`.

--- a/docs/09-chat.md
+++ b/docs/09-chat.md
@@ -1,0 +1,189 @@
+# Chat REPL
+
+`uio chat` starts an interactive, streaming, multi-turn conversation with an LLM. Unlike `agent run`, the chat REPL is not driven by a definition file — it uses a built-in general-purpose system prompt and accumulates conversation history for the duration of the session.
+
+---
+
+## Starting a session
+
+```bash
+uio chat
+```
+
+The header line shows the selected provider, model, and whether tools are enabled:
+
+```
+uio chat  [gemini/gemini-2.0-flash-lite]
+Type /help for commands, Ctrl-D or /exit to quit.
+
+You:
+```
+
+With tools enabled, the header shows `+tools`:
+
+```
+uio chat  [gemini/gemini-2.0-flash-lite +tools]
+```
+
+---
+
+## Basic usage
+
+Type any message and press Enter. The model's response streams to the terminal token-by-token. After the response, continue typing to add the next turn — the full conversation history is included on every request.
+
+To end the session: type `/exit`, `/quit`, or press Ctrl-D.
+
+---
+
+## Slash commands
+
+Inside the REPL, these commands are available:
+
+| Command | Effect |
+|---|---|
+| `/help` | Show available slash commands |
+| `/clear` | Clear the conversation history (the session continues with a fresh context) |
+| `/cost` | Show token spend and estimated cost for this session so far |
+| `/exit` | End the session |
+| `/quit` | End the session (alias for `/exit`) |
+
+---
+
+## Provider and model
+
+```bash
+uio chat --provider ollama
+uio chat --provider openai --model gpt-4o
+uio chat --base-url http://localhost:4000   # LiteLLM proxy
+```
+
+The chat session always uses the `small` complexity tier (the default). If you need a specific model:
+
+```bash
+uio chat --model gemini-2.5-flash
+```
+
+---
+
+## Tool use
+
+By default, the model cannot run shell commands. Pass `--tools` to expose `run_command`:
+
+```bash
+uio chat --tools
+```
+
+When the model requests a shell command, the REPL prints the command and asks for approval:
+
+```
+  $ git log --oneline -5
+  Execute? [Y/n]
+```
+
+Press Enter or `y` to approve. The command runs and its output is fed back to the model, which continues the response. Type `n` to reject — the model receives `[command rejected by user]` and can try a different approach.
+
+---
+
+## Auto-approve
+
+Skip the approval prompt for all commands:
+
+```bash
+uio chat --auto-approve
+```
+
+`--auto-approve` implies `--tools`. Use this only when you are comfortable with the model running any shell command — it has no safety restrictions.
+
+---
+
+## Allow and deny glob patterns
+
+For a middle ground between full approval prompts and `--auto-approve`, use `--allow` and `--deny` with shell glob patterns:
+
+```bash
+# Auto-approve git read commands; still prompt for everything else
+uio chat --tools --allow 'git log*' --allow 'git diff*' --allow 'git status'
+
+# Auto-approve everything EXCEPT git push
+uio chat --auto-approve --deny 'git push*'
+
+# Combine: approve git reads, deny destructive writes, prompt for the rest
+uio chat --tools --allow 'git log*' --allow 'git diff*' --deny 'git push*' --deny 'rm -*'
+```
+
+Evaluation order:
+1. **Deny patterns** are checked first. If the command matches any deny pattern, it is rejected without prompting.
+2. **Allow patterns** are checked next. If the command matches any allow pattern, it is approved without prompting.
+3. If no pattern matches and `--auto-approve` is not set, the user is prompted.
+
+Both flags can be repeated: `--allow 'git *' --allow 'ls *'`
+
+---
+
+## Custom system prompt
+
+Replace the default "helpful assistant" system prompt with the contents of a file:
+
+```bash
+uio chat --system /path/to/my-system.txt
+```
+
+This is useful for domain-specific assistants — a security researcher prompt, a commit-message writer prompt, a code reviewer with specific rules, etc.
+
+---
+
+## Multi-turn history
+
+The conversation accumulates across turns for the session lifetime. `/clear` resets the history back to empty — useful when the context has grown large or you are starting a different task.
+
+History is held in memory only; it is not persisted between sessions.
+
+---
+
+## Session cost summary
+
+When the session ends, uio prints a summary and writes a ledger entry:
+
+```
+Session ended.
+  Session: 4,218 tokens (3,891 in / 327 out) — $0.000422
+```
+
+The entry is written to the cost ledger under agent name `"chat"`. See [Cost ledger](10-cost.md) to query it.
+
+---
+
+## Streaming implementation
+
+Token streaming works differently per provider:
+
+- **Gemini** — uses `generate_content_stream`; tokens arrive as parts in each chunk
+- **OpenAI / Ollama** — uses `stream=True` with `stream_options: {include_usage: true}`; tokens arrive as delta content; usage metadata is included in the final chunk
+
+If a streaming error occurs, the REPL falls back to a non-streaming request automatically and prints a warning.
+
+Keyboard interrupt (Ctrl-C) during a response cancels the current turn without exiting the session.
+
+---
+
+## Examples
+
+```bash
+# Minimal — auto-selects provider
+uio chat
+
+# Force Ollama for offline use
+uio chat --provider ollama
+
+# Enable tools with pre-approved git read commands
+uio chat --tools --allow 'git *'
+
+# Use a project-specific system prompt
+uio chat --system .uio/chat-system.txt
+
+# Enable tools but block any rm command
+uio chat --tools --deny 'rm *' --deny 'sudo *'
+
+# Fully automated (no prompts)
+uio chat --auto-approve --provider gemini
+```

--- a/docs/10-cost.md
+++ b/docs/10-cost.md
@@ -1,0 +1,180 @@
+# Cost Ledger
+
+## Overview
+
+After every `agent run`, `skill run`, `prompt run`, and `chat` session, uio appends a JSON line to `uio_cost.jsonl`. This file is the cost ledger — an append-only record of every LLM call with token counts and estimated spend.
+
+The ledger is append-only by design: it is safe to `tail -f`, survives partial runs, and can never be corrupted by concurrent writes from different processes.
+
+---
+
+## Setup
+
+`uio init` automatically adds `uio_cost.jsonl` to your `.gitignore`. If you created `.uio/` manually, add it yourself:
+
+```bash
+echo "uio_cost.jsonl" >> .gitignore
+```
+
+Committing the ledger leaks your token spend to collaborators and can cause noisy diffs.
+
+---
+
+## Ledger entry schema
+
+Each line is a JSON object:
+
+```json
+{
+  "timestamp": "2026-04-30T12:01:05.341000+00:00",
+  "agent": "summarise",
+  "provider": "gemini",
+  "model": "gemini-2.0-flash-lite",
+  "prompt_tokens": 512,
+  "completion_tokens": 87,
+  "total_tokens": 599,
+  "estimated_cost_usd": 0.000065
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `timestamp` | ISO 8601 string (UTC) | When the run completed |
+| `agent` | string | Definition name; `"chat"` for REPL sessions |
+| `provider` | string | Provider used: `gemini`, `openai`, or `ollama` |
+| `model` | string | Exact model string sent to the provider |
+| `prompt_tokens` | integer | Input tokens |
+| `completion_tokens` | integer | Output tokens |
+| `total_tokens` | integer | `prompt_tokens + completion_tokens` |
+| `estimated_cost_usd` | float | Estimated cost in USD, rounded to 6 decimal places |
+
+---
+
+## Cost formula
+
+```
+estimated_cost_usd = (prompt_tokens × input_rate + completion_tokens × output_rate) / 1_000_000
+```
+
+Rates come from `TOKEN_COSTS_PER_1M` in `uio/core/clients.py` (see [Providers — token cost table](07-providers.md#token-cost-reference)). Ollama runs always record `0.0`.
+
+When a `--model` override is used with a model not in the table, the provider-level rate is used as a fallback. If no provider-level rate exists, `0.0` is recorded. The estimates are informational — check your provider's billing dashboard for authoritative numbers.
+
+---
+
+## `uio cost` command
+
+```bash
+# All entries, formatted table
+uio cost
+
+# Last 20 entries
+uio cost --tail 20
+
+# Entries since a date
+uio cost --since 2026-04-01
+
+# Entries since a specific time
+uio cost --since "2026-04-30T10:00:00"
+
+# Raw JSON lines (one per entry)
+uio cost --json
+
+# Different ledger file
+uio cost --ledger /path/to/other.jsonl
+```
+
+Example table output:
+
+```
+TIMESTAMP            AGENT        PROVIDER  MODEL                   TOKENS  COST
+2026-04-30 12:01:05  summarise    gemini    gemini-2.0-flash-lite      599  $0.000065
+2026-04-30 12:02:14  shell-helper gemini    gemini-2.0-flash-lite     1243  $0.000124
+2026-04-30 12:15:33  chat         gemini    gemini-2.0-flash-lite     4218  $0.000422
+
+Total: 3 run(s) | 6,060 tokens | $0.000611
+```
+
+---
+
+## `jq` recipes
+
+`uio cost --json` emits one JSON object per line, making it easy to pipe into `jq`.
+
+**Total spend across all runs:**
+
+```bash
+uio cost --json | jq -s '[.[].estimated_cost_usd] | add'
+```
+
+**Spend grouped by agent:**
+
+```bash
+uio cost --json | jq -s '
+  group_by(.agent)
+  | map({agent: .[0].agent, runs: length, cost: ([.[].estimated_cost_usd] | add)})
+  | sort_by(.cost) | reverse
+'
+```
+
+**Most expensive single run:**
+
+```bash
+uio cost --json | jq -s 'max_by(.estimated_cost_usd)'
+```
+
+**Total tokens this week:**
+
+```bash
+uio cost --since "$(date -d '7 days ago' --iso-8601)" --json \
+  | jq -s '[.[].total_tokens] | add'
+```
+
+**Runs that cost more than $0.01:**
+
+```bash
+uio cost --json | jq 'select(.estimated_cost_usd > 0.01)'
+```
+
+**Average cost per run by provider:**
+
+```bash
+uio cost --json | jq -s '
+  group_by(.provider)
+  | map({
+      provider: .[0].provider,
+      avg_cost: ([.[].estimated_cost_usd] | add / length)
+    })
+'
+```
+
+---
+
+## Custom ledger path
+
+Change the ledger path for a project in `uio.toml`:
+
+```toml
+[runtime]
+cost_ledger = "logs/uio_cost.jsonl"
+```
+
+Or per-invocation with `--ledger`:
+
+```bash
+uio cost --ledger /var/log/uio/costs.jsonl
+```
+
+This is useful for shared infrastructure where multiple projects or users write to a central ledger.
+
+---
+
+## Write failure handling
+
+If uio cannot write to the ledger (e.g., the directory does not exist or permissions are wrong), it prints a warning to stderr and continues. The run result is not affected by ledger write failures:
+
+```
+  [cost] Warning: could not write cost ledger: [Errno 13] Permission denied: 'uio_cost.jsonl'
+```
+
+Fix: ensure the directory exists and is writable, or change `cost_ledger` in `uio.toml`.

--- a/docs/11-registry.md
+++ b/docs/11-registry.md
@@ -1,0 +1,243 @@
+# Registry
+
+A registry is any Git repository with a `registry.yaml` manifest at its root. Anyone can host one — there is no central server. Definitions are fetched as plain text and written to your local `.uio/` directory, after which they have no live dependency on the registry.
+
+---
+
+## Quick start
+
+```bash
+# Add a registry to uio.toml (see Configuration section below)
+uio registry list                    # show configured registries
+uio registry search summarise        # find definitions by name, description, or tag
+uio registry install summarise       # copy the definition into .uio/
+uio registry update                  # refresh cached manifests
+```
+
+---
+
+## `registry.yaml` manifest schema
+
+A registry repo must contain a `registry.yaml` at its root with this structure:
+
+```yaml
+version: 1
+definitions:
+  - name: summarise
+    type: skill
+    path: skills/summarise.skill.md
+    description: Summarise text or a file
+    tags: [text, productivity]
+
+  - name: repo-health
+    type: agent
+    path: agents/repo-health.agent.md
+    description: Multi-tool repo health check
+    tags: [devops, git]
+
+  - name: ask-docs
+    type: prompt
+    path: prompts/ask-docs.prompt.md
+    description: Ask a focused question about a codebase
+    tags: [docs]
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `version` | Yes | Must be `1` |
+| `definitions` | Yes | List of definition entries |
+| `definitions[].name` | Yes | Identifier used in `uio registry search` and `uio registry install` |
+| `definitions[].type` | Yes | `agent`, `skill`, or `prompt` |
+| `definitions[].path` | Yes | Path to the definition file relative to the registry repo root |
+| `definitions[].description` | Yes | One-line summary shown in search results |
+| `definitions[].tags` | No | List of strings for tag-based search |
+
+`uio validate` checks manifest schema when run against a registry repo directory.
+
+---
+
+## Configuring registries
+
+Add `[[registries]]` entries to `uio.toml`:
+
+```toml
+[[registries]]
+name            = "official"
+url             = "https://github.com/jomkz/uio-registry"
+ref             = "main"
+enabled         = true
+cache_ttl_hours = 24
+
+[[registries]]
+name    = "my-team"
+url     = "https://github.com/acme/uio-agents"
+ref     = "v1.2.0"
+enabled = true
+```
+
+| Key | Default | Description |
+|---|---|---|
+| `name` | required | Identifier shown in `registry list` and `--registry` filter |
+| `url` | required | Git repo HTTPS URL |
+| `ref` | `main` | Branch name, tag, or commit SHA |
+| `enabled` | `true` | Skip this registry when `false` |
+| `cache_ttl_hours` | — | How many hours the cached manifest is considered fresh. Omit to serve the cache indefinitely (until `uio registry update` is run) |
+
+---
+
+## `uio registry list`
+
+Shows all configured registries:
+
+```
+$ uio registry list
+
+  NAME      URL                                         REF   ENABLED
+  ────────────────────────────────────────────────────────────────────
+  official  https://github.com/jomkz/uio-registry       main  yes
+  my-team   https://github.com/acme/uio-agents           v1.2  yes
+```
+
+---
+
+## `uio registry search`
+
+Searches for definitions by name, description, or tags (case-insensitive). Disabled registries are skipped. Network errors on one registry do not stop searching others.
+
+```bash
+uio registry search summarise
+uio registry search "text productivity"
+uio registry search devops --registry official
+```
+
+Example output:
+
+```
+$ uio registry search code
+
+  NAME          TYPE   REGISTRY  DESCRIPTION
+  ─────────────────────────────────────────────────────────────────────
+  explain-code  skill  official  Explain a source file in plain English
+  code-review   agent  official  Multi-turn code review with inline comments
+```
+
+---
+
+## `uio registry install`
+
+Fetches a definition from the first registry that contains it and writes it to the appropriate `.uio/` subdirectory.
+
+```bash
+uio registry install summarise
+uio registry install repo-health --registry official
+uio registry install summarise --force        # overwrite existing
+uio registry install repo-health --pin        # lock to current SHA
+```
+
+After installation:
+- The definition is a plain local file — editable, no live registry dependency
+- `uio validate` runs automatically and prints any warnings
+
+### `--force`
+
+By default, `install` refuses to overwrite an existing definition. Use `--force` to overwrite:
+
+```bash
+uio registry install summarise --force
+```
+
+### `--pin`
+
+`--pin` resolves the registry's branch ref to the current HEAD commit SHA and prints the `uio.toml` stanza to paste:
+
+```
+$ uio registry install repo-health --pin
+
+  Installed: .uio/agents/repo-health.agent.md  (from registry 'official')
+
+  Pin SHA: abc123def456789abcdef012
+  To pin, update uio.toml:
+    [[registries]]
+    name = "official"
+    url  = "https://github.com/jomkz/uio-registry"
+    ref  = "abc123def456"
+```
+
+Pinning to a commit SHA ensures the installed definition and future fetches match exactly. Pinning is only supported for GitHub-hosted registries; for other hosts `--pin` prints a warning and continues.
+
+A mutable `ref` (branch name) is not blocked, but it means the definition may silently change between installs. For production use, pin to a tag or SHA.
+
+---
+
+## `uio registry update`
+
+Force-refreshes all cached manifests, or a specific registry:
+
+```bash
+uio registry update
+uio registry update --registry official
+```
+
+On success, prints the number of definitions per registry. Exits 1 if any registry fails to refresh.
+
+---
+
+## Manifest caching
+
+Manifests are cached locally in `~/.cache/uio/registries/<name>.yaml`. The cache is used by default for all registry commands except `update`.
+
+The `cache_ttl_hours` setting controls freshness:
+- If no TTL is set, the cache is used indefinitely (until `uio registry update` is run manually)
+- If a TTL is set and the cache file is older than `cache_ttl_hours`, the manifest is re-fetched
+- If the network is unreachable and a (stale) cache exists, the stale cache is used as a fallback with a warning
+
+---
+
+## URL normalisation
+
+uio constructs raw file URLs from the registry's HTTPS URL and `ref`:
+
+| Host | Raw URL pattern |
+|---|---|
+| `github.com` | `https://raw.githubusercontent.com/{owner}/{repo}/{ref}/{path}` |
+| `gitlab.com` | `https://gitlab.com/{owner}/{repo}/-/raw/{ref}/{path}` |
+| Other | `{url}/{ref}/{path}` (direct path append) |
+
+GitHub authentication uses `GITHUB_PERSONAL_ACCESS_TOKEN` or `GITHUB_TOKEN` for both manifest fetches and definition file fetches, enabling private registry repositories.
+
+---
+
+## Hosting a registry
+
+To host your own registry:
+
+1. Create a Git repository (public or private).
+2. Create `registry.yaml` at the repository root following the schema above.
+3. Add your definition files in subdirectories matching the `path` fields in `registry.yaml`.
+4. Push to a branch or create a tag.
+5. Add the registry to `uio.toml` in your projects.
+
+Example repo layout:
+
+```
+uio-my-registry/
+├── registry.yaml
+├── agents/
+│   └── deploy-checker.agent.md
+├── skills/
+│   └── extract-todos.skill.md
+└── prompts/
+    └── standup-summary.prompt.md
+```
+
+The repository at `https://github.com/jomkz/uio-registry` is the official registry and can be used as a reference.
+
+---
+
+## Security model
+
+- **Definitions are plain text files.** Installing a definition does not execute code; it writes a markdown file to `.uio/`. The user decides whether to run it.
+- The trust model is identical to `pip install`: you are trusting the definition author. Read installed definitions before running them.
+- `uio validate` runs after every `install` and warns on unknown frontmatter keys, which can catch injected or malformed metadata.
+- Pinning to a commit SHA is the safest option for production use — mutable branch refs can change after install.
+- For private registries, the `GITHUB_TOKEN` must have `contents: read` on the registry repository.

--- a/docs/12-writing-definitions.md
+++ b/docs/12-writing-definitions.md
@@ -1,0 +1,293 @@
+# Writing Definitions
+
+This page covers how to write effective agents, skills, and prompts — from the basics of file structure to advanced patterns for tool use and reliability.
+
+---
+
+## Definition anatomy
+
+Every definition file has two parts separated by the frontmatter delimiters:
+
+```
+---
+name: My Agent
+description: Does something useful.
+complexity: small
+---
+
+The body text starts here and becomes the system prompt sent to the model.
+```
+
+The frontmatter is parsed by uio; the body is passed verbatim to the LLM as its system instruction. See [Frontmatter schema](04-frontmatter.md) for all available fields.
+
+---
+
+## The hidden preamble
+
+uio injects a runtime preamble into the system prompt *before* your definition body. You will not see it in your file, but the model does. Its content depends on whether MCP tools are available:
+
+**Without MCP** (`--no-mcp` or no token set):
+
+```
+## ⚠️ Runtime — MCP Tools Unavailable
+
+You are running inside uio. The ONLY tool available is `run_command`.
+
+MCP tools (mcp__github__*, etc.) do NOT exist in this runtime.
+Calling them will return "Unknown tool" and waste an iteration — do not attempt them.
+
+For ALL GitHub operations, use `run_command` with the `gh` CLI.
+```
+
+**With MCP** (token set, server started):
+
+```
+## ℹ️ Runtime — Tools Available
+
+You are running inside uio. Two tool families are available:
+
+**`run_command`** — execute any shell command ...
+**`mcp__github__*`** — native GitHub MCP tools ...
+Prefer these over `gh` CLI equivalents for GitHub operations.
+```
+
+Your definition body follows immediately after this preamble. You do not need to explain `run_command` to the model — the preamble already does. Focus your body on what *you* want the agent to do.
+
+---
+
+## Writing agent and skill bodies
+
+### State the goal first
+
+The model reads the system prompt before anything else. Put the core task in the first sentence:
+
+```markdown
+Run a comprehensive health check on this Git repository and produce a structured report.
+```
+
+Not:
+
+```markdown
+You are a helpful assistant that is very good at many things and can help with various tasks...
+```
+
+### Describe the expected output format
+
+Tell the model exactly what to produce:
+
+```markdown
+Produce a Markdown report with these sections:
+1. Test results (pass/fail count)
+2. Lint summary (error count, first 5 errors)
+3. Open PRs older than 7 days
+```
+
+### Give explicit stopping criteria
+
+Agents run in a loop until the model produces a response with no tool calls. Without a clear stopping condition, the model may keep calling tools unnecessarily.
+
+Good:
+
+```markdown
+When you have gathered all the information above, produce the final report and stop.
+Do not run any further shell commands after producing the report.
+```
+
+Bad (no stopping condition — model may loop):
+
+```markdown
+Investigate this repository thoroughly.
+```
+
+### Describe the input for skills
+
+Skills are often given an argument via `ARG`. Make it clear what the argument represents:
+
+```markdown
+# Skill: Explain Code
+
+You will receive a file path as input. Read the file using `run_command`
+with `cat <path>` and explain what it does in plain English.
+Target an audience with basic programming knowledge.
+```
+
+### Keep scope narrow for skills
+
+A skill that does one thing well is more composable than one that tries to handle every case:
+
+```markdown
+# Skill: Summarise
+
+Produce a concise summary in 1–3 sentences. Do not add information
+not present in the input. Do not provide opinions or recommendations.
+```
+
+---
+
+## Writing prompt bodies
+
+Prompts are single-shot — no tool loop. The body is sent once and the response is printed.
+
+When `invokable: true`, the argument passed on the command line is appended as a new line at the end of the body. **There is no template substitution** — the argument is concatenated literally. Structure the body so it makes sense with the argument appended:
+
+```markdown
+---
+name: ask-docs
+description: Ask a focused question about a codebase.
+argument-hint: "[question]"
+invokable: true
+---
+
+Answer the following question about this codebase using only information visible
+in the source code. Cite the relevant file or function name.
+
+Question:
+```
+
+Running `uio prompt run ask-docs "what does the cost ledger store?"` sends:
+
+```
+Answer the following question...
+
+Question:
+what does the cost ledger store?
+```
+
+---
+
+## Tool use patterns
+
+### Reading a file
+
+```
+Run `cat path/to/file` to read the contents.
+```
+
+The model will call `run_command` with `cat path/to/file`. The output is fed back and the model continues.
+
+### Getting git context
+
+Common patterns the model can use via `run_command`:
+
+```bash
+git log --oneline -20           # recent commits
+git diff HEAD~1                 # last commit diff
+git diff --name-only HEAD~1     # changed files
+git blame src/file.py           # line attribution
+```
+
+### Calling GitHub
+
+Without MCP — use the `gh` CLI:
+
+```bash
+gh issue list --state open --limit 10
+gh pr view 42
+gh api repos/:owner/:repo/commits
+```
+
+With MCP — the model uses `mcp__github__*` tools directly (no shell parsing required):
+
+```
+Use mcp__github__list_issues to get open issues.
+Use mcp__github__get_file_contents to read a specific file.
+```
+
+### Iterative refinement
+
+The agent loop is designed for tasks that require multiple steps. Write the body to guide the model through stages:
+
+```markdown
+# Agent: Code Review
+
+Review the staged changes in this repository:
+
+1. Run `git diff --cached` to see the staged changes.
+2. Identify potential issues: bugs, missing error handling, security concerns.
+3. Run `git log --oneline -5` for context on recent changes.
+4. Produce a structured review with: Summary, Issues Found, Suggestions.
+
+Stop after producing the review.
+```
+
+The model will call tools for steps 1 and 3, then produce the review in step 4 with no further tool calls.
+
+---
+
+## Complexity tier guidance
+
+| Task type | Recommended tier |
+|---|---|
+| Summarisation, translation, simple formatting | `small` |
+| Single-file code explanation | `small` |
+| Multi-file analysis | `large` |
+| Code review with reasoning | `large` |
+| Security audit | `large` |
+| Long tool-use chains with dependencies | `large` |
+
+When in doubt, start with `small` and move to `large` if the output quality is insufficient. The cost difference is often 4–10x.
+
+---
+
+## The iteration cap
+
+`MAX_ITERATIONS = 10` (defined in `uio/core/runner.py`). If the model calls tools 10 times without producing a tool-call-free response, the loop stops with a warning:
+
+```
+  [warning: reached tool iteration cap]
+```
+
+The last model response is still printed. This usually indicates:
+- The task is too open-ended — split it into smaller, focused runs
+- The stopping criteria in the body are unclear — add an explicit "stop after producing X" instruction
+- The model is stuck in a loop trying something that isn't working — add error handling guidance ("if the command fails, report the error and stop")
+
+---
+
+## Testing a definition
+
+```bash
+# Step 1: validate frontmatter
+uio validate
+
+# Step 2: run with the small model first
+uio agent run my-agent --complexity small
+
+# Step 3: check cost
+uio cost --tail 1
+
+# Step 4: iterate — edit the body, re-run
+```
+
+---
+
+## Common failure modes
+
+**Model ignores the argument**
+
+Ensure `invokable: true` is set in frontmatter (for prompts). For agents/skills, the argument is appended to the initial user message — make the body reference it: "You will receive input as the initial user message."
+
+**Output is too verbose / too terse**
+
+Specify the output length explicitly: "Produce a 1–3 sentence summary" or "Produce a detailed report with a section for each item."
+
+**Agent keeps running tool calls that return errors**
+
+Add: "If a command fails, report the error message and stop. Do not retry."
+
+**Agent uses MCP tools that don't exist**
+
+If MCP is disabled, the preamble tells the model. If you see "Unknown tool" errors, check that the token is set or add `--no-mcp` to confirm. The preamble is injected automatically — you do not need to document available tools in the body.
+
+**Output truncated mid-response**
+
+The `run_command` tool truncates output at 32,768 bytes. For large outputs, pipe through `head`, `tail`, or `grep` in the command:
+
+```bash
+git log --oneline | head -20
+find . -name "*.py" | head -50
+```
+
+**Cost is higher than expected**
+
+The model is calling too many tools or the context is growing large. Use `--complexity small`, break the task into smaller runs, or add stopping criteria to the body.

--- a/docs/13-internals.md
+++ b/docs/13-internals.md
@@ -1,0 +1,261 @@
+# Internals
+
+This page describes the uio package architecture, what each module does, and how to extend the framework.
+
+---
+
+## Package layout
+
+```
+uio/
+├── __init__.py              # version string
+├── config.py                # uio.toml loader
+├── examples.py              # bundled example definitions (embedded strings)
+├── core/
+│   ├── clients.py           # LLMClient ABC + provider implementations
+│   ├── ledger.py            # cost estimation and JSONL append
+│   ├── mcp.py               # MCP stdio client (JSON-RPC 2.0)
+│   ├── routing.py           # provider auto-routing and model-tier selection
+│   ├── runner.py            # main tool-use loop (run_agent)
+│   └── tools.py             # run_command tool execution
+├── cli/
+│   ├── main.py              # root click group + init, validate, completion
+│   ├── agent.py             # uio agent subcommands
+│   ├── skill.py             # uio skill subcommands
+│   ├── prompt.py            # uio prompt subcommands
+│   ├── chat.py              # uio chat REPL with streaming
+│   ├── cost.py              # uio cost command
+│   ├── config.py            # uio config subcommands
+│   ├── registry.py          # uio registry subcommands
+│   └── _helpers.py          # shared list_definitions, print_definition_table
+├── registry/
+│   └── manifest.py          # manifest fetch, cache, search, install, validate
+└── schema/
+    └── parser.py            # YAML frontmatter parser and validator
+```
+
+---
+
+## Layer-by-layer breakdown
+
+### Definition layer — `uio/schema/parser.py`
+
+`parse_definition_file(path)` reads a file, extracts the YAML frontmatter block (regex-matched between `---` delimiters), and returns `(frontmatter: dict, body: str)`.
+
+A regex is used instead of a streaming YAML parser because frontmatter is always a small, bounded block at the top of the file — the rest is the body text that should not be parsed as YAML.
+
+`validate_definition(path, frontmatter)` checks:
+- `name` and `description` are present and non-empty (error if missing)
+- All keys are in the known-keys set (warning if unknown)
+
+Known keys: `name description complexity tools timeout argument-hint invokable`
+
+---
+
+### Config layer — `uio/config.py`
+
+`load_config(path="uio.toml")` reads and merges `uio.toml` with built-in defaults. Uses `tomllib` from the standard library (Python 3.11+).
+
+`_DEFAULTS` is the dict of built-in defaults. `load_config()` performs a shallow merge per section — values present in `uio.toml` override the corresponding defaults; missing sections fall back to defaults entirely.
+
+`get_starter_toml()` returns the `_STARTER_TOML` string written by `uio config init`.
+
+---
+
+### Routing layer — `uio/core/routing.py`
+
+`ROUTING_CHAIN = ["gemini", "openai", "ollama"]` — the auto-routing order.
+
+`PROVIDER_KEY_ENV` maps each provider to its required API key env var (`None` for Ollama).
+
+`infer_complexity(agent_name, frontmatter, override, large_names)` — returns `"large"` or `"small"`. Resolution order: CLI override → frontmatter `complexity:` → `large_names` list → default `"small"`.
+
+`select_model(provider, complexity, model_override)` — returns the model string. Resolution order: `model_override` → `LLM_MODEL` env var → tier-based default from `PROVIDER_DEFAULTS` / `PROVIDER_SMALL_MODELS`.
+
+`select_provider_chain(provider_override)` — if `provider_override` is set, returns `[provider_override]`. Otherwise returns all providers in `ROUTING_CHAIN` whose API key is set, with Ollama always included as the final fallback.
+
+---
+
+### Client layer — `uio/core/clients.py`
+
+`LLMClient` is an abstract base class with three methods that all provider clients must implement:
+
+- `build_history(user_text)` — returns an initial message history list containing the first user message, in the provider's native format
+- `chat(system, history)` — sends the conversation to the LLM and returns `LLMResponse(text, tool_calls, usage)`
+- `append_turn(history, response, tool_results)` — mutates the history list to append the model's response and the tool results, ready for the next turn
+
+The three implementations:
+
+- **`GeminiClient`** — uses `google.genai`. Message format uses `{"role": "user"/"model", "parts": [...]}`. Function calls use `FunctionDeclaration` and `Tool` types. Tool results use `function_response` parts.
+- **`OpenAIClient`** — uses `openai`. Message format uses `{"role": "user"/"assistant"/"system"/"tool", "content": ...}`. Tool calls use the `tools` parameter with function JSON schemas. Supports `base_url` and `api_key` overrides.
+- **`OllamaClient`** — subclasses `OpenAIClient` with a different base URL (`http://localhost:11434/v1`) and a dummy API key. Inherits the full OpenAI message format.
+
+`make_client(provider, model, tools, base_url)` is the factory function.
+
+`TOKEN_COSTS_PER_1M` is a dict mapping `"provider/model"` (or just `"provider"` as a fallback) to `(input_rate, output_rate)` tuples in USD per million tokens.
+
+---
+
+### Tools layer — `uio/core/tools.py`
+
+`TOOL_SCHEMA` is the single JSON Schema for `run_command`:
+
+```python
+{
+    "name": "run_command",
+    "description": "Execute a shell command and return its stdout and stderr.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "command": {"type": "string", "description": "The shell command to execute."}
+        },
+        "required": ["command"],
+    },
+}
+```
+
+`execute_tool(tc, *, mcp, timeout)` dispatches on tool name:
+- `run_command` → `subprocess.run(command, shell=True, ...)` with output capped at 32,768 bytes and a configurable timeout (default 300s)
+- `mcp__<server_name>__*` → forwarded to `MCPClient.call_tool()`
+- Anything else → returns `"Unknown tool: <name>"`
+
+`MAX_OUTPUT_BYTES = 32768`. Output that exceeds this is replaced with `"[output truncated]\n" + last_32k_bytes`.
+
+---
+
+### MCP layer — `uio/core/mcp.py`
+
+`MCPClient` wraps a subprocess with stdin/stdout pipes. All communication is newline-delimited JSON (JSON-RPC 2.0).
+
+Startup sequence:
+1. `subprocess.Popen` with stdin/stdout pipes, stderr discarded
+2. `_initialize()` — sends `initialize` RPC, waits for response, sends `initialized` notification
+3. `list_tools()` — sends `tools/list` RPC, prefixes all tool names with `mcp__<server_name>__`
+4. `call_tool(name, args)` — strips the prefix, sends `tools/call` RPC, joins text content parts
+
+`_rpc(method, params)` is the blocking RPC primitive — it writes the request, then reads lines from stdout until it finds one with the matching `id`.
+
+`make_mcp_client(server_name)` tries to start the GitHub MCP server. Returns `None` on any failure (missing token, missing npx, process crash) and prints a warning to stderr. The run continues without MCP.
+
+---
+
+### Runner layer — `uio/core/runner.py`
+
+`run_agent(agent_name, arg, provider, model, complexity, ...)` is the main entry point for all definition runs (agents, skills, and prompts share this function).
+
+Execution flow:
+
+1. Read and parse the definition file (`parse_definition_file`)
+2. Build the provider chain (`select_provider_chain`)
+3. Infer complexity and select model (`infer_complexity`, `select_model`)
+4. Optionally start MCP client (`make_mcp_client`)
+5. Build tool schema list (TOOL_SCHEMA + MCP tools, or empty list for prompts)
+6. Inject the runtime preamble (`_PREAMBLE_SHELL_ONLY` or `_PREAMBLE_WITH_MCP`)
+7. Build initial history with the user message (definition name + optional arg)
+8. Enter the tool-use loop:
+   - Call `client.chat(system, history)`
+   - If no tool calls: print response, break
+   - For each tool call: call `execute_tool`, collect results
+   - Append turn to history (`client.append_turn`)
+   - Repeat up to `MAX_ITERATIONS = 10`
+9. Write cost ledger entry
+10. Close MCP client
+
+The loop is shared between agents and skills. Prompts bypass the loop: a single `client.chat()` call is made with an empty tool list, and the response is printed directly.
+
+---
+
+### Ledger layer — `uio/core/ledger.py`
+
+`estimate_cost_usd(provider, model, prompt_tokens, completion_tokens)` looks up rates in `TOKEN_COSTS_PER_1M` using `"provider/model"` as the key, falling back to `"provider"`, then to `(0.0, 0.0)`.
+
+`write_cost_ledger(agent_name, provider, model, ...)` builds the entry dict, opens the ledger file in append mode, and writes a JSON line. `OSError` is caught — write failures are non-fatal.
+
+---
+
+### Registry layer — `uio/registry/manifest.py`
+
+`_raw_url(repo_url, ref, path)` converts a hosting URL to a raw file URL:
+- `github.com` → `raw.githubusercontent.com/{owner}/{repo}/{ref}/{path}`
+- `gitlab.com` → `{base}/-/raw/{ref}/{path}`
+- Anything else → `{url}/{ref}/{path}`
+
+`fetch_manifest(registry, *, force, cache_dir)`:
+1. Check if the cached file at `cache_dir/<name>.yaml` is fresh (based on `cache_ttl_hours`)
+2. If fresh and not `force=True`, return the cached manifest
+3. Fetch the manifest via `urllib.request.urlopen` with optional `Authorization` header (from `GITHUB_TOKEN`)
+4. Write to cache, return parsed YAML
+5. On network failure: return stale cache if it exists, otherwise raise `RuntimeError`
+
+`search_definitions(registries, query, *, cache_dir)`:
+- Iterates enabled registries, fetches each manifest
+- Matches `query` (case-insensitive) against `name`, `description`, and each element of `tags`
+- Injects `_registry: <name>` into each matched entry
+
+`fetch_definition_content(registry, defn)` fetches a raw definition file via `_raw_url`. Raises `RuntimeError` on network failure.
+
+`validate_manifest(manifest)` returns a list of error strings — checks `version`, `definitions` is a list, each entry has `name`/`type`/`path`/`description`, type is one of `agent`/`skill`/`prompt`.
+
+`resolve_ref_to_sha(registry)` calls the GitHub API (`/repos/{owner}/{repo}/commits/{ref}`) and returns the SHA string. Returns `None` for non-GitHub URLs or network errors.
+
+---
+
+## Adding a new provider
+
+1. **`uio/core/clients.py`** — Add a class that implements `LLMClient` (three methods: `build_history`, `chat`, `append_turn`). Add default and small model strings to `PROVIDER_DEFAULTS` and `PROVIDER_SMALL_MODELS`. Add cost rates to `TOKEN_COSTS_PER_1M`. Add a case to `make_client()`.
+
+2. **`uio/core/routing.py`** — Add the provider name to `ROUTING_CHAIN` at the appropriate position. Add its key env var to `PROVIDER_KEY_ENV` (`None` if no key is needed).
+
+3. **Tests** — Add message format tests to `tests/test_clients.py`. Add routing tests to `tests/test_routing.py`.
+
+4. **Docs** — Add a section to [Providers](07-providers.md) and update the cost table.
+
+---
+
+## Adding a new tool
+
+1. **`uio/core/tools.py`** — Add a JSON Schema entry (same shape as `TOOL_SCHEMA`) to the tool list. Add a dispatch branch in `execute_tool()`.
+
+2. **`uio/cli/agent.py`** / **`uio/cli/chat.py`** — If the new tool requires an approval gate (like `run_command` does in the chat REPL), add the check in `_inner_tool_loop()` in `chat.py` and in the runner loop.
+
+3. **Tests** — Add tests to `tests/test_tools.py`.
+
+4. **Docs** — Document the tool in [Writing definitions](12-writing-definitions.md) under "Tool use patterns".
+
+---
+
+## Running the test suite
+
+```bash
+pytest
+```
+
+All 150+ tests run without API keys. Network calls are mocked via `unittest.mock.patch("urllib.request.urlopen")`. LLM calls are tested with mock client objects.
+
+Test modules:
+
+| File | What it covers |
+|---|---|
+| `tests/test_clients.py` | Message format per provider, `make_client` factory |
+| `tests/test_routing.py` | Provider chain, model selection, `infer_complexity` |
+| `tests/test_ledger.py` | Cost estimation, file append, `OSError` handling |
+| `tests/test_parser.py` | Frontmatter edge cases, list-type fields, missing delimiters |
+| `tests/test_tools.py` | `run_command` execution, timeout, output truncation, unknown tool |
+| `tests/test_examples.py` | All bundled examples parse and pass `validate_definition` |
+| `tests/test_registry.py` | URL normalisation, manifest cache/TTL, search, install, pin |
+
+---
+
+## Contributing
+
+1. Fork the repository and create a feature branch.
+2. Make your changes.
+3. Run the test suite: `pytest`
+4. Run the linter: `ruff check .`
+5. Open a pull request.
+
+Guidelines:
+- Keep tests offline — no API keys in CI. Mock all network and LLM calls.
+- New user-visible behaviour requires a docs update in the relevant `docs/` page.
+- New definition types (if ever added) require changes in `parser.py` (known fields), `cli/_helpers.py` (list support), and all affected docs pages.
+- The two-persona documentation structure described in issue #5 applies to new docs: every page should serve both the newcomer and the experienced engineer.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,55 @@
+# uio Documentation
+
+> **New here?** Start with [Installation](01-installation.md), then work through the [Quickstart tutorial](03-quickstart.md).
+>
+> **Looking for a specific reference?** Jump straight to the [CLI reference](05-cli.md), [Frontmatter schema](04-frontmatter.md), or [Architecture internals](13-internals.md).
+
+---
+
+## Contents
+
+| Page | What it answers |
+|---|---|
+| [01 — Installation](01-installation.md) | How to install `uio`, set up shell completion, and verify the installation |
+| [02 — Core concepts](02-concepts.md) | What agents, skills, and prompts are, and when to use each |
+| [03 — Quickstart](03-quickstart.md) | End-to-end tutorial: set a key, scaffold `.uio/`, run your first agent, read the cost report |
+| [04 — Frontmatter schema](04-frontmatter.md) | Complete YAML frontmatter reference for `.agent.md`, `.skill.md`, and `.prompt.md` files |
+| [05 — CLI reference](05-cli.md) | Every command, subcommand, flag, exit code, and environment variable |
+| [06 — Configuration](06-configuration.md) | `uio.toml` key inventory, merge/precedence semantics, and a fully-annotated example |
+| [07 — Providers](07-providers.md) | Gemini, OpenAI, Ollama, LiteLLM proxy, and Azure OpenAI — setup, models, and cost table |
+| [08 — MCP integration](08-mcp.md) | GitHub MCP server setup, tool naming, custom servers, and the security model |
+| [09 — Chat REPL](09-chat.md) | Interactive session options, slash commands, tool approval, and allow/deny glob patterns |
+| [10 — Cost ledger](10-cost.md) | Ledger schema, cost formula, `uio cost` usage, and `jq` recipes |
+| [11 — Registry](11-registry.md) | Remote registry discovery — configure, search, install, pin, and host a registry |
+| [12 — Writing definitions](12-writing-definitions.md) | How to write effective agents, skills, and prompts; tool-use patterns; common failure modes |
+| [13 — Internals](13-internals.md) | Package architecture, every module's role, how to add a provider or tool, and contributing |
+
+---
+
+## Suggested reading paths
+
+### I'm new to uio
+
+1. [Installation](01-installation.md) — get the CLI working
+2. [Core concepts](02-concepts.md) — understand the three definition types
+3. [Quickstart](03-quickstart.md) — run your first agent
+4. [Writing definitions](12-writing-definitions.md) — write your own
+
+### I want to configure a specific provider
+
+- [Providers](07-providers.md) — Gemini, OpenAI, Ollama, LiteLLM, Azure
+- [Configuration](06-configuration.md) — persist settings in `uio.toml`
+
+### I want to use the chat REPL
+
+- [Chat REPL](09-chat.md)
+- [Providers](07-providers.md) — choose a model
+
+### I want to find and install community definitions
+
+- [Registry](11-registry.md) — `uio registry search` and `uio registry install`
+
+### I want to understand how uio works internally
+
+- [Internals](13-internals.md) — architecture, extension points, contributing
+- [Core concepts](02-concepts.md) — mental model first


### PR DESCRIPTION
Closes #5

## Summary

- Adds `docs/` directory with 14 pages (2,782 lines) covering every aspect of uio
- Navigation hub at `docs/README.md` with suggested reading paths for newcomers and experienced engineers
- Each page serves both personas: sequential steps for newcomers, precise technical specs and extension points for senior engineers

## Pages added

| File | Covers |
|---|---|
| `docs/README.md` | Navigation hub with two suggested reading paths |
| `docs/01-installation.md` | pip install, shell completion, first-run verification, troubleshooting |
| `docs/02-concepts.md` | UIO analogy, agent/skill/prompt mental model, comparison table |
| `docs/03-quickstart.md` | End-to-end tutorial: key → init → run → edit → cost report |
| `docs/04-frontmatter.md` | Complete YAML schema for all three types, complexity resolution order, validation rules |
| `docs/05-cli.md` | Every command, flag, exit code, env var table, shell-scriptable patterns |
| `docs/06-configuration.md` | Full uio.toml key inventory, precedence order, fully-annotated example |
| `docs/07-providers.md` | Gemini, OpenAI, Ollama, LiteLLM, Azure; token cost reference table |
| `docs/08-mcp.md` | GitHub MCP server setup, token scopes, tool naming, JSON-RPC 2.0 internals |
| `docs/09-chat.md` | REPL slash commands, tool approval, allow/deny globs, streaming implementation |
| `docs/10-cost.md` | Ledger schema, cost formula, uio cost usage, jq recipes |
| `docs/11-registry.md` | Manifest schema, TTL caching, URL normalisation, pinning, hosting a registry |
| `docs/12-writing-definitions.md` | System prompt anatomy, tool-use patterns, iteration cap, common failure modes |
| `docs/13-internals.md` | Module breakdown, adding a provider/tool walkthroughs, test suite guide |

## Test plan

- [ ] All code examples cross-checked against source (`MAX_ITERATIONS`, `MAX_OUTPUT_BYTES`, `ROUTING_CHAIN`, `TOKEN_COSTS_PER_1M`, known frontmatter keys — all verified)
- [ ] `uio.toml` key inventory in `06-configuration.md` matches `_DEFAULTS` and `_STARTER_TOML` in `uio/config.py`
- [ ] Token cost table in `07-providers.md` matches `TOKEN_COSTS_PER_1M` in `uio/core/clients.py`
- [ ] Provider/model defaults in `04-frontmatter.md` match `PROVIDER_DEFAULTS` / `PROVIDER_SMALL_MODELS`
- [ ] MCP tool naming convention matches `MCPClient.list_tools()` in `uio/core/mcp.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)