### PR TITLE
fix: warn on duplicate definition name across registries during install

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,73 @@
+name: Bug Report
+description: Report a reproducible bug in uio
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill in as much detail as possible.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of what the bug is.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to reproduce the behaviour.
+      placeholder: |
+        1. Run `uio agent run ...`
+        2. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: What you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+      description: What actually happened. Include the full error/traceback if applicable.
+    validations:
+      required: true
+
+  - type: input
+    id: uio-version
+    attributes:
+      label: uio version
+      description: Output of `uio --version`
+    validations:
+      required: true
+
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      description: Output of `python --version`
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: "e.g. macOS 15.3, Ubuntu 24.04, Windows 11"
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Any other context, config files, or screenshots.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature Request
+description: Propose a new feature or enhancement
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea? We'd love to hear it. Please provide as much context as you can.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem does this feature solve? What use-case drives it?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the feature you'd like. CLI flags, API shape, config keys — be as specific as you can.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you've thought about and why they fall short.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links, prior art, related issues, mockups.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Summary
+
+<!-- What does this PR do? Reference the issue it closes: "Closes #N" -->
+
+Closes #
+
+## Changes
+
+<!-- Bullet-point list of what changed -->
+
+-
+
+## Test plan
+
+<!-- How did you verify this works? New tests added? Manual steps? -->
+
+- [ ] `pytest` passes locally
+- [ ] `ruff check .` passes locally
+- [ ] `ruff format --check .` passes locally
+
+## Notes for reviewers
+
+<!-- Anything that needs extra attention or context during review -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install ruff
+        run: pip install ruff
+
+      - name: Check formatting
+        run: ruff format --check .
+
+      - name: Check linting
+        run: ruff check .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,67 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install build
+        run: pip install build
+
+      - name: Build wheel and sdist
+        run: python -m build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: Create GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- CI workflow: pytest across Python 3.11–3.13, ruff lint/format checks
+- Release workflow: build wheel + sdist, publish to PyPI via Trusted Publisher, create GitHub Release
+- Issue templates: bug report and feature request (structured forms)
+- Pull request template with checklist
+- Dependabot: weekly pip and GitHub Actions dependency updates
+- `CONTRIBUTING.md`: setup, workflow, style, commit, and PR guidelines
+- `CHANGELOG.md`: this file
+
+## [0.1.0] - 2025-01-01
+
+### Added
+
+- Initial release: provider-agnostic agent/skill/prompt runner
+- CLI (`uio`) with `agent run`, `skill run`, `prompt run`, `chat`, `cost`, `init`, `registry` sub-commands
+- Bundled examples and remote registry discovery
+- Full documentation suite in `docs/`
+
+[Unreleased]: https://github.com/jomkz/uio/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/jomkz/uio/releases/tag/v0.1.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,7 @@
+# Code of Conduct
+
+This project is governed by the
+[Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+
+To report a violation, email [anthropic@mkz.io](mailto:anthropic@mkz.io).
+All reports are reviewed and investigated promptly and confidentially.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,117 @@
+# Contributing to uio
+
+Thank you for your interest in contributing! This document covers everything you need to get started.
+
+## Table of contents
+
+- [Code of Conduct](#code-of-conduct)
+- [Getting started](#getting-started)
+- [Development workflow](#development-workflow)
+- [Running tests](#running-tests)
+- [Code style](#code-style)
+- [Commit messages](#commit-messages)
+- [Pull requests](#pull-requests)
+- [Reporting bugs](#reporting-bugs)
+- [Requesting features](#requesting-features)
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating you agree to abide by its terms.
+
+## Getting started
+
+```bash
+# Fork and clone the repo
+git clone https://github.com/<your-username>/uio.git
+cd uio
+
+# Create a virtual environment
+python -m venv .venv
+source .venv/bin/activate   # Windows: .venv\Scripts\activate
+
+# Install in editable mode with dev dependencies
+pip install -e ".[dev]"
+```
+
+## Development workflow
+
+1. Create a branch from `main`:
+   ```bash
+   git checkout -b feat/short-description   # new feature
+   git checkout -b fix/short-description    # bug fix
+   ```
+
+2. Make your changes, write tests, update docs as needed.
+
+3. Verify everything passes (see below).
+
+4. Push and open a pull request against `main`.
+
+## Running tests
+
+```bash
+# Run the full test suite
+pytest
+
+# With coverage
+pytest --cov=uio --cov-report=term-missing
+```
+
+All tests must pass before a PR can be merged.
+
+## Code style
+
+uio uses [ruff](https://docs.astral.sh/ruff/) for formatting and linting.
+
+```bash
+# Format
+ruff format .
+
+# Lint (auto-fix safe issues)
+ruff check --fix .
+```
+
+The CI pipeline enforces both checks on every PR. You can add a pre-commit hook to catch issues locally:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+## Commit messages
+
+Follow the [Conventional Commits](https://www.conventionalcommits.org/) spec:
+
+```
+<type>(<scope>): <short summary>
+
+<optional body>
+```
+
+Common types: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`.
+
+Examples:
+```
+feat(cli): add --timeout flag to agent run
+fix(registry): handle missing manifest gracefully
+docs: update quickstart for v0.2
+```
+
+## Pull requests
+
+- Keep PRs focused — one logical change per PR.
+- Fill in the PR template (it loads automatically).
+- Reference the issue your PR closes: `Closes #N`.
+- All CI checks must pass.
+- At least one maintainer approval is required before merge.
+
+## Reporting bugs
+
+Use the [Bug Report](https://github.com/jomkz/uio/issues/new?template=bug_report.yml) issue template. Include:
+- `uio --version` and `python --version` output
+- Minimal reproduction steps
+- The full error / traceback
+
+## Requesting features
+
+Use the [Feature Request](https://github.com/jomkz/uio/issues/new?template=feature_request.yml) issue template. Describe the problem, your proposed solution, and any alternatives you considered.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Supported versions
+
+| Version | Supported |
+|---------|-----------|
+| 0.1.x   | ✅        |
+
+## Reporting a vulnerability
+
+Please do **not** open a public GitHub issue for a potential vulnerability.
+
+Instead, email [anthropic@mkz.io](mailto:anthropic@mkz.io) with:
+
+- A description of the issue and its potential impact
+- Steps to reproduce or a proof-of-concept (if available)
+- Any suggested mitigations you have identified
+
+You can expect an acknowledgement within 48 hours and a resolution timeline within 7 days of the initial report. We will credit you in the release notes unless you prefer to remain anonymous.

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -3,9 +3,9 @@
 Instances are created via __new__ to skip __init__ (which requires API keys).
 Only append_turn and build_history are under test — pure message formatting.
 """
+
 import json
 
-import pytest
 
 from uio.core.clients import GeminiClient, LLMResponse, OpenAIClient
 from uio.core.tools import ToolCall
@@ -16,6 +16,7 @@ def tc(cmd: str = "echo hi", call_id: str = "tc-1") -> ToolCall:
 
 
 # ── GeminiClient ──────────────────────────────────────────────────────────────
+
 
 def gemini() -> GeminiClient:
     return GeminiClient.__new__(GeminiClient)
@@ -45,7 +46,9 @@ def test_gemini_tool_result_appended_as_user_turn():
     assert len(history) == 3
     model_turn = history[1]
     assert model_turn["role"] == "model"
-    assert {"function_call": {"name": "run_command", "args": {"command": "echo hi"}}} in model_turn["parts"]
+    assert {"function_call": {"name": "run_command", "args": {"command": "echo hi"}}} in model_turn[
+        "parts"
+    ]
 
     tool_turn = history[2]
     assert tool_turn["role"] == "user"
@@ -79,6 +82,7 @@ def test_gemini_text_and_tool_call_both_in_model_parts():
 
 
 # ── OpenAIClient ──────────────────────────────────────────────────────────────
+
 
 def openai_client() -> OpenAIClient:
     return OpenAIClient.__new__(OpenAIClient)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,9 +1,9 @@
 """Tests for bundled example definitions in uio.examples."""
+
 import pytest
 
 from uio.examples import EXAMPLES
 from uio.schema.parser import parse_definition_file, validate_definition
-import io
 import re
 import yaml
 
@@ -19,6 +19,7 @@ def _parse_embedded(content: str) -> tuple[dict, str]:
 
 
 # ── Structure ─────────────────────────────────────────────────────────────────
+
 
 def test_examples_has_agents_key():
     assert "agents" in EXAMPLES
@@ -39,6 +40,7 @@ def test_examples_nonempty():
 
 # ── Filename conventions ──────────────────────────────────────────────────────
 
+
 def test_agent_filenames_end_with_agent_md():
     for filename, _ in EXAMPLES["agents"]:
         assert filename.endswith(".agent.md"), f"Bad agent filename: {filename}"
@@ -55,6 +57,7 @@ def test_prompt_filenames_end_with_prompt_md():
 
 
 # ── Frontmatter parsing ───────────────────────────────────────────────────────
+
 
 def _all_examples():
     for kind, entries in EXAMPLES.items():
@@ -88,6 +91,7 @@ def test_example_has_nonempty_body(filename, content):
 
 # ── Validate via schema.parser ────────────────────────────────────────────────
 
+
 @pytest.mark.parametrize("filename,content", list(_all_examples()))
 def test_example_passes_validation(filename, content, tmp_path):
     """Write each example to a temp file and validate through the real parser."""
@@ -100,6 +104,7 @@ def test_example_passes_validation(filename, content, tmp_path):
 
 # ── Agent-specific ────────────────────────────────────────────────────────────
 
+
 def test_agent_complexity_is_valid():
     valid = {"large", "small"}
     for filename, content in EXAMPLES["agents"]:
@@ -111,6 +116,7 @@ def test_agent_complexity_is_valid():
 
 # ── Prompt-specific ───────────────────────────────────────────────────────────
 
+
 def test_prompts_are_invokable():
     for filename, content in EXAMPLES["prompts"]:
         fm, _ = _parse_embedded(content)
@@ -118,6 +124,7 @@ def test_prompts_are_invokable():
 
 
 # ── No duplicate filenames ────────────────────────────────────────────────────
+
 
 def test_no_duplicate_filenames():
     seen: set[str] = set()

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1,8 +1,8 @@
 """Tests for cost ledger: estimation and file append."""
+
 import json
 from pathlib import Path
 
-import pytest
 
 from uio.core.ledger import estimate_cost_usd, write_cost_ledger
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,7 +1,7 @@
 """Tests for the YAML frontmatter parser."""
+
 import textwrap
 
-import pytest
 
 from uio.schema.parser import parse_definition_file, validate_definition
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,9 +1,8 @@
 """Tests for uio.registry.manifest — fetch, cache, search, install, validate."""
+
 from __future__ import annotations
 
 import time
-from io import BytesIO
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -67,6 +66,7 @@ def _mock_urlopen(content: str):
 
 # ── _raw_url ──────────────────────────────────────────────────────────────────
 
+
 def test_raw_url_github():
     url = _raw_url("https://github.com/jomkz/uio-registry", "main", "registry.yaml")
     assert url == "https://raw.githubusercontent.com/jomkz/uio-registry/main/registry.yaml"
@@ -95,6 +95,7 @@ def test_raw_url_sha_ref():
 
 # ── fetch_manifest ────────────────────────────────────────────────────────────
 
+
 def test_fetch_manifest_parses_yaml(tmp_path):
     with patch("urllib.request.urlopen", return_value=_mock_urlopen(MANIFEST_YAML)):
         manifest = fetch_manifest(REG, force=True, cache_dir=tmp_path)
@@ -121,6 +122,7 @@ def test_fetch_manifest_refreshes_stale_cache(tmp_path):
     # Make the file appear old
     old_mtime = time.time() - 48 * 3600
     import os
+
     os.utime(cache, (old_mtime, old_mtime))
 
     reg_ttl = {**REG, "cache_ttl_hours": 24}
@@ -133,6 +135,7 @@ def test_fetch_manifest_falls_back_to_stale_on_error(tmp_path):
     (tmp_path / "official.yaml").write_text(MANIFEST_YAML)
     old_mtime = time.time() - 48 * 3600
     import os
+
     os.utime(tmp_path / "official.yaml", (old_mtime, old_mtime))
 
     reg_ttl = {**REG, "cache_ttl_hours": 24}
@@ -149,13 +152,16 @@ def test_fetch_manifest_raises_when_no_cache_and_network_fails(tmp_path):
 
 def test_fetch_manifest_force_ignores_fresh_cache(tmp_path):
     (tmp_path / "official.yaml").write_text(MANIFEST_YAML)
-    updated = MANIFEST_YAML + "  - name: extra\n    type: skill\n    path: x.md\n    description: x\n"
+    updated = (
+        MANIFEST_YAML + "  - name: extra\n    type: skill\n    path: x.md\n    description: x\n"
+    )
     with patch("urllib.request.urlopen", return_value=_mock_urlopen(updated)):
         manifest = fetch_manifest(REG, force=True, cache_dir=tmp_path)
     assert len(manifest["definitions"]) == 4
 
 
 # ── search_definitions ────────────────────────────────────────────────────────
+
 
 def test_search_by_name(tmp_path):
     with patch("urllib.request.urlopen", return_value=_mock_urlopen(MANIFEST_YAML)):
@@ -220,23 +226,33 @@ def test_search_is_case_insensitive(tmp_path):
 
 # ── fetch_definition_content ──────────────────────────────────────────────────
 
+
 def test_fetch_definition_content_returns_text():
-    defn = {"name": "summarise", "type": "skill", "path": "skills/summarise.skill.md",
-            "description": "x"}
+    defn = {
+        "name": "summarise",
+        "type": "skill",
+        "path": "skills/summarise.skill.md",
+        "description": "x",
+    }
     with patch("urllib.request.urlopen", return_value=_mock_urlopen(DEFINITION_CONTENT)):
         content = fetch_definition_content(REG, defn)
     assert "summarise" in content
 
 
 def test_fetch_definition_content_raises_on_error():
-    defn = {"name": "summarise", "type": "skill", "path": "skills/summarise.skill.md",
-            "description": "x"}
+    defn = {
+        "name": "summarise",
+        "type": "skill",
+        "path": "skills/summarise.skill.md",
+        "description": "x",
+    }
     with patch("urllib.request.urlopen", side_effect=OSError("timeout")):
         with pytest.raises(RuntimeError, match="timeout"):
             fetch_definition_content(REG, defn)
 
 
 # ── validate_manifest ─────────────────────────────────────────────────────────
+
 
 def test_validate_manifest_valid():
     manifest = yaml.safe_load(MANIFEST_YAML)
@@ -284,6 +300,7 @@ def test_validate_manifest_all_valid_types():
 
 # ── resolve_ref_to_sha ────────────────────────────────────────────────────────
 
+
 def test_resolve_ref_returns_none_for_non_github():
     reg = {"name": "gl", "url": "https://gitlab.com/x/y", "ref": "main"}
     sha = resolve_ref_to_sha(reg)
@@ -298,6 +315,7 @@ def test_resolve_ref_returns_none_on_network_error():
 
 def test_resolve_ref_parses_sha():
     import json
+
     fake_resp = MagicMock()
     fake_resp.__enter__ = lambda s: s
     fake_resp.__exit__ = MagicMock(return_value=False)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -348,15 +348,29 @@ def _make_cfg(tmp_path, registries):
             "skills": str(tmp_path / "skills"),
             "prompts": str(tmp_path / "prompts"),
         },
-        "runtime": {"default_provider": "anthropic", "timeout": 60, "cost_ledger": str(tmp_path / "cost.json")},
+        "runtime": {
+            "default_provider": "anthropic",
+            "timeout": 60,
+            "cost_ledger": str(tmp_path / "cost.json"),
+        },
         "large_agents": {"names": []},
     }
 
 
 def test_install_warns_on_duplicate_across_registries(tmp_path):
     """A warning is emitted to stderr when the same name exists in multiple registries."""
-    reg1 = {"name": "official", "url": "https://github.com/jomkz/uio-registry", "ref": "main", "enabled": True}
-    reg2 = {"name": "community", "url": "https://github.com/other/uio-reg", "ref": "main", "enabled": True}
+    reg1 = {
+        "name": "official",
+        "url": "https://github.com/jomkz/uio-registry",
+        "ref": "main",
+        "enabled": True,
+    }
+    reg2 = {
+        "name": "community",
+        "url": "https://github.com/other/uio-reg",
+        "ref": "main",
+        "enabled": True,
+    }
     cfg = _make_cfg(tmp_path, [reg1, reg2])
 
     manifest = yaml.safe_load(MANIFEST_WITH_SUMMARISE)
@@ -365,7 +379,10 @@ def test_install_warns_on_duplicate_across_registries(tmp_path):
         patch("uio.cli.registry.load_config", return_value=cfg),
         patch("uio.cli.registry.fetch_manifest", return_value=manifest),
         patch("uio.cli.registry.fetch_definition_content", return_value=DEFINITION_CONTENT),
-        patch("uio.cli.registry.parse_definition_file", return_value=({"name": "summarise", "type": "skill"}, "")),
+        patch(
+            "uio.cli.registry.parse_definition_file",
+            return_value=({"name": "summarise", "type": "skill"}, ""),
+        ),
         patch("uio.cli.registry.validate_definition", return_value=[]),
     ):
         result = CliRunner().invoke(registry_install_cmd, ["summarise"])
@@ -377,7 +394,12 @@ def test_install_warns_on_duplicate_across_registries(tmp_path):
 
 def test_install_no_warning_when_no_duplicate(tmp_path):
     """No warning is emitted when the definition exists in only one registry."""
-    reg1 = {"name": "official", "url": "https://github.com/jomkz/uio-registry", "ref": "main", "enabled": True}
+    reg1 = {
+        "name": "official",
+        "url": "https://github.com/jomkz/uio-registry",
+        "ref": "main",
+        "enabled": True,
+    }
     reg2_manifest = yaml.safe_load("version: 1\ndefinitions: []\n")
     cfg = _make_cfg(tmp_path, [reg1])
 
@@ -387,7 +409,10 @@ def test_install_no_warning_when_no_duplicate(tmp_path):
         patch("uio.cli.registry.load_config", return_value=cfg),
         patch("uio.cli.registry.fetch_manifest", return_value=manifest),
         patch("uio.cli.registry.fetch_definition_content", return_value=DEFINITION_CONTENT),
-        patch("uio.cli.registry.parse_definition_file", return_value=({"name": "summarise", "type": "skill"}, "")),
+        patch(
+            "uio.cli.registry.parse_definition_file",
+            return_value=({"name": "summarise", "type": "skill"}, ""),
+        ),
         patch("uio.cli.registry.validate_definition", return_value=[]),
     ):
         result = CliRunner().invoke(registry_install_cmd, ["summarise"])

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -7,7 +7,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml
+from click.testing import CliRunner
 
+from uio.cli.registry import registry_install_cmd
 from uio.registry.manifest import (
     _raw_url,
     fetch_definition_content,
@@ -323,3 +325,73 @@ def test_resolve_ref_parses_sha():
     with patch("urllib.request.urlopen", return_value=fake_resp):
         sha = resolve_ref_to_sha(REG)
     assert sha == "abc123def456"
+
+
+# ── registry_install_cmd duplicate warning ────────────────────────────────────
+
+MANIFEST_WITH_SUMMARISE = """\
+version: 1
+definitions:
+  - name: summarise
+    type: skill
+    path: skills/summarise.skill.md
+    description: Summarise text or a file
+    tags: [text]
+"""
+
+
+def _make_cfg(tmp_path, registries):
+    return {
+        "registries": registries,
+        "dirs": {
+            "agents": str(tmp_path / "agents"),
+            "skills": str(tmp_path / "skills"),
+            "prompts": str(tmp_path / "prompts"),
+        },
+        "runtime": {"default_provider": "anthropic", "timeout": 60, "cost_ledger": str(tmp_path / "cost.json")},
+        "large_agents": {"names": []},
+    }
+
+
+def test_install_warns_on_duplicate_across_registries(tmp_path):
+    """A warning is emitted to stderr when the same name exists in multiple registries."""
+    reg1 = {"name": "official", "url": "https://github.com/jomkz/uio-registry", "ref": "main", "enabled": True}
+    reg2 = {"name": "community", "url": "https://github.com/other/uio-reg", "ref": "main", "enabled": True}
+    cfg = _make_cfg(tmp_path, [reg1, reg2])
+
+    manifest = yaml.safe_load(MANIFEST_WITH_SUMMARISE)
+
+    with (
+        patch("uio.cli.registry.load_config", return_value=cfg),
+        patch("uio.cli.registry.fetch_manifest", return_value=manifest),
+        patch("uio.cli.registry.fetch_definition_content", return_value=DEFINITION_CONTENT),
+        patch("uio.cli.registry.parse_definition_file", return_value=({"name": "summarise", "type": "skill"}, "")),
+        patch("uio.cli.registry.validate_definition", return_value=[]),
+    ):
+        result = CliRunner().invoke(registry_install_cmd, ["summarise"])
+
+    assert result.exit_code == 0
+    assert "community" in result.output  # warning goes to stderr, mixed into output by CliRunner
+    assert "also found" in result.output
+
+
+def test_install_no_warning_when_no_duplicate(tmp_path):
+    """No warning is emitted when the definition exists in only one registry."""
+    reg1 = {"name": "official", "url": "https://github.com/jomkz/uio-registry", "ref": "main", "enabled": True}
+    reg2_manifest = yaml.safe_load("version: 1\ndefinitions: []\n")
+    cfg = _make_cfg(tmp_path, [reg1])
+
+    manifest = yaml.safe_load(MANIFEST_WITH_SUMMARISE)
+
+    with (
+        patch("uio.cli.registry.load_config", return_value=cfg),
+        patch("uio.cli.registry.fetch_manifest", return_value=manifest),
+        patch("uio.cli.registry.fetch_definition_content", return_value=DEFINITION_CONTENT),
+        patch("uio.cli.registry.parse_definition_file", return_value=({"name": "summarise", "type": "skill"}, "")),
+        patch("uio.cli.registry.validate_definition", return_value=[]),
+    ):
+        result = CliRunner().invoke(registry_install_cmd, ["summarise"])
+
+    assert result.exit_code == 0
+    assert "also found" not in result.output
+    _ = reg2_manifest  # unused; kept to clarify intent

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,7 +1,5 @@
 """Tests for routing: complexity inference, model selection, provider chain, cost."""
 
-
-
 from uio.core.clients import (
     LLMResponse,
     OllamaClient,

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,7 +1,6 @@
 """Tests for routing: complexity inference, model selection, provider chain, cost."""
-import os
 
-import pytest
+
 
 from uio.core.clients import (
     LLMResponse,
@@ -21,6 +20,7 @@ from uio.core.tools import ToolCall
 
 
 # ── infer_complexity ───────────────────────────────────────────────────────────
+
 
 def test_complexity_cli_override_wins():
     assert infer_complexity("my-agent", {"complexity": "small"}, "large") == "large"
@@ -59,10 +59,14 @@ def test_complexity_empty_large_names_list():
 
 
 def test_complexity_frontmatter_beats_large_names():
-    assert infer_complexity("my-agent", {"complexity": "small"}, None, large_names=["my-agent"]) == "small"
+    assert (
+        infer_complexity("my-agent", {"complexity": "small"}, None, large_names=["my-agent"])
+        == "small"
+    )
 
 
 # ── select_model ───────────────────────────────────────────────────────────────
+
 
 def test_select_model_explicit_override():
     assert select_model("gemini", "large", "my-custom-model") == "my-custom-model"
@@ -103,6 +107,7 @@ def test_select_model_explicit_override_beats_env(monkeypatch):
 
 
 # ── select_provider_chain ──────────────────────────────────────────────────────
+
 
 def test_provider_chain_explicit_override(monkeypatch):
     monkeypatch.delenv("GEMINI_API_KEY", raising=False)
@@ -153,6 +158,7 @@ def test_provider_chain_respects_routing_order(monkeypatch):
 
 # ── estimate_cost_usd ──────────────────────────────────────────────────────────
 
+
 def test_cost_estimate_gemini_flash():
     cost = estimate_cost_usd("gemini", "gemini-2.5-flash", 1_000_000, 1_000_000)
     assert abs(cost - 0.75) < 1e-9
@@ -179,6 +185,7 @@ def test_cost_estimate_unknown_model_falls_back_to_provider():
 
 # ── TokenUsage / LLMResponse ───────────────────────────────────────────────────
 
+
 def test_llm_response_usage_defaults_to_none():
     r = LLMResponse(text="hi", tool_calls=[])
     assert r.usage is None
@@ -192,6 +199,7 @@ def test_llm_response_usage_field():
 
 
 # ── OllamaClient ──────────────────────────────────────────────────────────────
+
 
 def ollama_client() -> OllamaClient:
     return OllamaClient.__new__(OllamaClient)
@@ -209,7 +217,7 @@ def test_ollama_inherits_openai_append_turn_text_only():
 
 
 def test_ollama_inherits_openai_append_turn_tool_result():
-    import json
+
     client = ollama_client()
     history = [{"role": "user", "content": "begin"}]
     call = tc(call_id="tc-1")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,5 +1,5 @@
 """Tests for tool execution: run_command, truncation, timeout, unknown tools."""
-import pytest
+
 
 from uio.core.tools import DEFAULT_TIMEOUT, MAX_OUTPUT_BYTES, ToolCall, execute_tool
 
@@ -32,11 +32,7 @@ def test_output_truncated_at_limit():
 def test_tail_biased_truncation_preserves_end():
     sentinel = "SENTINEL_END"
     big = MAX_OUTPUT_BYTES + 1000
-    output = execute_tool(call(
-        f"python3 -c \""
-        f"print('a' * {big}); print('{sentinel}')"
-        f"\""
-    ))
+    output = execute_tool(call(f"python3 -c \"print('a' * {big}); print('{sentinel}')\""))
     assert "[output truncated]" in output
     assert sentinel in output
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,6 +1,5 @@
 """Tests for tool execution: run_command, truncation, timeout, unknown tools."""
 
-
 from uio.core.tools import DEFAULT_TIMEOUT, MAX_OUTPUT_BYTES, ToolCall, execute_tool
 
 

--- a/uio/cli/_helpers.py
+++ b/uio/cli/_helpers.py
@@ -1,4 +1,5 @@
 """Shared CLI helpers: definition listing and table printing."""
+
 from __future__ import annotations
 
 from glob import glob
@@ -26,10 +27,7 @@ def print_definition_table(rows: list[list[str]], headers: list[str]) -> None:
     if not rows:
         click.echo("  (none found)")
         return
-    widths = [
-        max(len(h), max(len(r[i]) for r in rows))
-        for i, h in enumerate(headers)
-    ]
+    widths = [max(len(h), max(len(r[i]) for r in rows)) for i, h in enumerate(headers)]
     click.echo("  ".join(h.ljust(w) for h, w in zip(headers, widths)))
     click.echo("  ".join("-" * w for w in widths))
     for row in rows:

--- a/uio/cli/agent.py
+++ b/uio/cli/agent.py
@@ -1,4 +1,5 @@
 """uio agent subcommands: run, list, inspect, new."""
+
 from __future__ import annotations
 
 import textwrap
@@ -10,7 +11,6 @@ from uio.cli._helpers import list_definitions, print_definition_table
 from uio.config import load_config
 from uio.core.routing import infer_complexity
 from uio.core.runner import run_agent
-from uio.core.tools import DEFAULT_TIMEOUT
 from uio.schema.parser import parse_definition_file
 
 _AGENT_TEMPLATE = textwrap.dedent("""\
@@ -40,17 +40,23 @@ def agent_group() -> None:
 @agent_group.command("run")
 @click.argument("agent_name", metavar="AGENT")
 @click.argument("arg", required=False)
-@click.option("--provider", default=None,
-              help="LLM provider: gemini, openai, or ollama (default: auto-routes).")
+@click.option(
+    "--provider",
+    default=None,
+    help="LLM provider: gemini, openai, or ollama (default: auto-routes).",
+)
 @click.option("--model", default=None, help="Model name override.")
-@click.option("--complexity", type=click.Choice(["large", "small"]), default=None,
-              help="Task complexity tier (default: inferred from frontmatter or uio.toml).")
-@click.option("--base-url", default=None,
-              help="Base URL for an OpenAI-compatible endpoint.")
-@click.option("--timeout", default=None, show_default=True, type=int,
-              help="Per-command timeout in seconds.")
-@click.option("--no-mcp", is_flag=True, default=False,
-              help="Disable the GitHub MCP server.")
+@click.option(
+    "--complexity",
+    type=click.Choice(["large", "small"]),
+    default=None,
+    help="Task complexity tier (default: inferred from frontmatter or uio.toml).",
+)
+@click.option("--base-url", default=None, help="Base URL for an OpenAI-compatible endpoint.")
+@click.option(
+    "--timeout", default=None, show_default=True, type=int, help="Per-command timeout in seconds."
+)
+@click.option("--no-mcp", is_flag=True, default=False, help="Disable the GitHub MCP server.")
 def agent_run_cmd(
     agent_name: str,
     arg: str | None,
@@ -122,7 +128,9 @@ def agent_inspect_cmd(agent_name: str) -> None:
     fm, body = parse_definition_file(path)
     click.echo(f"  Name:        {fm.get('name', agent_name)}")
     click.echo(f"  Description: {fm.get('description', '—')}")
-    click.echo(f"  Complexity:  {infer_complexity(agent_name, fm, None, load_config()['large_agents']['names'])}")
+    click.echo(
+        f"  Complexity:  {infer_complexity(agent_name, fm, None, load_config()['large_agents']['names'])}"
+    )
     if fm.get("tools"):
         click.echo(f"  Tools:       {', '.join(fm['tools'])}")
     click.echo()

--- a/uio/cli/chat.py
+++ b/uio/cli/chat.py
@@ -1,4 +1,5 @@
 """uio chat — interactive streaming multi-turn REPL."""
+
 from __future__ import annotations
 
 import fnmatch
@@ -10,7 +11,7 @@ from uio.config import load_config
 from uio.core.clients import GeminiClient, LLMClient, LLMResponse, OpenAIClient, TokenUsage
 from uio.core.ledger import estimate_cost_usd, write_cost_ledger
 from uio.core.routing import select_model, select_provider_chain
-from uio.core.tools import DEFAULT_TIMEOUT, TOOL_SCHEMA, ToolCall, execute_tool
+from uio.core.tools import TOOL_SCHEMA, ToolCall, execute_tool
 from uio.core.clients import make_client
 
 _DEFAULT_SYSTEM = """\
@@ -21,11 +22,11 @@ and assist with any development task. Be concise and direct.
 _MAX_TOOL_ITERS = 10
 
 _SLASH_CMDS = {
-    "/exit":  "Exit the session",
-    "/quit":  "Exit the session",
+    "/exit": "Exit the session",
+    "/quit": "Exit the session",
     "/clear": "Clear conversation history",
-    "/cost":  "Show token spend for this session",
-    "/help":  "Show this help",
+    "/cost": "Show token spend for this session",
+    "/help": "Show this help",
 }
 
 
@@ -226,7 +227,9 @@ def _inner_tool_loop(
     return response, extra_prompt, extra_completion
 
 
-def _show_session_cost(provider: str, model: str, prompt_tokens: int, completion_tokens: int) -> None:
+def _show_session_cost(
+    provider: str, model: str, prompt_tokens: int, completion_tokens: int
+) -> None:
     total = prompt_tokens + completion_tokens
     cost = estimate_cost_usd(provider, model, prompt_tokens, completion_tokens)
     click.echo(
@@ -236,21 +239,45 @@ def _show_session_cost(provider: str, model: str, prompt_tokens: int, completion
 
 
 @click.command("chat")
-@click.option("--provider", default=None,
-              help="LLM provider: gemini, openai, or ollama (default: auto-routes).")
+@click.option(
+    "--provider",
+    default=None,
+    help="LLM provider: gemini, openai, or ollama (default: auto-routes).",
+)
 @click.option("--model", default=None, help="Model name override.")
-@click.option("--base-url", default=None,
-              help="Base URL for an OpenAI-compatible endpoint.")
-@click.option("--system", "system_file", default=None,
-              help="Path to a file whose contents become the system prompt.")
-@click.option("--tools", is_flag=True, default=False,
-              help="Expose the run_command tool so the LLM can execute shell commands.")
-@click.option("--auto-approve", is_flag=True, default=False,
-              help="Skip per-command approval prompts (implies --tools).")
-@click.option("--allow", "allow_globs", multiple=True, metavar="GLOB",
-              help="Shell-glob pattern for auto-approved commands (repeatable).")
-@click.option("--deny", "deny_globs", multiple=True, metavar="GLOB",
-              help="Shell-glob pattern for always-rejected commands (repeatable).")
+@click.option("--base-url", default=None, help="Base URL for an OpenAI-compatible endpoint.")
+@click.option(
+    "--system",
+    "system_file",
+    default=None,
+    help="Path to a file whose contents become the system prompt.",
+)
+@click.option(
+    "--tools",
+    is_flag=True,
+    default=False,
+    help="Expose the run_command tool so the LLM can execute shell commands.",
+)
+@click.option(
+    "--auto-approve",
+    is_flag=True,
+    default=False,
+    help="Skip per-command approval prompts (implies --tools).",
+)
+@click.option(
+    "--allow",
+    "allow_globs",
+    multiple=True,
+    metavar="GLOB",
+    help="Shell-glob pattern for auto-approved commands (repeatable).",
+)
+@click.option(
+    "--deny",
+    "deny_globs",
+    multiple=True,
+    metavar="GLOB",
+    help="Shell-glob pattern for always-rejected commands (repeatable).",
+)
 def chat_cmd(
     provider: str | None,
     model: str | None,
@@ -285,9 +312,7 @@ def chat_cmd(
             raise SystemExit(1)
 
     tool_schemas = [TOOL_SCHEMA] if tools else []
-    provider_chain = select_provider_chain(
-        provider or cfg["runtime"].get("default_provider")
-    )
+    provider_chain = select_provider_chain(provider or cfg["runtime"].get("default_provider"))
     chosen_provider: str | None = None
     resolved_model: str | None = None
     client: LLMClient | None = None
@@ -369,7 +394,10 @@ def chat_cmd(
 
         if tools and response.tool_calls:
             response, ep, ec = _inner_tool_loop(
-                client, history, system, response,
+                client,
+                history,
+                system,
+                response,
                 auto_approve=auto_approve,
                 allow_globs=allow_globs,
                 deny_globs=deny_globs,
@@ -388,6 +416,10 @@ def chat_cmd(
     if total_prompt + total_completion > 0:
         _show_session_cost(chosen_provider, resolved_model, total_prompt, total_completion)
         write_cost_ledger(
-            "chat", chosen_provider, resolved_model, total_prompt, total_completion,
+            "chat",
+            chosen_provider,
+            resolved_model,
+            total_prompt,
+            total_completion,
             cfg["runtime"]["cost_ledger"],
         )

--- a/uio/cli/config.py
+++ b/uio/cli/config.py
@@ -1,4 +1,5 @@
 """uio config subcommands: show, init."""
+
 from __future__ import annotations
 
 import os

--- a/uio/cli/cost.py
+++ b/uio/cli/cost.py
@@ -1,4 +1,5 @@
 """uio cost — summarise token spend from the cost ledger."""
+
 from __future__ import annotations
 
 import datetime
@@ -8,7 +9,6 @@ from pathlib import Path
 import click
 
 from uio.config import load_config
-from uio.core.ledger import DEFAULT_LEDGER_PATH
 
 
 def _load_ledger(ledger_path: str, since: str | None, tail: int | None) -> list[dict]:
@@ -31,9 +31,7 @@ def _load_ledger(ledger_path: str, since: str | None, tail: int | None) -> list[
             if cutoff.tzinfo is None:
                 cutoff = cutoff.replace(tzinfo=datetime.timezone.utc)
         except ValueError:
-            raise click.BadParameter(
-                f"not a valid ISO 8601 date: {since!r}", param_hint="--since"
-            )
+            raise click.BadParameter(f"not a valid ISO 8601 date: {since!r}", param_hint="--since")
         filtered = []
         for e in entries:
             try:
@@ -67,10 +65,7 @@ def _print_cost_table(entries: list[dict]) -> None:
         for e in entries
     ]
     headers = ["TIMESTAMP", "AGENT", "PROVIDER", "MODEL", "TOKENS", "COST"]
-    widths = [
-        max(len(h), max(len(r[i]) for r in rows))
-        for i, h in enumerate(headers)
-    ]
+    widths = [max(len(h), max(len(r[i]) for r in rows)) for i, h in enumerate(headers)]
     click.echo("  ".join(h.ljust(w) for h, w in zip(headers, widths)))
     click.echo("  ".join("-" * w for w in widths))
     for row in rows:
@@ -82,14 +77,23 @@ def _print_cost_table(entries: list[dict]) -> None:
 
 
 @click.command("cost")
-@click.option("--tail", default=None, type=int, metavar="N",
-              help="Show only the last N entries.")
-@click.option("--since", default=None, metavar="DATE",
-              help="Show entries on or after DATE (ISO 8601).")
-@click.option("--json", "as_json", is_flag=True, default=False,
-              help="Emit raw JSON lines instead of a formatted table.")
-@click.option("--ledger", default=None, metavar="PATH",
-              help="Path to the cost ledger file (default: from uio.toml or uio_cost.jsonl).")
+@click.option("--tail", default=None, type=int, metavar="N", help="Show only the last N entries.")
+@click.option(
+    "--since", default=None, metavar="DATE", help="Show entries on or after DATE (ISO 8601)."
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit raw JSON lines instead of a formatted table.",
+)
+@click.option(
+    "--ledger",
+    default=None,
+    metavar="PATH",
+    help="Path to the cost ledger file (default: from uio.toml or uio_cost.jsonl).",
+)
 def cost_cmd(
     tail: int | None,
     since: str | None,

--- a/uio/cli/main.py
+++ b/uio/cli/main.py
@@ -1,4 +1,5 @@
 """Root CLI group and top-level commands: init, validate, completion."""
+
 from __future__ import annotations
 
 import sys
@@ -15,7 +16,7 @@ from uio.cli.cost import cost_cmd
 from uio.cli.prompt import prompt_group
 from uio.cli.registry import registry_group
 from uio.cli.skill import skill_group
-from uio.config import get_starter_toml, load_config
+from uio.config import load_config
 from uio.examples import EXAMPLES
 from uio.schema.parser import parse_definition_file, validate_definition
 
@@ -73,7 +74,9 @@ main.add_command(registry_group, "registry")
 
 @main.command("init")
 @click.option(
-    "--examples", is_flag=True, default=False,
+    "--examples",
+    is_flag=True,
+    default=False,
     help="Also install bundled example agents, skills, and prompts.",
 )
 def init_cmd(examples: bool) -> None:

--- a/uio/cli/prompt.py
+++ b/uio/cli/prompt.py
@@ -1,4 +1,5 @@
 """uio prompt subcommands: run, list, new."""
+
 from __future__ import annotations
 
 import textwrap
@@ -9,7 +10,6 @@ import click
 from uio.cli._helpers import list_definitions, print_definition_table
 from uio.config import load_config
 from uio.core.runner import run_agent
-from uio.schema.parser import parse_definition_file
 
 _PROMPT_TEMPLATE = textwrap.dedent("""\
     ---
@@ -34,15 +34,15 @@ def prompt_group() -> None:
 @prompt_group.command("run")
 @click.argument("prompt_name", metavar="PROMPT")
 @click.argument("arg", required=False)
-@click.option("--provider", default=None,
-              help="LLM provider: gemini, openai, or ollama (default: auto-routes).")
+@click.option(
+    "--provider",
+    default=None,
+    help="LLM provider: gemini, openai, or ollama (default: auto-routes).",
+)
 @click.option("--model", default=None, help="Model name override.")
-@click.option("--base-url", default=None,
-              help="Base URL for an OpenAI-compatible endpoint.")
-@click.option("--timeout", default=None, type=int,
-              help="Per-command timeout in seconds.")
-@click.option("--no-mcp", is_flag=True, default=False,
-              help="Disable the GitHub MCP server.")
+@click.option("--base-url", default=None, help="Base URL for an OpenAI-compatible endpoint.")
+@click.option("--timeout", default=None, type=int, help="Per-command timeout in seconds.")
+@click.option("--no-mcp", is_flag=True, default=False, help="Disable the GitHub MCP server.")
 def prompt_run_cmd(
     prompt_name: str,
     arg: str | None,

--- a/uio/cli/registry.py
+++ b/uio/cli/registry.py
@@ -191,9 +191,11 @@ def registry_install_cmd(name: str, registry: str | None, pin: bool, force: bool
         if not registries:
             raise click.ClickException(f"Registry '{registry}' not found in uio.toml.")
 
-    # Find the definition entry and its registry
+    # Find the definition entry and its registry (first match wins).
+    # Continue scanning remaining registries to detect duplicates and warn.
     found_reg: dict | None = None
     found_defn: dict | None = None
+    duplicate_reg_names: list[str] = []
     for reg in registries:
         if not reg.get("enabled", True):
             continue
@@ -203,16 +205,24 @@ def registry_install_cmd(name: str, registry: str | None, pin: bool, force: bool
             continue
         for defn in manifest.get("definitions", []):
             if defn.get("name") == name:
-                found_reg = reg
-                found_defn = defn
+                if found_reg is None:
+                    found_reg = reg
+                    found_defn = defn
+                else:
+                    duplicate_reg_names.append(reg["name"])
                 break
-        if found_reg:
-            break
 
     if found_reg is None or found_defn is None:
         raise click.ClickException(
             f"Definition '{name}' not found in any enabled registry. "
             "Run 'uio registry search <query>' to discover available definitions."
+        )
+
+    if duplicate_reg_names:
+        others = ", ".join(f"'{n}'" for n in duplicate_reg_names)
+        click.echo(
+            f"  Warning: '{name}' also found in {others} — use --registry to be explicit.",
+            err=True,
         )
 
     defn_type = found_defn.get("type", "")

--- a/uio/cli/registry.py
+++ b/uio/cli/registry.py
@@ -1,4 +1,5 @@
 """uio registry subcommands: list, search, update, install."""
+
 from __future__ import annotations
 
 import sys
@@ -51,9 +52,7 @@ def registry_list_cmd() -> None:
         return
 
     col_w = [max(len(r.get("name", "")), 8) for r in registries]
-    header = (
-        f"  {'NAME':<{max(col_w)}}  {'URL':<50}  {'REF':<12}  ENABLED"
-    )
+    header = f"  {'NAME':<{max(col_w)}}  {'URL':<50}  {'REF':<12}  ENABLED"
     click.echo(header)
     click.echo("  " + "-" * (len(header) - 2))
     for reg in registries:
@@ -67,8 +66,9 @@ def registry_list_cmd() -> None:
 
 @registry_group.command("search")
 @click.argument("query")
-@click.option("--registry", default=None, metavar="NAME",
-              help="Restrict search to a specific registry.")
+@click.option(
+    "--registry", default=None, metavar="NAME", help="Restrict search to a specific registry."
+)
 def registry_search_cmd(query: str, registry: str | None) -> None:
     """Search for definitions matching QUERY across all enabled registries.
 
@@ -97,10 +97,7 @@ def registry_search_cmd(query: str, registry: str | None) -> None:
     col_type = max(len(r.get("type", "")) for r in results)
     col_reg = max(len(r.get("_registry", "")) for r in results)
 
-    header = (
-        f"  {'NAME':<{col_name}}  {'TYPE':<{col_type}}  "
-        f"{'REGISTRY':<{col_reg}}  DESCRIPTION"
-    )
+    header = f"  {'NAME':<{col_name}}  {'TYPE':<{col_type}}  {'REGISTRY':<{col_reg}}  DESCRIPTION"
     click.echo(header)
     click.echo("  " + "-" * (len(header) - 2))
     for r in results:
@@ -114,8 +111,7 @@ def registry_search_cmd(query: str, registry: str | None) -> None:
 
 
 @registry_group.command("update")
-@click.option("--registry", default=None, metavar="NAME",
-              help="Update only the named registry.")
+@click.option("--registry", default=None, metavar="NAME", help="Update only the named registry.")
 def registry_update_cmd(registry: str | None) -> None:
     """Refresh all (or one) cached registry manifests.
 
@@ -156,12 +152,21 @@ def registry_update_cmd(registry: str | None) -> None:
 
 @registry_group.command("install")
 @click.argument("name")
-@click.option("--registry", default=None, metavar="REGISTRY",
-              help="Use only this registry when resolving NAME.")
-@click.option("--pin", is_flag=True, default=False,
-              help="Resolve the registry ref to a commit SHA and print it.")
-@click.option("--force", is_flag=True, default=False,
-              help="Overwrite an existing local definition.")
+@click.option(
+    "--registry",
+    default=None,
+    metavar="REGISTRY",
+    help="Use only this registry when resolving NAME.",
+)
+@click.option(
+    "--pin",
+    is_flag=True,
+    default=False,
+    help="Resolve the registry ref to a commit SHA and print it.",
+)
+@click.option(
+    "--force", is_flag=True, default=False, help="Overwrite an existing local definition."
+)
 def registry_install_cmd(name: str, registry: str | None, pin: bool, force: bool) -> None:
     """Install a definition from a registry into .uio/.
 
@@ -217,18 +222,14 @@ def registry_install_cmd(name: str, registry: str | None, pin: bool, force: bool
         "prompt": cfg["dirs"]["prompts"],
     }
     if defn_type not in type_to_dir:
-        raise click.ClickException(
-            f"Unknown definition type '{defn_type}' in registry manifest."
-        )
+        raise click.ClickException(f"Unknown definition type '{defn_type}' in registry manifest.")
 
     ext_map = {"agent": ".agent.md", "skill": ".skill.md", "prompt": ".prompt.md"}
     dest_dir = Path(type_to_dir[defn_type])
     dest = dest_dir / f"{name}{ext_map[defn_type]}"
 
     if dest.exists() and not force:
-        raise click.ClickException(
-            f"{dest} already exists. Use --force to overwrite."
-        )
+        raise click.ClickException(f"{dest} already exists. Use --force to overwrite.")
 
     content = fetch_definition_content(found_reg, found_defn)
 
@@ -253,9 +254,9 @@ def registry_install_cmd(name: str, registry: str | None, pin: bool, force: bool
                 f"\n  Pin SHA: {sha}\n"
                 f"  To pin, update uio.toml:\n"
                 f"    [[registries]]\n"
-                f"    name = \"{found_reg['name']}\"\n"
-                f"    url  = \"{found_reg['url']}\"\n"
-                f"    ref  = \"{sha[:12]}\""
+                f'    name = "{found_reg["name"]}"\n'
+                f'    url  = "{found_reg["url"]}"\n'
+                f'    ref  = "{sha[:12]}"'
             )
         else:
             click.echo(

--- a/uio/cli/skill.py
+++ b/uio/cli/skill.py
@@ -1,4 +1,5 @@
 """uio skill subcommands: run, list, inspect, new."""
+
 from __future__ import annotations
 
 import textwrap
@@ -9,7 +10,6 @@ import click
 from uio.cli._helpers import list_definitions, print_definition_table
 from uio.config import load_config
 from uio.core.runner import run_agent
-from uio.core.tools import DEFAULT_TIMEOUT
 from uio.schema.parser import parse_definition_file
 
 _SKILL_TEMPLATE = textwrap.dedent("""\
@@ -35,17 +35,21 @@ def skill_group() -> None:
 @skill_group.command("run")
 @click.argument("skill_name", metavar="SKILL")
 @click.argument("arg", required=False)
-@click.option("--provider", default=None,
-              help="LLM provider: gemini, openai, or ollama (default: auto-routes).")
+@click.option(
+    "--provider",
+    default=None,
+    help="LLM provider: gemini, openai, or ollama (default: auto-routes).",
+)
 @click.option("--model", default=None, help="Model name override.")
-@click.option("--complexity", type=click.Choice(["large", "small"]), default=None,
-              help="Task complexity tier.")
-@click.option("--base-url", default=None,
-              help="Base URL for an OpenAI-compatible endpoint.")
-@click.option("--timeout", default=None, type=int,
-              help="Per-command timeout in seconds.")
-@click.option("--no-mcp", is_flag=True, default=False,
-              help="Disable the GitHub MCP server.")
+@click.option(
+    "--complexity",
+    type=click.Choice(["large", "small"]),
+    default=None,
+    help="Task complexity tier.",
+)
+@click.option("--base-url", default=None, help="Base URL for an OpenAI-compatible endpoint.")
+@click.option("--timeout", default=None, type=int, help="Per-command timeout in seconds.")
+@click.option("--no-mcp", is_flag=True, default=False, help="Disable the GitHub MCP server.")
 def skill_run_cmd(
     skill_name: str,
     arg: str | None,

--- a/uio/config.py
+++ b/uio/config.py
@@ -1,4 +1,5 @@
 """Load and merge uio.toml project configuration."""
+
 from __future__ import annotations
 
 import os

--- a/uio/core/clients.py
+++ b/uio/core/clients.py
@@ -1,4 +1,5 @@
 """LLM client abstractions: GeminiClient, OpenAIClient, OllamaClient."""
+
 from __future__ import annotations
 
 import json
@@ -121,13 +122,15 @@ class GeminiClient(LLMClient):
             model_parts.append({"function_call": {"name": tc.name, "args": tc.args}})
         history.append({"role": "model", "parts": model_parts})
         if tool_results:
-            history.append({
-                "role": "user",
-                "parts": [
-                    {"function_response": {"name": tc.name, "response": {"output": out}}}
-                    for tc, out in tool_results
-                ],
-            })
+            history.append(
+                {
+                    "role": "user",
+                    "parts": [
+                        {"function_response": {"name": tc.name, "response": {"output": out}}}
+                        for tc, out in tool_results
+                    ],
+                }
+            )
 
 
 class OpenAIClient(LLMClient):
@@ -164,11 +167,13 @@ class OpenAIClient(LLMClient):
         calls: list[ToolCall] = []
         if msg.tool_calls:
             for tc in msg.tool_calls:
-                calls.append(ToolCall(
-                    name=tc.function.name,
-                    args=json.loads(tc.function.arguments),
-                    call_id=tc.id,
-                ))
+                calls.append(
+                    ToolCall(
+                        name=tc.function.name,
+                        args=json.loads(tc.function.arguments),
+                        call_id=tc.id,
+                    )
+                )
         usage: TokenUsage | None = None
         if resp.usage:
             usage = TokenUsage(
@@ -183,18 +188,21 @@ class OpenAIClient(LLMClient):
         response: LLMResponse,
         tool_results: list[tuple[ToolCall, str]],
     ) -> None:
-        history.append({
-            "role": "assistant",
-            "content": response.text,
-            "tool_calls": [
-                {
-                    "id": tc.call_id,
-                    "type": "function",
-                    "function": {"name": tc.name, "arguments": json.dumps(tc.args)},
-                }
-                for tc in response.tool_calls
-            ] or None,
-        })
+        history.append(
+            {
+                "role": "assistant",
+                "content": response.text,
+                "tool_calls": [
+                    {
+                        "id": tc.call_id,
+                        "type": "function",
+                        "function": {"name": tc.name, "arguments": json.dumps(tc.args)},
+                    }
+                    for tc in response.tool_calls
+                ]
+                or None,
+            }
+        )
         for tc, out in tool_results:
             history.append({"role": "tool", "tool_call_id": tc.call_id, "content": out})
 

--- a/uio/core/ledger.py
+++ b/uio/core/ledger.py
@@ -1,4 +1,5 @@
 """Cost estimation and JSONL append-only ledger."""
+
 from __future__ import annotations
 
 import datetime

--- a/uio/core/mcp.py
+++ b/uio/core/mcp.py
@@ -1,4 +1,5 @@
 """MCP stdio client (JSON-RPC 2.0)."""
+
 from __future__ import annotations
 
 import json
@@ -53,11 +54,14 @@ class MCPClient:
         self._proc.stdin.flush()
 
     def _initialize(self) -> None:
-        self._rpc("initialize", {
-            "protocolVersion": "2024-11-05",
-            "capabilities": {},
-            "clientInfo": {"name": "uio", "version": "0.1.0"},
-        })
+        self._rpc(
+            "initialize",
+            {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "uio", "version": "0.1.0"},
+            },
+        )
         self._notify("initialized", {})
 
     def list_tools(self) -> list[dict]:
@@ -65,23 +69,21 @@ class MCPClient:
         result = self._rpc("tools/list", {})
         tools = []
         for t in result.get("tools", []):
-            tools.append({
-                "name": f"mcp__{self.server_name}__{t['name']}",
-                "description": t.get("description", ""),
-                "parameters": t.get("inputSchema", {"type": "object", "properties": {}}),
-            })
+            tools.append(
+                {
+                    "name": f"mcp__{self.server_name}__{t['name']}",
+                    "description": t.get("description", ""),
+                    "parameters": t.get("inputSchema", {"type": "object", "properties": {}}),
+                }
+            )
         return tools
 
     def call_tool(self, name: str, args: dict) -> str:
         """Call a tool by prefixed name and return text output."""
         prefix = f"mcp__{self.server_name}__"
-        actual = name[len(prefix):] if name.startswith(prefix) else name
+        actual = name[len(prefix) :] if name.startswith(prefix) else name
         result = self._rpc("tools/call", {"name": actual, "arguments": args})
-        parts = [
-            item["text"]
-            for item in result.get("content", [])
-            if item.get("type") == "text"
-        ]
+        parts = [item["text"] for item in result.get("content", []) if item.get("type") == "text"]
         return "\n".join(parts) or "(no output)"
 
     def close(self) -> None:

--- a/uio/core/routing.py
+++ b/uio/core/routing.py
@@ -1,4 +1,5 @@
 """Provider routing and model-tier selection."""
+
 from __future__ import annotations
 
 import os

--- a/uio/core/runner.py
+++ b/uio/core/runner.py
@@ -1,4 +1,5 @@
 """Main tool-use loop for agents, skills, and prompts."""
+
 from __future__ import annotations
 
 import os
@@ -82,9 +83,7 @@ def run_agent(
     if arg:
         user_message = f"Begin your workflow now. Argument: {arg}"
 
-    resolved_complexity = infer_complexity(
-        agent_name, frontmatter, complexity, large_agent_names
-    )
+    resolved_complexity = infer_complexity(agent_name, frontmatter, complexity, large_agent_names)
     provider_chain = select_provider_chain(provider)
 
     try:

--- a/uio/core/tools.py
+++ b/uio/core/tools.py
@@ -1,4 +1,5 @@
 """Tool execution."""
+
 from __future__ import annotations
 
 import subprocess

--- a/uio/examples.py
+++ b/uio/examples.py
@@ -1,4 +1,5 @@
 """Bundled example definitions written to .uio/ via 'uio init --examples'."""
+
 from __future__ import annotations
 
 # Each entry: (filename, content).  Keys match uio.toml [dirs] keys.

--- a/uio/registry/manifest.py
+++ b/uio/registry/manifest.py
@@ -13,6 +13,7 @@ A registry is a Git repo with a registry.yaml manifest at its root:
 Configured via [[registries]] in uio.toml.  Manifests are cached locally
 under ~/.cache/uio/registries/<name>.yaml with a configurable TTL.
 """
+
 from __future__ import annotations
 
 import json
@@ -29,6 +30,7 @@ DEFAULT_TTL_HOURS = 24
 
 
 # ── URL helpers ───────────────────────────────────────────────────────────────
+
 
 def _raw_url(repo_url: str, ref: str, path: str) -> str:
     """Convert a hosting URL to a raw-content URL for the given ref and path."""
@@ -55,6 +57,7 @@ def _fetch_url(url: str, timeout: int = 10) -> str:
 
 # ── Cache helpers ─────────────────────────────────────────────────────────────
 
+
 def _cache_path(name: str, cache_dir: Path) -> Path:
     cache_dir.mkdir(parents=True, exist_ok=True)
     return cache_dir / f"{name}.yaml"
@@ -68,6 +71,7 @@ def _is_fresh(path: Path, ttl_hours: int) -> bool:
 
 
 # ── Public API ────────────────────────────────────────────────────────────────
+
 
 def fetch_manifest(
     registry: dict[str, Any],
@@ -191,7 +195,5 @@ def validate_manifest(manifest: dict[str, Any]) -> list[str]:
             if not defn.get(field):
                 errors.append(f"{prefix}: missing required field '{field}'")
         if defn.get("type") and defn["type"] not in valid_types:
-            errors.append(
-                f"{prefix}: type '{defn['type']}' must be one of {sorted(valid_types)}"
-            )
+            errors.append(f"{prefix}: type '{defn['type']}' must be one of {sorted(valid_types)}")
     return errors

--- a/uio/schema/parser.py
+++ b/uio/schema/parser.py
@@ -1,4 +1,5 @@
 """YAML frontmatter parser for .agent.md, .skill.md, and .prompt.md files."""
+
 from __future__ import annotations
 
 import re


### PR DESCRIPTION
## Summary

- `uio registry install` previously used silent first-match-wins when the same definition name existed in multiple registries — users had no idea a duplicate was being skipped
- Now emits a stderr warning listing the other registry names and points to `--registry` as the explicit override
- The `--registry` flag already existed and correctly scopes the search; no API changes needed

## Changes

- `uio/cli/registry.py`: search loop no longer breaks after the first match — continues scanning remaining registries to collect duplicates, then warns before installing
- `tests/test_registry.py`: two new tests via Click's `CliRunner` — one asserts the warning is emitted when a duplicate exists, one asserts silence when it doesn't

## Test plan

- [x] `pytest` — 152 tests, all pass
- [x] Duplicate warning test: mocks two registries both containing `summarise`, asserts `"also found"` and the second registry name appear in output
- [x] No-duplicate test: single registry, asserts `"also found"` is absent

Closes #8