### PR TITLE
feat: container image packaging (#21)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.github
+__pycache__
+*.pyc
+*.pyo
+.pytest_cache
+uio.egg-info
+dist/
+build/
+.env
+.venv
+venv/
+*.egg-info/
+docs/
+tests/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,48 @@
+name: Docker
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-push:
+    name: Build and push image
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+FROM python:3.11-slim
+
+# Node.js 20 LTS — required for GitHub MCP server and other @modelcontextprotocol packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl gnupg git \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# gh CLI — fallback for agents that shell out to GitHub via run_command
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) \
+        signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] \
+        https://cli.github.com/packages stable main" \
+        > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends gh \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+# Install uio from source
+COPY . /build
+RUN pip install --no-cache-dir /build && rm -rf /build
+
+# Pre-warm the npx cache for bundled MCP servers so the first agent run is fast
+RUN for pkg in \
+        @github/github-mcp-server \
+        @modelcontextprotocol/server-filesystem \
+        @modelcontextprotocol/server-fetch \
+        @modelcontextprotocol/server-memory; \
+    do npx -y "$pkg" --version 2>/dev/null || true; done
+
+# /workspace is the default mount point for uio.toml and .uio/ definitions.
+# uio.toml must exist in the current working directory — mount your project here.
+VOLUME ["/workspace"]
+
+# API keys — always pass at runtime, never bake into the image
+ENV GEMINI_API_KEY="" \
+    OPENAI_API_KEY="" \
+    GITHUB_PERSONAL_ACCESS_TOKEN=""
+
+ENTRYPOINT ["uio"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -77,6 +77,20 @@ Auto-routes across available providers in order: **Gemini → OpenAI → Ollama*
 | `openai` | `gpt-4o` | `gpt-4o-mini` |
 | `ollama` | `qwen2.5-coder:32b` | `qwen2.5-coder:7b` |
 
+## Container image
+
+```bash
+docker run --rm \
+  -e GEMINI_API_KEY=your-key \
+  -e GITHUB_PERSONAL_ACCESS_TOKEN=ghp_... \
+  -v $(pwd):/workspace \
+  ghcr.io/jomkz/uio agent run repo-health
+```
+
+The image includes Node.js and pre-warmed MCP servers (`@github/github-mcp-server`,
+`server-filesystem`, `server-fetch`, `server-memory`). A `docker-compose.yml` for local Ollama
+use is included in the repo. See [Container image](docs/14-container.md) for full details.
+
 ## License
 
 [GNU Affero General Public License v3.0](LICENSE)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+# Ollama sidecar: run uio with a local model — no cloud API keys required.
+#
+# Usage:
+#   docker compose run --rm uio agent run repo-health
+#   docker compose run --rm uio skill run summarise "Your text here"
+#
+# On first run, pull a model:
+#   docker compose run --rm ollama ollama pull qwen2.5-coder:7b
+
+services:
+  uio:
+    build: .
+    environment:
+      - OLLAMA_BASE_URL=http://ollama:11434/v1
+      - GEMINI_API_KEY=${GEMINI_API_KEY:-}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - GITHUB_PERSONAL_ACCESS_TOKEN=${GITHUB_PERSONAL_ACCESS_TOKEN:-}
+    volumes:
+      - .:/workspace
+    depends_on:
+      ollama:
+        condition: service_healthy
+
+  ollama:
+    image: ollama/ollama:latest
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:11434/api/version"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+volumes:
+  ollama_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,35 @@
 # Ollama sidecar: run uio with a local model — no cloud API keys required.
 #
-# Usage:
+# Quick start (CPU):
+#   docker compose run --rm ollama ollama pull qwen2.5-coder:7b   # first run only
 #   docker compose run --rm uio agent run repo-health
 #   docker compose run --rm uio skill run summarise "Your text here"
 #
-# On first run, pull a model:
-#   docker compose run --rm ollama ollama pull qwen2.5-coder:7b
+# Use the large model tier (32b):
+#   docker compose run --rm ollama ollama pull qwen2.5-coder:32b  # first run only
+#   docker compose run --rm uio agent run repo-health --complexity large
+#
+# Override the model entirely:
+#   LLM_MODEL=llama3.2 docker compose run --rm uio agent run repo-health
+#
+# GPU (NVIDIA) — requires nvidia-container-toolkit on the host:
+#   docker compose --profile gpu run --rm ollama-gpu ollama pull qwen2.5-coder:7b
+#   docker compose --profile gpu run --rm uio-gpu agent run repo-health
 
 services:
+  # ── CPU variant (default) ─────────────────────────────────────────────────
+
   uio:
     build: .
     environment:
       - OLLAMA_BASE_URL=http://ollama:11434/v1
+      # Cloud keys are optional — if absent, uio auto-routes to Ollama only.
+      # If present, uio prefers Gemini → OpenAI → Ollama in that order.
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - GITHUB_PERSONAL_ACCESS_TOKEN=${GITHUB_PERSONAL_ACCESS_TOKEN:-}
+      # Pin a specific model, bypassing tier selection (optional):
+      - LLM_MODEL=${LLM_MODEL:-}
     volumes:
       - .:/workspace
     depends_on:
@@ -27,6 +42,45 @@ services:
       - "11434:11434"
     volumes:
       - ollama_data:/root/.ollama
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:11434/api/version"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  # ── GPU variant (profile: gpu) ────────────────────────────────────────────
+  # Requires nvidia-container-toolkit: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html
+
+  uio-gpu:
+    build: .
+    profiles: [gpu]
+    environment:
+      - OLLAMA_BASE_URL=http://ollama-gpu:11434/v1
+      - GEMINI_API_KEY=${GEMINI_API_KEY:-}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - GITHUB_PERSONAL_ACCESS_TOKEN=${GITHUB_PERSONAL_ACCESS_TOKEN:-}
+      - LLM_MODEL=${LLM_MODEL:-}
+    volumes:
+      - .:/workspace
+    depends_on:
+      ollama-gpu:
+        condition: service_healthy
+
+  ollama-gpu:
+    image: ollama/ollama:latest
+    profiles: [gpu]
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:11434/api/version"]
       interval: 10s

--- a/docs/14-container.md
+++ b/docs/14-container.md
@@ -92,20 +92,131 @@ docker run --rm \
 
 ## Ollama sidecar (no cloud API keys)
 
-Use the bundled `docker-compose.yml` to run `uio` with a local Ollama model — no cloud API keys
-required.
+The bundled `docker-compose.yml` runs `uio` alongside a local Ollama instance. No cloud API
+keys are required — the entire stack runs with no egress, making it suitable for air-gapped
+environments and regulated on-premises deployments.
 
-```bash
-# Pull a model on first run
-docker compose run --rm ollama ollama pull qwen2.5-coder:7b
+### How provider routing works with the sidecar
 
-# Run an agent against the local model
-docker compose run --rm uio agent run repo-health
+`uio` tries providers in order: **Gemini → OpenAI → Ollama**. A provider is included only if
+its API key is present in the environment. Ollama has no key requirement and is always the
+final fallback.
+
+The compose file wires `OLLAMA_BASE_URL=http://ollama:11434/v1` so the uio container reaches
+the Ollama sidecar over the compose network. With no cloud keys set:
+
+```
+ROUTING_CHAIN: [ollama]  ← only Ollama is available, selected immediately
 ```
 
-The compose file wires `OLLAMA_BASE_URL=http://ollama:11434/v1` so `uio` auto-routes to the
-local Ollama instance. Cloud keys (`GEMINI_API_KEY`, etc.) are passed through from your host
-environment if set, but are not required.
+With cloud keys set (passed through from the host), cloud providers take priority:
+
+```
+ROUTING_CHAIN: [gemini, openai, ollama]  ← Gemini tried first; Ollama is the fallback
+```
+
+### First-time setup
+
+```bash
+# Pull the small model (≈4 GB, good for most agents)
+docker compose run --rm ollama ollama pull qwen2.5-coder:7b
+
+# Verify — run a skill
+docker compose run --rm uio skill run summarise "Hello from Ollama"
+```
+
+The `ollama` service persists downloaded models in a named volume (`ollama_data`) so you only
+pull once. The uio service waits for the Ollama healthcheck to pass before starting, so there
+is no need to manually sequence the startup.
+
+### Model tiers
+
+`uio` selects between a small and a large model based on the agent's complexity setting. With
+Ollama, the defaults are:
+
+| Tier | Model | VRAM (approx.) | Use when |
+|---|---|---|---|
+| `small` (default) | `qwen2.5-coder:7b` | ~5 GB | Most agents and skills |
+| `large` | `qwen2.5-coder:32b` | ~20 GB | Complex multi-step agents, `complexity: large` frontmatter |
+
+Pull both if you want to use the large tier:
+
+```bash
+docker compose run --rm ollama ollama pull qwen2.5-coder:7b
+docker compose run --rm ollama ollama pull qwen2.5-coder:32b
+```
+
+Force the large tier for a single run:
+
+```bash
+docker compose run --rm uio agent run repo-health --complexity large
+```
+
+Or set it permanently in the agent's frontmatter:
+
+```yaml
+---
+name: my-agent
+complexity: large
+---
+```
+
+### Pinning a model
+
+To bypass tier selection entirely and use any Ollama model (including ones not in the default
+table), set `LLM_MODEL` before running:
+
+```bash
+# Use llama3.2 instead of qwen2.5-coder:7b
+docker compose run --rm ollama ollama pull llama3.2
+LLM_MODEL=llama3.2 docker compose run --rm uio skill run summarise "Hello"
+```
+
+`LLM_MODEL` is passed through from the host by the compose file. It overrides tier selection
+for all providers — see [Providers](07-providers.md#model-override) for the full resolution
+order.
+
+### GPU acceleration (NVIDIA)
+
+The compose file ships a `gpu` profile that replaces the CPU Ollama container with one that
+has access to all NVIDIA GPUs on the host.
+
+**Prerequisite:** install [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html) on the host.
+
+```bash
+# Pull into the GPU container's volume (shared with the CPU container)
+docker compose --profile gpu run --rm ollama-gpu ollama pull qwen2.5-coder:32b
+
+# Run with GPU acceleration
+docker compose --profile gpu run --rm uio-gpu agent run repo-health --complexity large
+```
+
+The GPU variant is worthwhile for the 32b model; the 7b model runs acceptably on CPU.
+
+### Air-gapped deployment
+
+With no cloud keys in the environment and the Ollama volume pre-populated, the entire stack
+runs without any internet access:
+
+1. On a machine with internet: pull models and export the volume.
+2. On the air-gapped host: import the volume and run `docker compose up`.
+
+No requests leave the host — Ollama serves models locally, and MCP servers that make network
+calls (e.g. `@github/github-mcp-server`) are only started if a GitHub token is present.
+
+### Recommended models
+
+| Model | Pull command | Notes |
+|---|---|---|
+| `qwen2.5-coder:7b` | `ollama pull qwen2.5-coder:7b` | Default small tier — best general-purpose agentic model at this size |
+| `qwen2.5-coder:32b` | `ollama pull qwen2.5-coder:32b` | Default large tier — stronger reasoning, requires more VRAM |
+| `llama3.2` | `ollama pull llama3.2` | Fast, low VRAM, good for simple skills |
+| `mistral` | `ollama pull mistral` | Good instruction following, widely tested |
+| `deepseek-r1:7b` | `ollama pull deepseek-r1:7b` | Strong reasoning; slow output |
+
+For agents that use many tool calls, models with good instruction following (Qwen, Mistral)
+outperform raw-benchmark leaders. Avoid very small models (≤3b) for agentic use — they
+reliably fail to format tool calls correctly.
 
 ## CI/CD usage
 

--- a/docs/14-container.md
+++ b/docs/14-container.md
@@ -1,0 +1,134 @@
+# Container image
+
+`uio` ships an official container image built on `python:3.11-slim` with Node.js 20 included.
+Node.js is required for the GitHub MCP server and the other bundled `@modelcontextprotocol`
+packages. The `gh` CLI is also included as a fallback for agents that shell out to GitHub via
+`run_command`.
+
+## Bundled MCP servers
+
+The following MCP servers are pre-warmed in the image (no download on first use):
+
+| Server | Package | Tools exposed to the LLM |
+|---|---|---|
+| GitHub | `@github/github-mcp-server` | `mcp__github__*` — issues, PRs, repos, code search |
+| Filesystem | `@modelcontextprotocol/server-filesystem` | `mcp__filesystem__*` — typed file read/write/list |
+| Fetch | `@modelcontextprotocol/server-fetch` | `mcp__fetch__*` — typed HTTP GET/POST |
+| Memory | `@modelcontextprotocol/server-memory` | `mcp__memory__*` — persistent KV store per session |
+
+MCP server configuration is managed via `uio.toml`. See [MCP integration](08-mcp.md) for details.
+
+## Quick start
+
+```bash
+# One-shot agent run — mount your project at /workspace
+docker run --rm \
+  -e GEMINI_API_KEY=your-key \
+  -e GITHUB_PERSONAL_ACCESS_TOKEN=ghp_... \
+  -v $(pwd):/workspace \
+  ghcr.io/jomkz/uio agent run repo-health
+
+# Interactive skill run
+docker run --rm \
+  -e GEMINI_API_KEY=your-key \
+  -v $(pwd):/workspace \
+  ghcr.io/jomkz/uio skill run summarise "Your text here"
+
+# Chat REPL (interactive — allocate a TTY)
+docker run --rm -it \
+  -e GEMINI_API_KEY=your-key \
+  -v $(pwd):/workspace \
+  ghcr.io/jomkz/uio chat
+```
+
+## Configuration
+
+`uio.toml` must be present in `/workspace` (the container's working directory). Mount your project
+directory at `/workspace` so that `uio.toml` and `.uio/` definitions are picked up automatically.
+
+A minimal `uio.toml` for the container:
+
+```toml
+[runtime]
+default_provider = "gemini"
+
+[mcp.github]
+command = "npx -y @github/github-mcp-server stdio"
+
+[mcp.filesystem]
+command = "npx -y @modelcontextprotocol/server-filesystem /workspace"
+
+[mcp.fetch]
+command = "npx -y @modelcontextprotocol/server-fetch"
+
+[mcp.memory]
+command = "npx -y @modelcontextprotocol/server-memory"
+```
+
+## Stateful paths
+
+| Path | Purpose | Recommendation |
+|---|---|---|
+| `/workspace/uio.toml` | Project config | Volume-mount your project directory |
+| `/workspace/.uio/` | Agent/skill/prompt definitions | Volume-mount your project directory |
+| `/workspace/uio_cost.jsonl` | Cost ledger | Volume-mount if persistence is needed |
+| `~/.cache/uio/registries/` | Registry manifest cache | Ephemeral — re-fetched on demand |
+
+For one-shot CI runs, none of these need to persist. For long-running or scheduled containers,
+mount a named volume at `/workspace`.
+
+## API keys
+
+Pass API keys as environment variables at runtime. Never bake them into the image.
+
+```bash
+docker run --rm \
+  -e GEMINI_API_KEY=$GEMINI_API_KEY \
+  -e OPENAI_API_KEY=$OPENAI_API_KEY \
+  -e GITHUB_PERSONAL_ACCESS_TOKEN=$GITHUB_PERSONAL_ACCESS_TOKEN \
+  -v $(pwd):/workspace \
+  ghcr.io/jomkz/uio agent run my-agent
+```
+
+## Ollama sidecar (no cloud API keys)
+
+Use the bundled `docker-compose.yml` to run `uio` with a local Ollama model — no cloud API keys
+required.
+
+```bash
+# Pull a model on first run
+docker compose run --rm ollama ollama pull qwen2.5-coder:7b
+
+# Run an agent against the local model
+docker compose run --rm uio agent run repo-health
+```
+
+The compose file wires `OLLAMA_BASE_URL=http://ollama:11434/v1` so `uio` auto-routes to the
+local Ollama instance. Cloud keys (`GEMINI_API_KEY`, etc.) are passed through from your host
+environment if set, but are not required.
+
+## CI/CD usage
+
+Run `uio` as a step in any container-native pipeline:
+
+```yaml
+# GitHub Actions example
+- name: Run repo health check
+  run: |
+    docker run --rm \
+      -e GEMINI_API_KEY=${{ secrets.GEMINI_API_KEY }} \
+      -e GITHUB_PERSONAL_ACCESS_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+      -v ${{ github.workspace }}:/workspace \
+      ghcr.io/jomkz/uio agent run repo-health
+```
+
+## Building from source
+
+```bash
+docker build -t uio .
+
+docker run --rm \
+  -e GEMINI_API_KEY=your-key \
+  -v $(pwd):/workspace \
+  uio skill run summarise "Hello from a local build"
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@
 | [11 — Registry](11-registry.md) | Remote registry discovery — configure, search, install, pin, and host a registry |
 | [12 — Writing definitions](12-writing-definitions.md) | How to write effective agents, skills, and prompts; tool-use patterns; common failure modes |
 | [13 — Internals](13-internals.md) | Package architecture, every module's role, how to add a provider or tool, and contributing |
+| [14 — Container image](14-container.md) | Dockerfile, bundled MCP servers, Ollama sidecar, CI/CD usage, and building from source |
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `Dockerfile` (Option A: Python 3.11-slim + Node.js 20 + `gh` CLI + four pre-warmed MCP servers: `@github/github-mcp-server`, `server-filesystem`, `server-fetch`, `server-memory`)
- Adds `.dockerignore` to keep the build context lean
- Adds `docker-compose.yml` for the Ollama sidecar use case (no cloud API keys required)
- Adds `.github/workflows/docker.yml` — builds and pushes to GHCR on `v*` tags, with layer caching
- Adds `docs/14-container.md` — full usage guide covering quick start, config, stateful paths, API keys, Ollama compose, CI/CD usage, and building from source
- Updates `README.md` with a container quick-start section
- Updates `docs/README.md` index with the new page

Closes #21.

## Test plan

- [ ] `docker build -t uio .` completes cleanly
- [ ] `docker run --rm -e GEMINI_API_KEY=... -v $(pwd):/workspace uio skill run summarise "hello"` returns a summary
- [ ] `docker compose run --rm uio --help` works against the Ollama sidecar
- [ ] GHCR push fires on a `v*` tag push (verifiable in Actions after merge + tag)
- [ ] 152 existing tests still pass (`pytest` — no Python changes)
- [ ] `ruff format --check . && ruff check .` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)