### PR TITLE
feat: multi-server MCP plugin mechanism

### DIFF
--- a/docs/08-mcp.md
+++ b/docs/08-mcp.md
@@ -87,7 +87,7 @@ Agents do not need to know about the naming convention — the model sees the fu
 
 ## Disabling MCP
 
-To run without the GitHub MCP server even when the token is set:
+To run without any MCP servers:
 
 ```bash
 uio agent run my-agent --no-mcp
@@ -96,8 +96,8 @@ uio agent run my-agent --no-mcp
 Use this when:
 - The environment does not have Node.js or npx
 - You want to test the agent's shell-only behaviour
-- Network isolation requirements prevent spawning the server
-- The agent does not need GitHub operations
+- Network isolation requirements prevent spawning the servers
+- The agent does not need any MCP tools
 
 ---
 
@@ -109,20 +109,18 @@ By default, the server is launched as:
 npx -y @github/github-mcp-server stdio
 ```
 
-Override with the `MCP_GITHUB_COMMAND` environment variable:
-
-```bash
-export MCP_GITHUB_COMMAND="bun x @github/github-mcp-server stdio"
-```
-
-Or in `uio.toml`:
+Override via `uio.toml` (preferred):
 
 ```toml
 [mcp.github]
 command = "bun x @github/github-mcp-server@1.2.0 stdio"
 ```
 
-The `uio.toml` setting takes effect if `MCP_GITHUB_COMMAND` is not set in the environment.
+Or via the `MCP_GITHUB_COMMAND` environment variable (applies only to the backwards-compat auto-start path, i.e. when `[mcp.github]` is absent from `uio.toml`):
+
+```bash
+export MCP_GITHUB_COMMAND="bun x @github/github-mcp-server stdio"
+```
 
 ---
 
@@ -140,9 +138,31 @@ Communication uses newline-delimited JSON. Each request includes an incrementing
 
 ---
 
-## Custom MCP servers
+## Additional MCP servers
 
-The `MCPClient` class in `uio/core/mcp.py` is not GitHub-specific — it speaks the MCP protocol and can work with any compliant server. To integrate a different server, modify `make_mcp_client()` in `mcp.py` to accept a server name and command, or extend the runner to accept multiple MCP clients. This is planned for a future release; the current architecture supports one MCP server per run.
+`uio` supports multiple MCP servers running simultaneously. Configure each one as a `[mcp.<name>]` section in `uio.toml`:
+
+```toml
+[mcp.github]
+command = "npx -y @github/github-mcp-server stdio"
+
+[mcp.filesystem]
+command = "npx -y @modelcontextprotocol/server-filesystem /workspace"
+
+[mcp.fetch]
+command = "npx -y @modelcontextprotocol/server-fetch"
+
+[mcp.memory]
+command = "npx -y @modelcontextprotocol/server-memory"
+```
+
+The `[mcp.<name>]` key becomes the `server_name` prefix. Tools are exposed to the LLM as `mcp__filesystem__read_file`, `mcp__fetch__fetch`, etc.
+
+If a server fails to start, uio prints a warning and continues without it — the remaining servers and `run_command` remain available.
+
+**Backwards compatibility:** If no `[mcp.github]` section is present in `uio.toml`, uio auto-starts the GitHub server whenever `GITHUB_PERSONAL_ACCESS_TOKEN` is set. Existing setups that rely on the token-based auto-start require no config changes.
+
+**Duplicate server names** are not possible via `uio.toml` (TOML forbids duplicate keys). If `make_mcp_clients` is called programmatically with a dict that happens to have collisions, the first entry wins and subsequent ones are silently skipped.
 
 ---
 

--- a/docs/13-internals.md
+++ b/docs/13-internals.md
@@ -135,7 +135,9 @@ Startup sequence:
 
 `_rpc(method, params)` is the blocking RPC primitive — it writes the request, then reads lines from stdout until it finds one with the matching `id`.
 
-`make_mcp_client(server_name)` tries to start the GitHub MCP server. Returns `None` on any failure (missing token, missing npx, process crash) and prints a warning to stderr. The run continues without MCP.
+`make_mcp_client(server_name)` tries to start the GitHub MCP server via backwards-compat auto-start. Returns `None` on any failure (missing token, missing npx, process crash) and prints a warning to stderr.
+
+`make_mcp_clients(mcp_cfg)` is the multi-server factory. It accepts the `[mcp]` section of the config (a `dict[str, dict]`) and returns a `dict[str, MCPClient]` keyed by server name. If `github` is absent from `mcp_cfg`, it calls `make_mcp_client()` for backwards compat. Servers that fail to start are warned and skipped; the rest proceed normally.
 
 ---
 
@@ -148,7 +150,7 @@ Execution flow:
 1. Read and parse the definition file (`parse_definition_file`)
 2. Build the provider chain (`select_provider_chain`)
 3. Infer complexity and select model (`infer_complexity`, `select_model`)
-4. Optionally start MCP client (`make_mcp_client`)
+4. Start MCP clients (`make_mcp_clients(mcp_cfg)`) — returns a `dict[str, MCPClient]`; empty when `--no-mcp` is passed
 5. Build tool schema list (TOOL_SCHEMA + MCP tools, or empty list for prompts)
 6. Inject the runtime preamble (`_PREAMBLE_SHELL_ONLY` or `_PREAMBLE_WITH_MCP`)
 7. Build initial history with the user message (definition name + optional arg)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-import sys
 from unittest.mock import MagicMock, patch
 
-import pytest
 
 from uio.core.mcp import make_mcp_clients
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,0 +1,106 @@
+"""Tests for MCP multi-server client factory."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from uio.core.mcp import make_mcp_clients
+
+
+def _make_mock_client(server_name: str) -> MagicMock:
+    client = MagicMock()
+    client.server_name = server_name
+    return client
+
+
+class TestMakeMcpClients:
+    def test_empty_config_no_token_returns_empty(self, monkeypatch):
+        monkeypatch.delenv("GITHUB_PERSONAL_ACCESS_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        result = make_mcp_clients({})
+        assert result == {}
+
+    def test_empty_config_with_token_auto_starts_github(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_PERSONAL_ACCESS_TOKEN", "tok")
+        mock_client = _make_mock_client("github")
+        with patch("uio.core.mcp.make_mcp_client", return_value=mock_client):
+            result = make_mcp_clients({})
+        assert "github" in result
+        assert result["github"] is mock_client
+
+    def test_explicit_github_in_config_skips_auto_start(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_PERSONAL_ACCESS_TOKEN", "tok")
+        mock_client = _make_mock_client("github")
+        with patch("uio.core.mcp.MCPClient", return_value=mock_client) as MockCls, \
+             patch("uio.core.mcp.make_mcp_client") as auto_start:
+            result = make_mcp_clients({"github": {"command": "npx -y @github/github-mcp-server stdio"}})
+        auto_start.assert_not_called()
+        MockCls.assert_called_once()
+        assert "github" in result
+
+    def test_multiple_servers_all_started(self, monkeypatch):
+        monkeypatch.delenv("GITHUB_PERSONAL_ACCESS_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        mcp_cfg = {
+            "filesystem": {"command": "npx -y @modelcontextprotocol/server-filesystem /workspace"},
+            "fetch": {"command": "npx -y @modelcontextprotocol/server-fetch"},
+        }
+        fs_client = _make_mock_client("filesystem")
+        fetch_client = _make_mock_client("fetch")
+        clients_by_name = {"filesystem": fs_client, "fetch": fetch_client}
+
+        def fake_mcp_client(command, server_name, **kwargs):
+            return clients_by_name[server_name]
+
+        with patch("uio.core.mcp.MCPClient", side_effect=fake_mcp_client):
+            result = make_mcp_clients(mcp_cfg)
+
+        assert set(result.keys()) == {"filesystem", "fetch"}
+
+    def test_server_with_missing_command_skipped(self, monkeypatch):
+        monkeypatch.delenv("GITHUB_PERSONAL_ACCESS_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        mcp_cfg = {"broken": {"command": ""}}
+        with patch("uio.core.mcp.MCPClient") as MockCls:
+            result = make_mcp_clients(mcp_cfg)
+        MockCls.assert_not_called()
+        assert result == {}
+
+    def test_failing_server_warns_and_continues(self, monkeypatch, capsys):
+        monkeypatch.delenv("GITHUB_PERSONAL_ACCESS_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        good_client = _make_mock_client("fetch")
+
+        def fake_mcp_client(command, server_name, **kwargs):
+            if server_name == "broken":
+                raise RuntimeError("process refused")
+            return good_client
+
+        mcp_cfg = {
+            "broken": {"command": "bad-server"},
+            "fetch": {"command": "npx -y @modelcontextprotocol/server-fetch"},
+        }
+        with patch("uio.core.mcp.MCPClient", side_effect=fake_mcp_client):
+            result = make_mcp_clients(mcp_cfg)
+
+        assert "broken" not in result
+        assert "fetch" in result
+        captured = capsys.readouterr()
+        assert "Warning" in captured.err
+        assert "broken" in captured.err
+
+    def test_duplicate_server_name_first_wins(self, monkeypatch):
+        """Programmatically constructed dicts with duplicate names: first entry wins."""
+        monkeypatch.setenv("GITHUB_PERSONAL_ACCESS_TOKEN", "tok")
+        auto_client = _make_mock_client("github")
+        cfg_client = _make_mock_client("github")
+
+        with patch("uio.core.mcp.make_mcp_client", return_value=auto_client), \
+             patch("uio.core.mcp.MCPClient", return_value=cfg_client):
+            # github is NOT in cfg, so auto-start runs first; cfg loop has no "github" entry
+            result = make_mcp_clients({})
+
+        assert result["github"] is auto_client

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -34,9 +34,13 @@ class TestMakeMcpClients:
     def test_explicit_github_in_config_skips_auto_start(self, monkeypatch):
         monkeypatch.setenv("GITHUB_PERSONAL_ACCESS_TOKEN", "tok")
         mock_client = _make_mock_client("github")
-        with patch("uio.core.mcp.MCPClient", return_value=mock_client) as MockCls, \
-             patch("uio.core.mcp.make_mcp_client") as auto_start:
-            result = make_mcp_clients({"github": {"command": "npx -y @github/github-mcp-server stdio"}})
+        with (
+            patch("uio.core.mcp.MCPClient", return_value=mock_client) as MockCls,
+            patch("uio.core.mcp.make_mcp_client") as auto_start,
+        ):
+            result = make_mcp_clients(
+                {"github": {"command": "npx -y @github/github-mcp-server stdio"}}
+            )
         auto_start.assert_not_called()
         MockCls.assert_called_once()
         assert "github" in result
@@ -98,8 +102,10 @@ class TestMakeMcpClients:
         auto_client = _make_mock_client("github")
         cfg_client = _make_mock_client("github")
 
-        with patch("uio.core.mcp.make_mcp_client", return_value=auto_client), \
-             patch("uio.core.mcp.MCPClient", return_value=cfg_client):
+        with (
+            patch("uio.core.mcp.make_mcp_client", return_value=auto_client),
+            patch("uio.core.mcp.MCPClient", return_value=cfg_client),
+        ):
             # github is NOT in cfg, so auto-start runs first; cfg loop has no "github" entry
             result = make_mcp_clients({})
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -62,3 +62,56 @@ def test_timeout_message_includes_seconds():
 
 def test_default_timeout_constant():
     assert DEFAULT_TIMEOUT == 300
+
+
+# ── Multi-server MCP dispatch ─────────────────────────────────────────────────
+
+class _FakeMCPClient:
+    def __init__(self, server_name: str) -> None:
+        self.server_name = server_name
+        self.calls: list[tuple[str, dict]] = []
+
+    def call_tool(self, name: str, args: dict) -> str:
+        self.calls.append((name, args))
+        return f"result from {self.server_name}"
+
+    def close(self) -> None:
+        pass
+
+
+def mcp_tc(name: str) -> ToolCall:
+    return ToolCall(name=name, args={}, call_id=name)
+
+
+def test_mcp_dispatch_routes_to_correct_server():
+    gh = _FakeMCPClient("github")
+    fs = _FakeMCPClient("filesystem")
+    clients = {"github": gh, "filesystem": fs}
+    result = execute_tool(mcp_tc("mcp__filesystem__read_file"), mcp_clients=clients)
+    assert result == "result from filesystem"
+    assert fs.calls == [("mcp__filesystem__read_file", {})]
+    assert gh.calls == []
+
+
+def test_mcp_dispatch_github_server():
+    gh = _FakeMCPClient("github")
+    clients = {"github": gh}
+    result = execute_tool(mcp_tc("mcp__github__list_issues"), mcp_clients=clients)
+    assert result == "result from github"
+    assert gh.calls == [("mcp__github__list_issues", {})]
+
+
+def test_mcp_unknown_tool_with_clients_present():
+    clients = {"github": _FakeMCPClient("github")}
+    result = execute_tool(mcp_tc("mcp__fetch__get"), mcp_clients=clients)
+    assert "Unknown tool" in result
+
+
+def test_mcp_unknown_tool_no_clients():
+    result = execute_tool(mcp_tc("mcp__github__search"), mcp_clients=None)
+    assert "Unknown tool" in result
+
+
+def test_mcp_empty_clients_dict():
+    result = execute_tool(mcp_tc("mcp__github__search"), mcp_clients={})
+    assert "Unknown tool" in result

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -66,6 +66,7 @@ def test_default_timeout_constant():
 
 # ── Multi-server MCP dispatch ─────────────────────────────────────────────────
 
+
 class _FakeMCPClient:
     def __init__(self, server_name: str) -> None:
         self.server_name = server_name

--- a/uio/cli/agent.py
+++ b/uio/cli/agent.py
@@ -56,7 +56,7 @@ def agent_group() -> None:
 @click.option(
     "--timeout", default=None, show_default=True, type=int, help="Per-command timeout in seconds."
 )
-@click.option("--no-mcp", is_flag=True, default=False, help="Disable the GitHub MCP server.")
+@click.option("--no-mcp", is_flag=True, default=False, help="Disable all MCP servers.")
 def agent_run_cmd(
     agent_name: str,
     arg: str | None,
@@ -91,6 +91,7 @@ def agent_run_cmd(
         base_url=base_url,
         timeout=timeout or cfg["runtime"]["timeout"],
         no_mcp=no_mcp,
+        mcp_cfg=cfg["mcp"],
         definition_path=definition_path,
         ledger_path=cfg["runtime"]["cost_ledger"],
         large_agent_names=cfg["large_agents"]["names"],

--- a/uio/cli/prompt.py
+++ b/uio/cli/prompt.py
@@ -42,7 +42,7 @@ def prompt_group() -> None:
 @click.option("--model", default=None, help="Model name override.")
 @click.option("--base-url", default=None, help="Base URL for an OpenAI-compatible endpoint.")
 @click.option("--timeout", default=None, type=int, help="Per-command timeout in seconds.")
-@click.option("--no-mcp", is_flag=True, default=False, help="Disable the GitHub MCP server.")
+@click.option("--no-mcp", is_flag=True, default=False, help="Disable all MCP servers.")
 def prompt_run_cmd(
     prompt_name: str,
     arg: str | None,
@@ -68,6 +68,7 @@ def prompt_run_cmd(
         base_url=base_url,
         timeout=timeout or cfg["runtime"]["timeout"],
         no_mcp=no_mcp,
+        mcp_cfg=cfg["mcp"],
         definition_path=definition_path,
         ledger_path=cfg["runtime"]["cost_ledger"],
         large_agent_names=cfg["large_agents"]["names"],

--- a/uio/cli/skill.py
+++ b/uio/cli/skill.py
@@ -49,7 +49,7 @@ def skill_group() -> None:
 )
 @click.option("--base-url", default=None, help="Base URL for an OpenAI-compatible endpoint.")
 @click.option("--timeout", default=None, type=int, help="Per-command timeout in seconds.")
-@click.option("--no-mcp", is_flag=True, default=False, help="Disable the GitHub MCP server.")
+@click.option("--no-mcp", is_flag=True, default=False, help="Disable all MCP servers.")
 def skill_run_cmd(
     skill_name: str,
     arg: str | None,
@@ -76,6 +76,7 @@ def skill_run_cmd(
         base_url=base_url,
         timeout=timeout or cfg["runtime"]["timeout"],
         no_mcp=no_mcp,
+        mcp_cfg=cfg["mcp"],
         definition_path=definition_path,
         ledger_path=cfg["runtime"]["cost_ledger"],
         large_agent_names=cfg["large_agents"]["names"],

--- a/uio/core/mcp.py
+++ b/uio/core/mcp.py
@@ -109,3 +109,36 @@ def make_mcp_client(server_name: str = "github") -> "MCPClient | None":
     except Exception as e:
         print(f"  [mcp] Warning: could not start GitHub MCP server: {e}", file=sys.stderr)
         return None
+
+
+def make_mcp_clients(mcp_cfg: dict) -> "dict[str, MCPClient]":
+    """Start all MCP servers from config and return a name→client mapping.
+
+    Backwards-compat: if GITHUB_PERSONAL_ACCESS_TOKEN is present and 'github'
+    is not in mcp_cfg, the GitHub server is auto-started exactly as before.
+
+    TOML already forbids duplicate keys, but if the same name appears twice in
+    a programmatically-constructed dict, the first entry wins (subsequent ones
+    are silently skipped so the already-running process is not leaked).
+    """
+    clients: dict[str, MCPClient] = {}
+
+    # Backwards compat: auto-start GitHub when token is set and not in config
+    if "github" not in mcp_cfg:
+        github_client = make_mcp_client()
+        if github_client:
+            clients["github"] = github_client
+
+    for name, server_cfg in mcp_cfg.items():
+        if name in clients:
+            # Already running (github auto-start) or duplicate key — skip.
+            continue
+        raw_cmd = server_cfg.get("command", "")
+        if not raw_cmd:
+            continue
+        try:
+            clients[name] = MCPClient(raw_cmd.split(), server_name=name)
+        except Exception as e:
+            print(f"  [mcp] Warning: could not start '{name}' MCP server: {e}", file=sys.stderr)
+
+    return clients

--- a/uio/core/runner.py
+++ b/uio/core/runner.py
@@ -75,7 +75,9 @@ def run_agent(
             all_tools.extend(mcp_tools)
             print(f"  [mcp] '{server_name}' ready — {len(mcp_tools)} tools registered")
         except Exception as e:
-            print(f"  [mcp] Warning: could not list tools for '{server_name}': {e}", file=sys.stderr)
+            print(
+                f"  [mcp] Warning: could not list tools for '{server_name}': {e}", file=sys.stderr
+            )
             client.close()
             failed.append(server_name)
     for name in failed:

--- a/uio/core/runner.py
+++ b/uio/core/runner.py
@@ -7,7 +7,7 @@ import sys
 
 from uio.core.clients import make_client
 from uio.core.ledger import DEFAULT_LEDGER_PATH, write_cost_ledger
-from uio.core.mcp import make_mcp_client
+from uio.core.mcp import make_mcp_clients
 from uio.core.routing import infer_complexity, select_model, select_provider_chain
 from uio.core.tools import DEFAULT_TIMEOUT, TOOL_SCHEMA, execute_tool
 from uio.schema.parser import parse_definition_file
@@ -34,8 +34,9 @@ You are running inside uio. Two tool families are available:
 
 **`run_command`** — execute any shell command (gh CLI, kubectl, s3cmd, etc.)
 
-**`mcp__github__*`** — native GitHub MCP tools (typed JSON, paginated, full API coverage).
-Prefer these over `gh` CLI equivalents for GitHub operations.
+**`mcp__<server>__*`** — native MCP tools (typed JSON, full API coverage).
+Active servers and their tool prefixes are listed in the tool schema.
+Prefer MCP tools over `run_command` equivalents when a matching server is available.
 
 ---
 """
@@ -50,6 +51,7 @@ def run_agent(
     base_url: str | None = None,
     timeout: int = DEFAULT_TIMEOUT,
     no_mcp: bool = False,
+    mcp_cfg: dict | None = None,
     definition_path: str | None = None,
     ledger_path: str = DEFAULT_LEDGER_PATH,
     large_agent_names: list[str] | None = None,
@@ -61,22 +63,25 @@ def run_agent(
 
     frontmatter, body = parse_definition_file(definition_path)
 
-    mcp = None
+    mcp_clients: dict = {}
     if not no_mcp:
-        mcp = make_mcp_client()
+        mcp_clients = make_mcp_clients(mcp_cfg or {})
 
     all_tools = [TOOL_SCHEMA]
-    if mcp is not None:
+    failed: list[str] = []
+    for server_name, client in list(mcp_clients.items()):
         try:
-            mcp_tools = mcp.list_tools()
+            mcp_tools = client.list_tools()
             all_tools.extend(mcp_tools)
-            print(f"  [mcp] GitHub MCP server ready — {len(mcp_tools)} tools registered")
+            print(f"  [mcp] '{server_name}' ready — {len(mcp_tools)} tools registered")
         except Exception as e:
-            print(f"  [mcp] Warning: could not list MCP tools: {e}", file=sys.stderr)
-            mcp.close()
-            mcp = None
+            print(f"  [mcp] Warning: could not list tools for '{server_name}': {e}", file=sys.stderr)
+            client.close()
+            failed.append(server_name)
+    for name in failed:
+        del mcp_clients[name]
 
-    preamble = _PREAMBLE_WITH_MCP if mcp is not None else _PREAMBLE_SHELL_ONLY
+    preamble = _PREAMBLE_WITH_MCP if mcp_clients else _PREAMBLE_SHELL_ONLY
     system_prompt = f"{preamble}# Agent: {frontmatter.get('name', agent_name)}\n\n{body}"
 
     user_message = "Begin your workflow now."
@@ -137,7 +142,7 @@ def run_agent(
                         return
 
                     tool_results = [
-                        (tc, execute_tool(tc, mcp=mcp, timeout=timeout))
+                        (tc, execute_tool(tc, mcp_clients=mcp_clients, timeout=timeout))
                         for tc in response.tool_calls
                     ]
                     client.append_turn(history, response, tool_results)
@@ -163,5 +168,5 @@ def run_agent(
 
         sys.exit(f"Error: all providers exhausted. Last error: {last_error}")
     finally:
-        if mcp is not None:
-            mcp.close()
+        for client in mcp_clients.values():
+            client.close()

--- a/uio/core/tools.py
+++ b/uio/core/tools.py
@@ -33,7 +33,7 @@ class ToolCall(NamedTuple):
 def execute_tool(
     tc: ToolCall,
     *,
-    mcp: "MCPClient | None" = None,
+    mcp_clients: "dict[str, MCPClient] | None" = None,
     timeout: int = DEFAULT_TIMEOUT,
 ) -> str:
     if tc.name == "run_command":
@@ -51,7 +51,9 @@ def execute_tool(
         except subprocess.TimeoutExpired:
             return f"[command timed out after {timeout}s]"
 
-    if mcp is not None and tc.name.startswith(f"mcp__{mcp.server_name}__"):
-        return mcp.call_tool(tc.name, tc.args)
+    if mcp_clients:
+        for server_name, client in mcp_clients.items():
+            if tc.name.startswith(f"mcp__{server_name}__"):
+                return client.call_tool(tc.name, tc.args)
 
     return f"Unknown tool: {tc.name}"


### PR DESCRIPTION
Closes #23.

## Summary

- `make_mcp_clients(mcp_cfg)` in `uio/core/mcp.py` — starts all servers from `[mcp.*]` config sections and returns a `dict[str, MCPClient]`; one failing server does not abort the others
- `execute_tool()` in `uio/core/tools.py` — `mcp` (single client) replaced by `mcp_clients` (dict); dispatch iterates the dict looking for a matching `mcp__<server>__` prefix
- `run_agent()` in `uio/core/runner.py` — new `mcp_cfg` param wired from the CLI; startup loop registers tools from all servers and prints one ready-line per server; `finally` closes all clients
- CLI callers (`agent`, `skill`, `prompt`) pass `mcp_cfg=cfg["mcp"]`

## Backwards compatibility

No config changes required. If `[mcp.github]` is absent from `uio.toml`, the GitHub server is still auto-started when `GITHUB_PERSONAL_ACCESS_TOKEN` is set — identical behaviour to before.

## Duplicate key handling

TOML disallows duplicate keys at the parser level (`tomllib` raises `TOMLDecodeError`). `make_mcp_clients` is also defensive for programmatically-constructed dicts: if a name is already in `clients` (e.g. from the GitHub auto-start), subsequent entries with the same name are silently skipped so no process is leaked.

## Tests

- `tests/test_mcp.py` — 7 new tests for `make_mcp_clients`: empty config, auto-start, explicit github in config, multiple servers, missing command, failing server warns and continues, duplicate-name first-wins
- `tests/test_tools.py` — 5 new tests for multi-server dispatch in `execute_tool`

All 164 tests pass.

## Test plan

- [ ] `uio agent run <agent> --no-mcp` — no MCP servers started, shell-only preamble injected
- [ ] Token set, no `[mcp.github]` in toml — GitHub auto-started as before
- [ ] `[mcp.filesystem]` + `[mcp.fetch]` in toml, no token — both servers start, tools registered
- [ ] One server command invalid — warning printed, other servers and `run_command` still work
- [ ] `pytest tests/` — 164 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)