### PR TITLE
feat: Windows/PowerShell compatibility for native install

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,22 @@ Auto-routes across available providers in order: **Gemini → OpenAI → Ollama*
 ## Container image
 
 ```bash
+# bash/zsh
 docker run --rm \
   -e GEMINI_API_KEY=your-key \
   -e GITHUB_PERSONAL_ACCESS_TOKEN=ghp_... \
   -v $(pwd):/workspace \
   ghcr.io/jomkz/uio agent run repo-health
+
+# PowerShell (Windows) — use ${PWD} instead of $(pwd)
+docker run --rm `
+  -e GEMINI_API_KEY=your-key `
+  -e GITHUB_PERSONAL_ACCESS_TOKEN=ghp_... `
+  -v ${PWD}:/workspace `
+  ghcr.io/jomkz/uio agent run repo-health
+
+# Cross-platform — docker compose avoids the $(pwd) issue entirely
+docker compose run --rm uio agent run repo-health
 ```
 
 The image includes Node.js and pre-warmed MCP servers (`@github/github-mcp-server`,

--- a/docs/01-installation.md
+++ b/docs/01-installation.md
@@ -59,7 +59,7 @@ pytest
 
 ## Shell completion
 
-uio can generate completion scripts for bash, zsh, and fish. Add the appropriate line to your shell's startup file.
+uio can generate completion scripts for bash, zsh, fish, and PowerShell. Add the appropriate line to your shell's startup file.
 
 **bash** — add to `~/.bashrc`:
 ```bash
@@ -76,7 +76,86 @@ eval "$(uio completion zsh)"
 uio completion fish | source
 ```
 
-Restart your shell or `source` the file to activate completion. You can then press Tab to complete `uio` subcommands, agent names, and flags.
+**PowerShell (pwsh)** — add to your `$PROFILE`:
+```powershell
+uio completion pwsh | Out-String | Invoke-Expression
+```
+
+To find your profile path: `echo $PROFILE`. Create it if it doesn't exist: `New-Item -Path $PROFILE -Force`.
+
+Restart your shell or source the file to activate completion. You can then press Tab to complete `uio` subcommands, agent names, and flags.
+
+---
+
+## Windows (PowerShell)
+
+uio works natively on Windows via PowerShell. On Windows, `run_command` is automatically routed to `powershell.exe` instead of `cmd.exe`, and the LLM is told to emit PowerShell-style commands. No extra configuration is required.
+
+### Install Python
+
+Download Python 3.11+ from [python.org](https://www.python.org/downloads/) or install via winget:
+
+```powershell
+winget install Python.Python.3.11
+```
+
+Check your version:
+
+```powershell
+python --version
+```
+
+### Install uio
+
+```powershell
+pip install uio
+```
+
+If `pip` isn't on your PATH after install, use:
+
+```powershell
+python -m pip install uio
+```
+
+### Setting environment variables
+
+Use PowerShell syntax for API keys. Temporary (session only):
+
+```powershell
+$env:GEMINI_API_KEY = "your-key-here"
+$env:GITHUB_PERSONAL_ACCESS_TOKEN = "ghp_..."
+```
+
+To persist across sessions, set them permanently via the System Properties GUI, or:
+
+```powershell
+[System.Environment]::SetEnvironmentVariable("GEMINI_API_KEY", "your-key-here", "User")
+```
+
+### PATH issues
+
+If `uio` isn't found after install, the Scripts directory is not on your PATH. Add it:
+
+```powershell
+# Find where pip installed the scripts
+python -m site --user-site
+# Typically: C:\Users\<you>\AppData\Roaming\Python\Python311\Scripts
+
+# Add to your PowerShell profile so it persists
+Add-Content $PROFILE "`n`$env:PATH = `"C:\Users\<you>\AppData\Roaming\Python\Python311\Scripts;`$env:PATH`""
+```
+
+Or simply call uio via Python directly: `python -m uio`.
+
+### Forcing a specific shell
+
+If you need to run bash-style commands (e.g. in WSL or Git Bash), use `--shell`:
+
+```powershell
+uio agent run my-agent --shell bash    # bash in WSL/Git Bash
+uio agent run my-agent --shell pwsh    # PowerShell Core (default on Windows)
+uio agent run my-agent --shell powershell  # Windows PowerShell 5.x
+```
 
 ---
 
@@ -104,7 +183,11 @@ A `✗` next to a provider means its API key is not set — that provider is ski
 Set at least one API key before running agents:
 
 ```bash
+# bash/zsh
 export GEMINI_API_KEY=your-key-here
+
+# PowerShell
+$env:GEMINI_API_KEY = "your-key-here"
 ```
 
 See [Providers](07-providers.md) for detailed setup instructions for each provider.
@@ -131,12 +214,24 @@ pip install openai
 
 The Ollama process must be running. Start it with `ollama serve`. The default endpoint is `http://localhost:11434/v1`. If your Ollama instance runs elsewhere, set `OLLAMA_BASE_URL`.
 
-**`uio: command not found`**
+**`uio: command not found` (Linux/macOS)**
 
 The `uio` script is installed into your Python environment's `bin/` directory. If that directory is not on your `PATH`, either:
 - Activate a virtual environment: `source .venv/bin/activate`
 - Or add the directory to PATH: `export PATH="$HOME/.local/bin:$PATH"` (for user-level installs)
 
+**`uio` not recognised after install (Windows)**
+
+The Scripts directory is not on PATH. See the [Windows](#windows-powershell) section above for instructions.
+
+**Execution policy error on Windows**
+
+PowerShell may block the completion script. Relax the policy for the current user:
+
+```powershell
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+```
+
 **Python version is 3.10 or older**
 
-uio requires Python 3.11+. Install a newer version via your OS package manager, `pyenv`, or `deadsnakes` PPA (Ubuntu).
+uio requires Python 3.11+. Install a newer version via your OS package manager, `pyenv`, or `deadsnakes` PPA (Ubuntu). On Windows: `winget install Python.Python.3.11`.

--- a/docs/05-cli.md
+++ b/docs/05-cli.md
@@ -55,6 +55,7 @@ The following flags apply to `agent run`, `skill run`, and `prompt run`:
 | `--base-url` | URL | env/config | OpenAI-compatible base URL (LiteLLM, Azure, local proxy) |
 | `--timeout` | integer | 300 | Per-command shell timeout in seconds |
 | `--no-mcp` | flag | off | Disable GitHub MCP server even when token is set |
+| `--shell` | `bash\|sh\|zsh\|powershell\|pwsh` | auto | Shell for `run_command`; auto-detects platform (PowerShell on Windows, bash/sh on POSIX) |
 
 ---
 
@@ -72,6 +73,7 @@ uio agent run my-agent
 uio agent run my-agent "focus on the auth module"
 uio agent run my-agent --provider openai --complexity large
 uio agent run my-agent --no-mcp
+uio agent run my-agent --shell pwsh    # force PowerShell on any platform
 ```
 
 Exit code: 0 on success, 1 if the definition file is not found or validation fails.
@@ -312,9 +314,16 @@ uio registry install repo-health --force
 Prints a shell completion script.
 
 ```bash
-eval "$(uio completion bash)"    # bash
-eval "$(uio completion zsh)"     # zsh
-uio completion fish | source     # fish
+eval "$(uio completion bash)"                        # bash
+eval "$(uio completion zsh)"                         # zsh
+uio completion fish | source                         # fish
+uio completion pwsh | Out-String | Invoke-Expression # PowerShell
+```
+
+To persist PowerShell completion, add the line to your `$PROFILE`:
+
+```powershell
+Add-Content $PROFILE "`nuio completion pwsh | Out-String | Invoke-Expression"
 ```
 
 ---
@@ -332,6 +341,15 @@ uio completion fish | source     # fish
 | `MCP_GITHUB_COMMAND` | Override MCP server launch command | `[mcp.github].command` in uio.toml |
 | `LLM_PROVIDER` | Default provider | `--provider` flag, `uio.toml` `default_provider` |
 | `LLM_MODEL` | Default model | `--model` flag |
+
+**Setting variables on Windows (PowerShell):**
+
+```powershell
+$env:GEMINI_API_KEY = "your-key"
+$env:GITHUB_PERSONAL_ACCESS_TOKEN = "ghp_..."
+```
+
+To persist across sessions: `[System.Environment]::SetEnvironmentVariable("GEMINI_API_KEY", "your-key", "User")`
 
 ---
 

--- a/docs/14-container.md
+++ b/docs/14-container.md
@@ -41,6 +41,22 @@ docker run --rm -it \
   ghcr.io/jomkz/uio chat
 ```
 
+### Windows users
+
+The examples above use `$(pwd)` (bash/zsh syntax) for the volume mount. In PowerShell use
+`${PWD}` instead:
+
+```powershell
+docker run --rm `
+  -e GEMINI_API_KEY=your-key `
+  -e GITHUB_PERSONAL_ACCESS_TOKEN=ghp_... `
+  -v ${PWD}:/workspace `
+  ghcr.io/jomkz/uio agent run repo-health
+```
+
+If you use `docker compose`, the `.:/workspace` volume path in `docker-compose.yml` is
+resolved by Compose and works on all platforms without any change.
+
 ## Configuration
 
 `uio.toml` must be present in `/workspace` (the container's working directory). Mount your project

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,6 +1,13 @@
 """Tests for tool execution: run_command, truncation, timeout, unknown tools."""
 
-from uio.core.tools import DEFAULT_TIMEOUT, MAX_OUTPUT_BYTES, ToolCall, execute_tool
+from uio.core.tools import (
+    DEFAULT_TIMEOUT,
+    MAX_OUTPUT_BYTES,
+    SHELL_CHOICES,
+    ToolCall,
+    _shell_args,
+    execute_tool,
+)
 
 
 def call(command: str) -> ToolCall:
@@ -62,6 +69,62 @@ def test_timeout_message_includes_seconds():
 
 def test_default_timeout_constant():
     assert DEFAULT_TIMEOUT == 300
+
+
+# ── Shell dispatch ────────────────────────────────────────────────────────────
+
+
+def test_shell_choices_exports_expected_names():
+    assert set(SHELL_CHOICES) == {"bash", "sh", "zsh", "powershell", "pwsh"}
+
+
+def test_shell_args_bash_override():
+    args, shell = _shell_args("echo hi", "bash")
+    assert args == ["bash", "-c", "echo hi"]
+    assert shell is False
+
+
+def test_shell_args_sh_override():
+    args, shell = _shell_args("echo hi", "sh")
+    assert args == ["sh", "-c", "echo hi"]
+    assert shell is False
+
+
+def test_shell_args_zsh_override():
+    args, shell = _shell_args("echo hi", "zsh")
+    assert args == ["zsh", "-c", "echo hi"]
+    assert shell is False
+
+
+def test_shell_args_powershell_override():
+    args, shell = _shell_args("echo hi", "powershell")
+    assert args == ["powershell.exe", "-Command", "echo hi"]
+    assert shell is False
+
+
+def test_shell_args_pwsh_override():
+    args, shell = _shell_args("echo hi", "pwsh")
+    assert args == ["pwsh", "-Command", "echo hi"]
+    assert shell is False
+
+
+def test_shell_args_no_override_posix():
+    import sys
+
+    if sys.platform != "win32":
+        args, shell = _shell_args("echo hi")
+        assert args == "echo hi"
+        assert shell is True
+
+
+def test_execute_tool_with_bash_override():
+    output = execute_tool(call("echo hello"), shell_override="bash")
+    assert "hello" in output
+
+
+def test_execute_tool_with_sh_override():
+    output = execute_tool(call("echo world"), shell_override="sh")
+    assert "world" in output
 
 
 # ── Multi-server MCP dispatch ─────────────────────────────────────────────────

--- a/uio/cli/agent.py
+++ b/uio/cli/agent.py
@@ -11,6 +11,7 @@ from uio.cli._helpers import list_definitions, print_definition_table
 from uio.config import load_config
 from uio.core.routing import infer_complexity
 from uio.core.runner import run_agent
+from uio.core.tools import SHELL_CHOICES
 from uio.schema.parser import parse_definition_file
 
 _AGENT_TEMPLATE = textwrap.dedent("""\
@@ -57,6 +58,12 @@ def agent_group() -> None:
     "--timeout", default=None, show_default=True, type=int, help="Per-command timeout in seconds."
 )
 @click.option("--no-mcp", is_flag=True, default=False, help="Disable all MCP servers.")
+@click.option(
+    "--shell",
+    type=click.Choice(SHELL_CHOICES),
+    default=None,
+    help="Shell for run_command (default: powershell on Windows, bash/sh on POSIX).",
+)
 def agent_run_cmd(
     agent_name: str,
     arg: str | None,
@@ -66,6 +73,7 @@ def agent_run_cmd(
     base_url: str | None,
     timeout: int | None,
     no_mcp: bool,
+    shell: str | None,
 ) -> None:
     """Run a named AI agent.
 
@@ -78,6 +86,7 @@ def agent_run_cmd(
       uio agent run my-agent
       uio agent run my-agent --provider openai
       uio agent run my-agent --complexity large
+      uio agent run my-agent --shell pwsh
     """
     cfg = load_config()
     agents_dir = cfg["dirs"]["agents"]
@@ -95,6 +104,7 @@ def agent_run_cmd(
         definition_path=definition_path,
         ledger_path=cfg["runtime"]["cost_ledger"],
         large_agent_names=cfg["large_agents"]["names"],
+        shell_override=shell,
     )
 
 

--- a/uio/cli/main.py
+++ b/uio/cli/main.py
@@ -190,7 +190,7 @@ def validate_cmd() -> None:
 
 
 @main.command("completion")
-@click.argument("shell", type=click.Choice(["bash", "zsh", "fish"]), default="bash")
+@click.argument("shell", type=click.Choice(["bash", "zsh", "fish", "pwsh"]), default="bash")
 def completion_cmd(shell: str) -> None:
     """Print a shell completion script.
 
@@ -199,12 +199,24 @@ def completion_cmd(shell: str) -> None:
       bash:  eval "$(uio completion bash)"
       zsh:   eval "$(uio completion zsh)"
       fish:  uio completion fish | source
+      pwsh:  uio completion pwsh | Out-String | Invoke-Expression
     """
     try:
         from click.shell_completion import BashComplete, FishComplete, ZshComplete
 
-        cls = {"bash": BashComplete, "zsh": ZshComplete, "fish": FishComplete}[shell]
-        sc = cls(main, {}, "uio", "_UIO_COMPLETE")
+        if shell == "pwsh":
+            try:
+                from click.shell_completion import PowerShellComplete
+
+                sc = PowerShellComplete(main, {}, "uio", "_UIO_COMPLETE")
+            except ImportError:
+                raise click.ClickException(
+                    "PowerShell completion requires Click 8.0+. "
+                    "Upgrade with: pip install --upgrade click"
+                )
+        else:
+            cls = {"bash": BashComplete, "zsh": ZshComplete, "fish": FishComplete}[shell]
+            sc = cls(main, {}, "uio", "_UIO_COMPLETE")
         click.echo(sc.source())
     except (ImportError, AttributeError) as e:
         raise click.ClickException(f"Shell completion unavailable: {e}")

--- a/uio/cli/prompt.py
+++ b/uio/cli/prompt.py
@@ -10,6 +10,7 @@ import click
 from uio.cli._helpers import list_definitions, print_definition_table
 from uio.config import load_config
 from uio.core.runner import run_agent
+from uio.core.tools import SHELL_CHOICES
 
 _PROMPT_TEMPLATE = textwrap.dedent("""\
     ---
@@ -43,6 +44,12 @@ def prompt_group() -> None:
 @click.option("--base-url", default=None, help="Base URL for an OpenAI-compatible endpoint.")
 @click.option("--timeout", default=None, type=int, help="Per-command timeout in seconds.")
 @click.option("--no-mcp", is_flag=True, default=False, help="Disable all MCP servers.")
+@click.option(
+    "--shell",
+    type=click.Choice(SHELL_CHOICES),
+    default=None,
+    help="Shell for run_command (default: powershell on Windows, bash/sh on POSIX).",
+)
 def prompt_run_cmd(
     prompt_name: str,
     arg: str | None,
@@ -51,6 +58,7 @@ def prompt_run_cmd(
     base_url: str | None,
     timeout: int | None,
     no_mcp: bool,
+    shell: str | None,
 ) -> None:
     """Run a named prompt.
 
@@ -72,6 +80,7 @@ def prompt_run_cmd(
         definition_path=definition_path,
         ledger_path=cfg["runtime"]["cost_ledger"],
         large_agent_names=cfg["large_agents"]["names"],
+        shell_override=shell,
     )
 
 

--- a/uio/cli/skill.py
+++ b/uio/cli/skill.py
@@ -10,6 +10,7 @@ import click
 from uio.cli._helpers import list_definitions, print_definition_table
 from uio.config import load_config
 from uio.core.runner import run_agent
+from uio.core.tools import SHELL_CHOICES
 from uio.schema.parser import parse_definition_file
 
 _SKILL_TEMPLATE = textwrap.dedent("""\
@@ -50,6 +51,12 @@ def skill_group() -> None:
 @click.option("--base-url", default=None, help="Base URL for an OpenAI-compatible endpoint.")
 @click.option("--timeout", default=None, type=int, help="Per-command timeout in seconds.")
 @click.option("--no-mcp", is_flag=True, default=False, help="Disable all MCP servers.")
+@click.option(
+    "--shell",
+    type=click.Choice(SHELL_CHOICES),
+    default=None,
+    help="Shell for run_command (default: powershell on Windows, bash/sh on POSIX).",
+)
 def skill_run_cmd(
     skill_name: str,
     arg: str | None,
@@ -59,6 +66,7 @@ def skill_run_cmd(
     base_url: str | None,
     timeout: int | None,
     no_mcp: bool,
+    shell: str | None,
 ) -> None:
     """Run a named skill as a standalone agent loop.
 
@@ -80,6 +88,7 @@ def skill_run_cmd(
         definition_path=definition_path,
         ledger_path=cfg["runtime"]["cost_ledger"],
         large_agent_names=cfg["large_agents"]["names"],
+        shell_override=shell,
     )
 
 

--- a/uio/core/mcp.py
+++ b/uio/core/mcp.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import subprocess
 import sys
 
@@ -103,7 +104,7 @@ def make_mcp_client(server_name: str = "github") -> "MCPClient | None":
     command_env = os.environ.copy()
     command_env["GITHUB_PERSONAL_ACCESS_TOKEN"] = token
     raw = os.environ.get("MCP_GITHUB_COMMAND")
-    command = raw.split() if raw else ["npx", "-y", "@github/github-mcp-server", "stdio"]
+    command = shlex.split(raw) if raw else ["npx", "-y", "@github/github-mcp-server", "stdio"]
     try:
         return MCPClient(command, server_name=server_name, env=command_env)
     except Exception as e:
@@ -137,7 +138,7 @@ def make_mcp_clients(mcp_cfg: dict) -> "dict[str, MCPClient]":
         if not raw_cmd:
             continue
         try:
-            clients[name] = MCPClient(raw_cmd.split(), server_name=name)
+            clients[name] = MCPClient(shlex.split(raw_cmd), server_name=name)
         except Exception as e:
             print(f"  [mcp] Warning: could not start '{name}' MCP server: {e}", file=sys.stderr)
 

--- a/uio/core/runner.py
+++ b/uio/core/runner.py
@@ -14,9 +14,30 @@ from uio.schema.parser import parse_definition_file
 
 MAX_ITERATIONS = 10
 
-_SHELL_NAME = "PowerShell" if sys.platform == "win32" else "bash/sh"
 
-_PREAMBLE_SHELL_ONLY = f"""\
+def _build_preamble(has_mcp: bool, shell_override: str | None = None) -> str:
+    """Build the runtime preamble injected before the agent system prompt.
+
+    shell_override (from --shell) takes precedence over platform auto-detection so
+    the LLM is told the correct shell syntax regardless of the host OS.
+    """
+    shell_name = shell_override or ("PowerShell" if sys.platform == "win32" else "bash/sh")
+    if has_mcp:
+        return f"""\
+## ℹ️ Runtime — Tools Available
+
+You are running inside uio. Two tool families are available:
+
+**`run_command`** — execute any shell command (gh CLI, kubectl, s3cmd, etc.)
+Shell: {shell_name} — emit {shell_name}-style commands only.
+
+**`mcp__<server>__*`** — native MCP tools (typed JSON, full API coverage).
+Active servers and their tool prefixes are listed in the tool schema.
+Prefer MCP tools over `run_command` equivalents when a matching server is available.
+
+---
+"""
+    return f"""\
 ## ⚠️ Runtime — MCP Tools Unavailable
 
 You are running inside uio. The ONLY tool available is `run_command`.
@@ -25,22 +46,7 @@ MCP tools (mcp__github__*, etc.) do NOT exist in this runtime.
 Calling them will return "Unknown tool" and waste an iteration — do not attempt them.
 
 For ALL GitHub operations, use `run_command` with the `gh` CLI.
-Shell: {_SHELL_NAME} — emit {_SHELL_NAME}-style commands only.
-
----
-"""
-
-_PREAMBLE_WITH_MCP = f"""\
-## ℹ️ Runtime — Tools Available
-
-You are running inside uio. Two tool families are available:
-
-**`run_command`** — execute any shell command (gh CLI, kubectl, s3cmd, etc.)
-Shell: {_SHELL_NAME} — emit {_SHELL_NAME}-style commands only.
-
-**`mcp__<server>__*`** — native MCP tools (typed JSON, full API coverage).
-Active servers and their tool prefixes are listed in the tool schema.
-Prefer MCP tools over `run_command` equivalents when a matching server is available.
+Shell: {shell_name} — emit {shell_name}-style commands only.
 
 ---
 """
@@ -59,6 +65,7 @@ def run_agent(
     definition_path: str | None = None,
     ledger_path: str = DEFAULT_LEDGER_PATH,
     large_agent_names: list[str] | None = None,
+    shell_override: str | None = None,
 ) -> None:
     if definition_path is None:
         raise ValueError("definition_path must be provided")
@@ -87,7 +94,7 @@ def run_agent(
     for name in failed:
         del mcp_clients[name]
 
-    preamble = _PREAMBLE_WITH_MCP if mcp_clients else _PREAMBLE_SHELL_ONLY
+    preamble = _build_preamble(bool(mcp_clients), shell_override)
     system_prompt = f"{preamble}# Agent: {frontmatter.get('name', agent_name)}\n\n{body}"
 
     user_message = "Begin your workflow now."
@@ -148,7 +155,15 @@ def run_agent(
                         return
 
                     tool_results = [
-                        (tc, execute_tool(tc, mcp_clients=mcp_clients, timeout=timeout))
+                        (
+                            tc,
+                            execute_tool(
+                                tc,
+                                mcp_clients=mcp_clients,
+                                timeout=timeout,
+                                shell_override=shell_override,
+                            ),
+                        )
                         for tc in response.tool_calls
                     ]
                     client.append_turn(history, response, tool_results)

--- a/uio/core/runner.py
+++ b/uio/core/runner.py
@@ -14,7 +14,9 @@ from uio.schema.parser import parse_definition_file
 
 MAX_ITERATIONS = 10
 
-_PREAMBLE_SHELL_ONLY = """\
+_SHELL_NAME = "PowerShell" if sys.platform == "win32" else "bash/sh"
+
+_PREAMBLE_SHELL_ONLY = f"""\
 ## ⚠️ Runtime — MCP Tools Unavailable
 
 You are running inside uio. The ONLY tool available is `run_command`.
@@ -23,16 +25,18 @@ MCP tools (mcp__github__*, etc.) do NOT exist in this runtime.
 Calling them will return "Unknown tool" and waste an iteration — do not attempt them.
 
 For ALL GitHub operations, use `run_command` with the `gh` CLI.
+Shell: {_SHELL_NAME} — emit {_SHELL_NAME}-style commands only.
 
 ---
 """
 
-_PREAMBLE_WITH_MCP = """\
+_PREAMBLE_WITH_MCP = f"""\
 ## ℹ️ Runtime — Tools Available
 
 You are running inside uio. Two tool families are available:
 
 **`run_command`** — execute any shell command (gh CLI, kubectl, s3cmd, etc.)
+Shell: {_SHELL_NAME} — emit {_SHELL_NAME}-style commands only.
 
 **`mcp__<server>__*`** — native MCP tools (typed JSON, full API coverage).
 Active servers and their tool prefixes are listed in the tool schema.

--- a/uio/core/tools.py
+++ b/uio/core/tools.py
@@ -12,13 +12,29 @@ if TYPE_CHECKING:
 MAX_OUTPUT_BYTES = 32768
 DEFAULT_TIMEOUT = 300
 
+# Maps --shell choice names to [executable, flag] prefixes for subprocess.run.
+_SHELL_MAP: dict[str, list[str]] = {
+    "bash": ["bash", "-c"],
+    "sh": ["sh", "-c"],
+    "zsh": ["zsh", "-c"],
+    "powershell": ["powershell.exe", "-Command"],
+    "pwsh": ["pwsh", "-Command"],
+}
 
-def _shell_args(command: str) -> tuple:
+SHELL_CHOICES: list[str] = list(_SHELL_MAP)
+
+
+def _shell_args(command: str, shell_override: str | None = None) -> tuple:
     """Return (args, shell) for subprocess.run.
 
     On Windows, shell=True routes to cmd.exe which doesn't understand bash idioms.
     Route to powershell.exe instead so LLM-generated commands work correctly.
+    Explicit shell_override (from --shell) always takes precedence.
     """
+    if shell_override:
+        prefix = _SHELL_MAP.get(shell_override)
+        if prefix:
+            return prefix + [command], False
     if sys.platform == "win32":
         return ["powershell.exe", "-Command", command], False
     return command, True
@@ -48,12 +64,13 @@ def execute_tool(
     *,
     mcp_clients: "dict[str, MCPClient] | None" = None,
     timeout: int = DEFAULT_TIMEOUT,
+    shell_override: str | None = None,
 ) -> str:
     if tc.name == "run_command":
         command = tc.args.get("command", "")
         print(f"  [tool] $ {command}")
         try:
-            args, use_shell = _shell_args(command)
+            args, use_shell = _shell_args(command, shell_override)
             result = subprocess.run(
                 args, shell=use_shell, capture_output=True, text=True, timeout=timeout
             )

--- a/uio/core/tools.py
+++ b/uio/core/tools.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 from typing import TYPE_CHECKING, NamedTuple
 
 if TYPE_CHECKING:
@@ -10,6 +11,18 @@ if TYPE_CHECKING:
 
 MAX_OUTPUT_BYTES = 32768
 DEFAULT_TIMEOUT = 300
+
+
+def _shell_args(command: str) -> tuple:
+    """Return (args, shell) for subprocess.run.
+
+    On Windows, shell=True routes to cmd.exe which doesn't understand bash idioms.
+    Route to powershell.exe instead so LLM-generated commands work correctly.
+    """
+    if sys.platform == "win32":
+        return ["powershell.exe", "-Command", command], False
+    return command, True
+
 
 TOOL_SCHEMA = {
     "name": "run_command",
@@ -40,8 +53,9 @@ def execute_tool(
         command = tc.args.get("command", "")
         print(f"  [tool] $ {command}")
         try:
+            args, use_shell = _shell_args(command)
             result = subprocess.run(
-                command, shell=True, capture_output=True, text=True, timeout=timeout
+                args, shell=use_shell, capture_output=True, text=True, timeout=timeout
             )
             output = result.stdout + result.stderr
             if len(output) > MAX_OUTPUT_BYTES:


### PR DESCRIPTION
## Summary

Full Windows/PowerShell native-install support. All items from the issue analysis implemented.

### Required (core functionality)
- **`tools.py`**: Platform-aware shell dispatch already shipped; extended with `--shell` override so users can force any shell (`bash`, `sh`, `zsh`, `powershell`, `pwsh`) on any platform
- **`runner.py`**: Static preamble constants replaced with `_build_preamble()` — LLM always receives the correct shell name, even when `--shell` overrides platform auto-detection
- **`agent run` / `skill run` / `prompt run`**: New `--shell` flag wired end-to-end from CLI → `run_agent` → `execute_tool`

### Nice-to-have
- **PowerShell tab completion**: `pwsh` added to `uio completion` choices; uses Click's `PowerShellComplete` (Click 8.0+); persists via `$PROFILE`
- **Windows docs**: New Windows section in `docs/01-installation.md` covering Python install, pip PATH issues, env var syntax, completion setup, and troubleshooting; `--shell` documented in `docs/05-cli.md`; PowerShell env var syntax callout added to env vars table

### Low-severity fixes
- **`mcp.py`**: `str.split()` → `shlex.split()` on both MCP command env vars — handles paths with spaces

### Docs
- `README.md`: container quick-start shows `${PWD}` (PowerShell) and `docker compose` (cross-platform) alternatives
- `docs/14-container.md`: Windows callout already shipped in first commit

### Tests
- 9 new tests: `_shell_args` for every override choice, POSIX no-override path, and `execute_tool` with `bash`/`sh` overrides

Closes #9

## Test plan

- [ ] All 173 tests pass (`pytest`)
- [ ] `ruff format` + `ruff check` clean
- [ ] `uio agent run --shell pwsh` routes commands to `pwsh -Command` on any platform
- [ ] `uio completion pwsh` generates a valid PowerShell completion script
- [ ] On Windows: `uio agent run` defaults to `powershell.exe` without `--shell`

🤖 Generated with [Claude Code](https://claude.com/claude-code)