### PR TITLE
feat: add release assets for all supported platforms (#28)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,6 +34,9 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -42,6 +45,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,43 @@ jobs:
           name: dist
           path: dist/
 
+  build-binaries:
+    name: Build binary (${{ matrix.asset_name }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            asset_name: uio-linux-x86_64
+          - os: macos-latest
+            asset_name: uio-macos-universal2
+          - os: windows-latest
+            asset_name: uio-windows-x86_64.exe
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install pyinstaller .
+
+      - name: Build binary (macOS universal2)
+        if: runner.os == 'macOS'
+        run: pyinstaller --onefile --name ${{ matrix.asset_name }} --target-arch universal2 uio/cli/main.py
+
+      - name: Build binary (Linux / Windows)
+        if: runner.os != 'macOS'
+        run: pyinstaller --onefile --name ${{ matrix.asset_name }} uio/cli/main.py
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: binary-${{ matrix.os }}
+          path: dist/${{ matrix.asset_name }}*
+
   publish-pypi:
     name: Publish to PyPI
     needs: build
@@ -49,7 +86,7 @@ jobs:
 
   github-release:
     name: Create GitHub Release
-    needs: build
+    needs: [build, build-binaries]
     runs-on: ubuntu-latest
 
     steps:
@@ -60,8 +97,25 @@ jobs:
           name: dist
           path: dist/
 
+      - uses: actions/download-artifact@v8
+        with:
+          name: binary-ubuntu-latest
+          path: binaries/
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: binary-macos-latest
+          path: binaries/
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: binary-windows-latest
+          path: binaries/
+
       - name: Create release
         uses: softprops/action-gh-release@v3
         with:
-          files: dist/*
+          files: |
+            dist/*
+            binaries/*
           generate_release_notes: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ uio = "uio.cli.main:main"
 dev = [
     "pytest>=9.0.3",
     "ruff",
+    "pyinstaller",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Summary

- Adds a `build-binaries` job to `release.yml` with a 3-way OS matrix (`ubuntu-latest`, `macos-latest`, `windows-latest`) that uses PyInstaller to produce standalone single-file executables — `uio-linux-x86_64`, `uio-macos-universal2` (fat binary, Intel + Apple Silicon), and `uio-windows-x86_64.exe`
- Updates `github-release` to depend on `build-binaries` and attach all three binaries to the GitHub Release alongside the existing wheel and sdist
- Adds QEMU + `platforms: linux/amd64,linux/arm64` to `docker.yml` so the GHCR image is multi-arch
- Adds `pyinstaller` to `[project.optional-dependencies].dev` in `pyproject.toml`

Closes #28

## Test plan

- [ ] Push a pre-release tag (`v0.1.0-rc1`) and verify all three `Build binary` matrix jobs complete successfully
- [ ] Confirm the draft release contains `uio-linux-x86_64`, `uio-macos-universal2`, `uio-windows-x86_64.exe`, the `.whl`, and the `.tar.gz`
- [ ] Run `docker buildx imagetools inspect ghcr.io/jomkz/uio:latest` and confirm both `linux/amd64` and `linux/arm64` are listed
- [ ] Delete the pre-release tag and draft release before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)