### PR TITLE
fix: split macOS binary build into arm64 + x86_64 matrix entries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,10 @@ jobs:
         include:
           - os: ubuntu-latest
             asset_name: uio-linux-x86_64
+          - os: macos-13
+            asset_name: uio-macos-x86_64
           - os: macos-latest
-            asset_name: uio-macos-universal2
+            asset_name: uio-macos-arm64
           - os: windows-latest
             asset_name: uio-windows-x86_64.exe
 
@@ -57,12 +59,7 @@ jobs:
       - name: Install dependencies
         run: pip install pyinstaller .
 
-      - name: Build binary (macOS universal2)
-        if: runner.os == 'macOS'
-        run: pyinstaller --onefile --name ${{ matrix.asset_name }} --target-arch universal2 uio/cli/main.py
-
-      - name: Build binary (Linux / Windows)
-        if: runner.os != 'macOS'
+      - name: Build binary
         run: pyinstaller --onefile --name ${{ matrix.asset_name }} uio/cli/main.py
 
       - uses: actions/upload-artifact@v7
@@ -102,6 +99,11 @@ jobs:
       - uses: actions/download-artifact@v8
         with:
           name: binary-ubuntu-latest
+          path: binaries/
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: binary-macos-13
           path: binaries/
 
       - uses: actions/download-artifact@v8


### PR DESCRIPTION
## Summary

- Replaces the broken `macos-latest` + `--target-arch universal2` matrix entry with two separate native entries: `macos-13` (Intel x86_64) and `macos-latest` (Apple Silicon arm64)
- Removes the `--target-arch universal2` PyInstaller flag and consolidates to a single unified build step
- Adds a `binary-macos-13` artifact download in the `github-release` job

## Root cause

`pyyaml` ships arm64-only wheels on PyPI; PyInstaller's `--target-arch universal2` requires every bundled `.so` to be a fat binary, so the build fails with `IncompatibleBinaryArchError`.

## Test plan

- [ ] Tag a pre-release and verify all four `Build binary` matrix jobs pass
- [ ] Confirm `uio-macos-x86_64` and `uio-macos-arm64` appear as release assets
- [ ] Verify each binary runs on its target architecture

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)