### PR TITLE
chore: bump version to 0.1.0rc2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "uio-ai"
-version = "0.1.0"
+version = "0.1.0rc2"
 description = "Provider-agnostic AI agent/skill/prompt runner"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- Deletes the mislabeled `v0.2.0-rc1` tag/release (already done)
- Updates `pyproject.toml` version from `0.1.0` to `0.1.0rc2` to match the intended `v0.1.0-rc2` tag
- Keeps git tag and PyPI package version in sync going forward

## After merging

Tag `v0.1.0-rc2` on the merge commit — this will publish `uio-ai 0.1.0rc2` to PyPI as the authoritative first pre-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)