### PR TITLE
feat: decouple macos-x86 binary from release gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,6 @@ jobs:
         include:
           - os: ubuntu-latest
             asset_name: uio-linux-x86_64
-          - os: macos-13
-            asset_name: uio-macos-x86_64
           - os: macos-latest
             asset_name: uio-macos-arm64
           - os: windows-latest
@@ -67,6 +65,29 @@ jobs:
         with:
           name: binary-${{ matrix.os }}
           path: dist/${{ matrix.asset_name }}*
+
+  build-binary-macos-x86:
+    name: Build binary (uio-macos-x86_64)
+    runs-on: macos-13
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install pyinstaller .
+
+      - name: Build binary
+        run: pyinstaller --onefile --name uio-macos-x86_64 uio/cli/main.py
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: binary-macos-13
+          path: dist/uio-macos-x86_64*
 
   publish-pypi:
     name: Publish to PyPI
@@ -104,11 +125,6 @@ jobs:
 
       - uses: actions/download-artifact@v8
         with:
-          name: binary-macos-13
-          path: binaries/
-
-      - uses: actions/download-artifact@v8
-        with:
           name: binary-macos-latest
           path: binaries/
 
@@ -124,6 +140,21 @@ jobs:
             dist/*
             binaries/*
           generate_release_notes: true
+
+  upload-macos-x86:
+    name: Upload macOS x86_64 binary to release
+    needs: [github-release, build-binary-macos-x86]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: binary-macos-13
+          path: binaries/
+
+      - uses: softprops/action-gh-release@v3
+        with:
+          files: binaries/*
 
   build-image:
     name: Build and push Docker image

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Full documentation lives in [`docs/`](docs/README.md) — covering installation,
 ## Quickstart
 
 ```bash
-pip install uio
+pip install uio-ai
 
 # Scaffold .uio/ and install bundled examples
 uio init --examples

--- a/docs/01-installation.md
+++ b/docs/01-installation.md
@@ -12,14 +12,16 @@ You do not need Node.js to use uio's core features. Node.js is only needed if yo
 ## Install from PyPI
 
 ```bash
-pip install uio
+pip install uio-ai
 ```
+
+The PyPI package is named `uio-ai`; the installed CLI command is `uio`.
 
 Verify the installation:
 
 ```bash
 uio --version
-# uio, version 0.1.0
+# uio, version 0.1.0rc2
 ```
 
 ---
@@ -29,7 +31,7 @@ uio --version
 The `dev` extras add the test runner and linter used during development:
 
 ```bash
-pip install "uio[dev]"
+pip install "uio-ai[dev]"
 ```
 
 This installs `pytest` and `ruff`. You only need this if you are running the test suite or contributing to uio itself.
@@ -108,13 +110,13 @@ python --version
 ### Install uio
 
 ```powershell
-pip install uio
+pip install uio-ai
 ```
 
 If `pip` isn't on your PATH after install, use:
 
 ```powershell
-python -m pip install uio
+python -m pip install uio-ai
 ```
 
 ### Setting environment variables

--- a/docs/13-internals.md
+++ b/docs/13-internals.md
@@ -253,7 +253,7 @@ Test modules:
 1. Fork the repository and create a feature branch.
 2. Make your changes.
 3. Run the test suite: `pytest`
-4. Run the linter: `ruff check .`
+4. Format and lint: `ruff format . && ruff check .`
 5. Open a pull request.
 
 Guidelines:

--- a/docs/14-container.md
+++ b/docs/14-container.md
@@ -251,11 +251,15 @@ Run `uio` as a step in any container-native pipeline:
 
 ## Building from source
 
+The official Dockerfile installs `uio-ai` from PyPI, so a published version is required via the `UIO_VERSION` build argument:
+
 ```bash
-docker build -t uio .
+docker build --build-arg UIO_VERSION=0.1.0rc2 -t uio .
 
 docker run --rm \
   -e GEMINI_API_KEY=your-key \
   -v $(pwd):/workspace \
   uio skill run summarise "Hello from a local build"
 ```
+
+Replace `0.1.0rc2` with the version you want to pin. For local development against unreleased code, install directly with `pip install -e .` and run `uio` from your virtual environment instead of using the container.


### PR DESCRIPTION
## Summary

- `build-binaries` matrix trimmed to ubuntu, macos-arm, windows — the three fast runners
- New standalone `build-binary-macos-x86` job runs on `macos-13` independently, with no downstream blockers
- `github-release` no longer waits for the x86 binary; it creates the release as soon as the fast runners finish
- New `upload-macos-x86` job (`needs: [github-release, build-binary-macos-x86]`) appends the binary to the existing release once both prerequisites are done

## Job graph

```
build ──► build-binaries (ubuntu, macos-arm, windows) ──► github-release ──┐
                                                                            ├──► upload-macos-x86
build ──► build-binary-macos-x86 (macos-13) ────────────────────────────── ┘

build ──► publish-pypi ──► build-image
```

## Test plan

- [ ] Push a `v*` tag and confirm `github-release` completes without waiting for `macos-13`
- [ ] Confirm the x86 binary is appended to the release once `upload-macos-x86` finishes
- [ ] Confirm all four binaries appear on the final release

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)