### PR TITLE
feat: derive PyPI version from git tag, eliminate pyproject.toml sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,24 @@ jobs:
   build:
     name: Build distribution
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.ver.outputs.pep }}
 
     steps:
       - uses: actions/checkout@v6
+
+      - name: Derive package version from tag
+        id: ver
+        run: |
+          RAW="${GITHUB_REF_NAME#v}"
+          PEP=$(echo "$RAW" | sed -E 's/-rc([0-9])/rc\1/g; s/-alpha([0-9])/a\1/g; s/-beta([0-9])/b\1/g')
+          echo "pep=$PEP" >> $GITHUB_OUTPUT
+          echo "Tag → PEP 440: $GITHUB_REF_NAME → $PEP"
+
+      - name: Patch pyproject.toml version
+        run: |
+          sed -i "s/^version = .*/version = \"${{ steps.ver.outputs.pep }}\"/" pyproject.toml
+          grep "^version" pyproject.toml
 
       - uses: actions/setup-python@v6
         with:
@@ -158,17 +173,11 @@ jobs:
 
   build-image:
     name: Build and push Docker image
-    needs: publish-pypi
+    needs: [publish-pypi, build]
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v6
-
-      - name: Extract package version
-        id: pkg
-        run: |
-          VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -201,6 +210,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: UIO_VERSION=${{ steps.pkg.outputs.version }}
+          build-args: UIO_VERSION=${{ needs.build.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/docs/13-internals.md
+++ b/docs/13-internals.md
@@ -248,6 +248,29 @@ Test modules:
 
 ---
 
+## Release process
+
+The git tag is the single source of truth for the published version. `pyproject.toml` holds the placeholder `0.0.0.dev0` — it is never manually bumped.
+
+When a `v*` tag is pushed, the `build` job in `release.yml`:
+
+1. Strips the leading `v` and normalises to PEP 440 — `v0.1.0-rc3` → `0.1.0rc3`
+2. Patches `pyproject.toml` in-place before building (CI only; the change is never committed)
+3. Emits the normalised version as a job output consumed by `build-image`
+
+**To cut a release:** push a tag — nothing else.
+
+```bash
+git tag v1.2.3          # stable release
+git tag v1.2.3-rc1      # release candidate  →  1.2.3rc1 on PyPI
+git tag v1.2.3-beta2    # beta               →  1.2.3b2 on PyPI
+git push origin <tag>
+```
+
+Supported pre-release suffixes: `-rcN`, `-betaN`, `-alphaN`.
+
+---
+
 ## Contributing
 
 1. Fork the repository and create a feature branch.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "uio-ai"
-version = "0.1.0rc2"
+version = "0.0.0.dev0"
 description = "Provider-agnostic AI agent/skill/prompt runner"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Problem

The git tag and `pyproject.toml` version were maintained separately. Pushing a tag before bumping the version caused the workflow to re-upload an already-published PyPI version (`400 File already exists`). This happened twice.

## Solution

The git tag is now the single source of truth. `pyproject.toml` holds `0.0.0.dev0` and is never manually bumped.

## Changes

### `release.yml` — `build` job

Two new steps run immediately after checkout, before the Python build:

1. **Derive package version from tag** — strips `v` prefix and normalises to PEP 440:
   - `v0.1.0-rc3` → `0.1.0rc3`
   - `v1.2.3-beta2` → `1.2.3b2`
   - `v2.0.0-alpha1` → `2.0.0a1`
   - `v1.2.3` → `1.2.3`

2. **Patch pyproject.toml version** — `sed` replaces the version in-place before `python -m build` (CI only; never committed). The correct version is baked into the wheel.

The job now declares `outputs: version` so downstream jobs can consume it.

### `release.yml` — `build-image` job

- Added `build` to `needs` (required for job output access — outputs don't propagate transitively)
- Removed the `tomllib` extraction step
- `build-args: UIO_VERSION=${{ needs.build.outputs.version }}`

### `pyproject.toml`

`version = "0.0.0.dev0"` — placeholder making clear this field is CI-managed.

### `docs/13-internals.md`

New **Release process** section explaining tag-driven versioning and the supported tag formats.

## To cut a release after this merges

```bash
git tag v0.1.0-rc3   # or whatever version
git push origin v0.1.0-rc3
```

That's it. No `pyproject.toml` bump needed.

## Test plan

- [ ] Merge this PR
- [ ] Delete the broken `v0.1.0-rc3` tag/release from GitHub
- [ ] Push `v0.1.0-rc3` fresh — verify `build` job logs show `Tag → PEP 440: v0.1.0-rc3 → 0.1.0rc3`
- [ ] Verify `uio-ai 0.1.0rc3` appears on PyPI
- [ ] Verify GHCR image tagged `0.1.0-rc3` is pushed

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)