### PR TITLE
feat: make GitHub release PyPI-gated; upload binaries progressively

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,17 +122,27 @@ jobs:
 
   github-release:
     name: Create GitHub Release
-    needs: [build, build-binaries]
+    needs: [build, publish-pypi]
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
-
       - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
 
+      - name: Create release
+        uses: softprops/action-gh-release@v3
+        with:
+          files: dist/*
+          generate_release_notes: true
+
+  upload-binaries:
+    name: Upload fast binaries to release
+    needs: [github-release, build-binaries]
+    runs-on: ubuntu-latest
+
+    steps:
       - uses: actions/download-artifact@v8
         with:
           name: binary-ubuntu-latest
@@ -148,13 +158,9 @@ jobs:
           name: binary-windows-latest
           path: binaries/
 
-      - name: Create release
-        uses: softprops/action-gh-release@v3
+      - uses: softprops/action-gh-release@v3
         with:
-          files: |
-            dist/*
-            binaries/*
-          generate_release_notes: true
+          files: binaries/*
 
   upload-macos-x86:
     name: Upload macOS x86_64 binary to release


### PR DESCRIPTION
Closes #41

## Summary

- `github-release` now depends on `[build, publish-pypi]` instead of `[build, build-binaries]` — the GitHub release fires as soon as PyPI is live, not after all three binaries finish compiling
- The release is created with `dist/*` only (wheel + sdist); binaries are appended by subsequent jobs
- New `upload-binaries` job fans in from `[github-release, build-binaries]` and appends the three fast binaries (ubuntu, macos-arm, windows) to the existing release
- `build-binaries` matrix stays dependency-free — starts immediately in parallel with `publish-pypi`
- `upload-macos-x86` and `build-image` are unchanged

## Job execution order after this change

```
build ──> publish-pypi ──> github-release (dist only)
       ↑ (parallel)               ↓ (parallel after release exists)
build-binaries ──> upload-binaries    build-image
build-binary-macos-x86 ──> upload-macos-x86
```

## Test plan

- [ ] Verify `github-release` job does not list `build-binaries` in `needs`
- [ ] Verify new `upload-binaries` job lists both `github-release` and `build-binaries` in `needs`
- [ ] Verify `build-binaries` matrix has no `needs` entry
- [ ] Push a test tag and confirm release appears before binaries are attached, then binaries are added once their build completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)