### PR TITLE
fix: poll PyPI before Docker build to handle CDN propagation delay

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,6 +185,21 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Wait for uio-ai to appear on PyPI
+        run: |
+          version="${{ needs.build.outputs.version }}"
+          echo "Polling PyPI for uio-ai==$version ..."
+          for i in $(seq 1 20); do
+            if curl -sf "https://pypi.org/pypi/uio-ai/$version/json" > /dev/null; then
+              echo "Available after $i attempt(s)."
+              exit 0
+            fi
+            echo "  [$i/20] not yet available, retrying in 15s..."
+            sleep 15
+          done
+          echo "Timed out waiting for uio-ai==$version on PyPI" >&2
+          exit 1
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
Fixes #43

## Problem

`build-image` failed on the `v0.1.1-rc1` tag run with:

```
ERROR: Could not find a version that satisfies the requirement uio-ai==0.1.1rc1
(from versions: 0.1.0rc2, 0.1.0rc3)
```

`pypa/gh-action-pypi-publish` returns success as soon as the upload is accepted — before the PyPI CDN indexes the package. The Docker build then immediately runs `pip install uio-ai==<version>` against a stale CDN.

## Fix

A polling step queries `https://pypi.org/pypi/uio-ai/<version>/json` (the canonical API, faster than the CDN) before the Docker build starts. It retries up to 20 times with 15s intervals (5-minute cap). Typical propagation is under 60s, so almost always exits on the first or second attempt. If it times out, the job fails with a clear message rather than a confusing pip error.

## Test plan

- [ ] Push a tag and confirm the polling step logs "Available after N attempt(s)." before the Docker build proceeds
- [ ] Confirm Docker image is published to GHCR with correct version tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)