### PR TITLE
fix: skip PyPI upload if version already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,6 +119,7 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           attestations: true
+          skip-existing: true
 
   github-release:
     name: Create GitHub Release


### PR DESCRIPTION
## Summary

- Adds `skip-existing: true` to `pypa/gh-action-pypi-publish` so re-publishing an already-uploaded version returns success instead of a 400 error
- Needed when a tag is re-pushed after a partial pipeline failure (e.g. Docker build fails after PyPI publish succeeded — re-push would fail publish on retry)

## Test plan

- [ ] Merge and re-push `v0.1.1-rc1` tag — publish step should skip existing files and downstream jobs (Docker build) should proceed

🤖 Generated with [Claude Code](https://claude.com/claude-code)