### PR TITLE
ci: disable macos-13 binary build (runner unavailable)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,7 @@ jobs:
 
   build-binary-macos-x86:
     name: Build binary (uio-macos-x86_64)
+    if: false # disabled — macos-13 runner unavailable; see #46
     runs-on: macos-13
 
     steps:
@@ -165,6 +166,7 @@ jobs:
 
   upload-macos-x86:
     name: Upload macOS x86_64 binary to release
+    if: false # disabled — depends on build-binary-macos-x86; see #46
     needs: [github-release, build-binary-macos-x86]
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary

- Adds `if: false` to `build-binary-macos-x86` and `upload-macos-x86` in `release.yml`
- The `macos-13` (Intel x86_64) GitHub-hosted runner pool is deprecated — runs queue indefinitely with no runner ever assigned, stalling every release
- Non-destructive: job definitions are preserved for when a replacement is ready

## Test plan

- [ ] Merge and push a test tag — confirm `Build binary (uio-macos-x86_64)` and `Upload macOS x86_64 binary to release` both show as ⊘ Skipped
- [ ] Confirm all other jobs (PyPI, GitHub Release, fast binaries, Docker image) complete successfully

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)