### PR TITLE
ci: add Linux musl/Alpine binary build (#50)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,28 @@ jobs:
           name: binary-${{ matrix.asset_name }}
           path: dist/${{ matrix.asset_name }}*
 
+  build-binary-linux-musl:
+    name: Build binary (uio-linux-x86_64-musl)
+    runs-on: ubuntu-latest
+    container: python:3.12-alpine
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install build dependencies
+        run: apk add --no-cache gcc musl-dev binutils
+
+      - name: Install dependencies
+        run: pip install pyinstaller .
+
+      - name: Build binary
+        run: pyinstaller --onefile --name uio-linux-x86_64-musl uio/cli/main.py
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: binary-uio-linux-x86_64-musl
+          path: dist/uio-linux-x86_64-musl
+
   publish-pypi:
     name: Publish to PyPI
     needs: build
@@ -132,7 +154,7 @@ jobs:
 
   upload-binaries:
     name: Upload fast binaries to release
-    needs: [github-release, build-binaries]
+    needs: [github-release, build-binaries, build-binary-linux-musl]
     runs-on: ubuntu-latest
 
     steps:
@@ -159,6 +181,11 @@ jobs:
       - uses: actions/download-artifact@v8
         with:
           name: binary-uio-windows-x86_64.exe
+          path: binaries/
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: binary-uio-linux-x86_64-musl
           path: binaries/
 
       - uses: softprops/action-gh-release@v3


### PR DESCRIPTION
## Summary

- Adds a new `build-binary-linux-musl` CI job that runs inside a `python:3.12-alpine` container, installing `gcc musl-dev binutils` before building with PyInstaller
- Produces a `uio-linux-x86_64-musl` binary statically linked against musl libc, with no glibc dependency
- Wires the artifact into `upload-binaries` so it appears in GitHub release assets alongside the other platform binaries

Closes #50

## Test plan

- [ ] Trigger a release tag and confirm `uio-linux-x86_64-musl` appears in release assets
- [ ] Download the binary into a bare Alpine 3.x container and verify it runs without glibc installed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)