### PR TITLE
feat: AI Planner GitHub App provisioning guide and identity validation script (M2a)

### DIFF
--- a/docs/provisioning/ai-planner.md
+++ b/docs/provisioning/ai-planner.md
@@ -1,0 +1,155 @@
+# Provisioning Guide — AI Planner GitHub App
+
+> **M2a deliverable** for epic #53 (Enterprise GitHub Identity Architecture for AI Agents).
+> Provision the `uio-ai-planner` GitHub App with minimum permissions for issue and PR planning.
+>
+> **Prerequisite:** Permission matrix must be approved (#57) before provisioning.
+
+---
+
+## Overview
+
+The AI Planner identity handles issue creation, issue comments, and PR comments on behalf
+of uio planning agents. It has **no code write access** — it cannot push commits, create
+branches, or merge pull requests.
+
+| Identity | `github-identity` value | Primary operations |
+|---|---|---|
+| AI Planner | `planner` | Issue create/edit · Issue comments · PR comments |
+
+---
+
+## Step 1 — Create the GitHub App
+
+Navigate to your GitHub account settings and create the app:
+
+1. Go to **[github.com/settings/apps/new](https://github.com/settings/apps/new)**
+   (for a personal account) or **Settings → Developer settings → GitHub Apps → New GitHub App**
+   under an organisation.
+
+2. Fill in the registration form:
+
+   | Field | Value |
+   |---|---|
+   | **GitHub App name** | `uio-ai-planner` |
+   | **Homepage URL** | `https://github.com/jomkz/uio` |
+   | **Webhook — Active** | **Uncheck** (no webhooks needed) |
+
+3. Under **Repository permissions**, set:
+
+   | Permission | Access |
+   |---|---|
+   | Issues | **Read and write** |
+   | Pull requests | **Read and write** |
+   | Metadata | **Read-only** (mandatory) |
+   | Contents | **No access** |
+
+   All other permissions must remain **No access**.
+
+4. Under **Where can this GitHub App be installed?**, select:
+   **Only on this account** (restricts installation to `jomkz`).
+
+5. Click **Create GitHub App**.
+
+6. Note the **App ID** shown on the app settings page — you will need it shortly.
+
+---
+
+## Step 2 — Generate the private key
+
+On the app settings page, scroll to **Private keys** and click
+**Generate a private key**. GitHub downloads a `.pem` file named
+`uio-ai-planner.YYYY-MM-DD.private-key.pem`.
+
+Store it securely (see §4 below). **Never commit this file to a repository.**
+
+---
+
+## Step 3 — Install the app in pilot repositories
+
+1. On the app settings page, click **Install App** in the left sidebar.
+2. Click **Install** next to the `jomkz` account.
+3. Under **Repository access**, select **Only select repositories** and add:
+   - `jomkz/uio`
+
+   Do **not** select "All repositories" — least-privilege requires explicit repo scope.
+
+4. Click **Install**.
+
+5. After installation, note the **Installation ID** from the URL:
+   `https://github.com/settings/installations/<INSTALLATION_ID>`.
+
+---
+
+## Step 4 — Store credentials securely
+
+Add the three required environment variables to your local secrets file.
+The `~/.config/uio/secrets` convention matches the pattern used by other
+uio credential configuration:
+
+```bash
+# ~/.config/uio/secrets  (chmod 600, sourced by ~/.bashrc or ~/.zshrc)
+
+export GITHUB_APP_PLANNER_ID="<app_id_from_step_1>"
+export GITHUB_APP_PLANNER_INSTALLATION_ID="<installation_id_from_step_3>"
+export GITHUB_APP_PLANNER_PRIVATE_KEY="$HOME/.config/uio/uio-ai-planner.private-key.pem"
+```
+
+Move the downloaded `.pem` file to the path above:
+
+```bash
+mkdir -p ~/.config/uio
+mv ~/Downloads/uio-ai-planner.*.private-key.pem ~/.config/uio/uio-ai-planner.private-key.pem
+chmod 600 ~/.config/uio/uio-ai-planner.private-key.pem
+```
+
+Source the secrets file (or open a new terminal):
+
+```bash
+source ~/.config/uio/secrets
+```
+
+---
+
+## Step 5 — Validate
+
+Run the uio identity validation script to confirm authentication works and
+the permission set matches the approved matrix:
+
+```bash
+python scripts/validate_github_identity.py planner jomkz/uio
+```
+
+Expected output (abridged):
+
+```
+[planner] Authenticating...
+[planner] Token obtained — expires 2026-05-01T12:00:00Z
+[planner] Permissions granted by installation:
+    issues: write       ✓ (required: write)
+    pull_requests: write  ✓ (required: write)
+    metadata: read      ✓ (required: read)
+[planner] Forbidden permissions (must be absent):
+    contents:           ✓ absent
+[planner] Connectivity check — GET /rate_limit: 200 OK
+✅ AI Planner identity validated successfully.
+```
+
+If any permission is unexpected, revisit Step 1 and adjust the app's
+repository permission settings, then re-install the app.
+
+---
+
+## Acceptance criteria checklist
+
+- [ ] App named `uio-ai-planner` created under the `jomkz` account
+- [ ] Repository permissions: Issues R/W · PRs R/W · Metadata R · Contents: None
+- [ ] App installed in `jomkz/uio` only (not "all repositories")
+- [ ] Private key stored at `~/.config/uio/uio-ai-planner.private-key.pem` (chmod 600)
+- [ ] Env vars set: `GITHUB_APP_PLANNER_ID`, `GITHUB_APP_PLANNER_INSTALLATION_ID`, `GITHUB_APP_PLANNER_PRIVATE_KEY`
+- [ ] `python scripts/validate_github_identity.py planner jomkz/uio` passes
+
+---
+
+*See `docs/provisioning/ai-coder.md` and `docs/provisioning/ai-reviewer.md` for M2b and M2c.*
+*See `docs/github-permission-matrix.md` (M1b, #57) for the approved permission matrix.*

--- a/scripts/validate_github_identity.py
+++ b/scripts/validate_github_identity.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Validate a uio GitHub App identity after provisioning.
+
+Usage:
+    python scripts/validate_github_identity.py <role> [<owner>/<repo>]
+
+    role   — planner, coder, or reviewer
+    repo   — optional repository to probe (e.g. jomkz/uio)
+
+The script reads GITHUB_APP_<ROLE>_* environment variables, obtains an
+installation token, checks the permissions reported by the token exchange,
+and runs a lightweight connectivity probe.
+
+Exit codes:
+    0 — all checks passed
+    1 — one or more checks failed or env vars are missing
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+# Required and forbidden permissions per identity (resource: required_level | None = absent).
+# None means the permission must NOT appear with write access.
+_PERMISSION_POLICY: dict[str, dict[str, str | None]] = {
+    "planner": {
+        "issues": "write",
+        "pull_requests": "write",
+        "metadata": "read",
+        "contents": None,  # must be absent or read-only
+    },
+    "coder": {
+        "contents": "write",
+        "pull_requests": "write",
+        "metadata": "read",
+        "issues": "read",  # read-only for context; not write
+    },
+    "reviewer": {
+        "pull_requests": "write",
+        "issues": "write",
+        "metadata": "read",
+        "contents": "read",
+    },
+}
+
+_FORBIDDEN_WRITE: dict[str, list[str]] = {
+    "planner": ["contents", "actions", "administration", "secrets"],
+    "coder": ["administration", "secrets", "actions"],
+    "reviewer": ["contents", "administration", "secrets", "actions"],
+}
+
+
+def _die(msg: str) -> None:
+    print(f"\n❌ {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def _warn(msg: str) -> None:
+    print(f"  ⚠️  {msg}", file=sys.stderr)
+
+
+def _ok(msg: str) -> None:
+    print(f"  ✓  {msg}")
+
+
+def _check_env(role: str) -> None:
+    role_upper = role.upper()
+    prefix = f"GITHUB_APP_{role_upper}_"
+    missing = []
+    for suffix in ("ID", "INSTALLATION_ID", "PRIVATE_KEY"):
+        if not os.environ.get(f"{prefix}{suffix}"):
+            missing.append(f"{prefix}{suffix}")
+    if missing:
+        _die(
+            f"Missing environment variables for role '{role}':\n"
+            + "\n".join(f"    {v}" for v in missing)
+            + "\n\nSet these before running this script. "
+            "See docs/provisioning/ for setup instructions."
+        )
+
+
+def _exchange_token(role: str) -> tuple[str, str, dict[str, str]]:
+    """Return (token, expires_at, permissions_dict) via the App authentication module."""
+    # Import here so the script can report env var problems before the import path is hit.
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+    try:
+        from uio.core.github_app import GitHubAppClient
+    except ImportError:
+        _die(
+            "Could not import uio.core.github_app — run from the repo root or install the package."
+        )
+
+    client = GitHubAppClient.from_env(role)
+    app_jwt = client._make_jwt()
+
+    url = f"https://api.github.com/app/installations/{client.installation_id}/access_tokens"
+    req = urllib.request.Request(
+        url,
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {app_jwt}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "uio-validate-identity/1.0",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            body = json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode(errors="replace")
+        _die(f"Token exchange failed (HTTP {exc.code}): {detail}")
+    except OSError as exc:
+        _die(f"Network error during token exchange: {exc}")
+
+    token = body.get("token", "")
+    expires_at = body.get("expires_at", "")
+    permissions = body.get("permissions", {})
+    return token, expires_at, permissions
+
+
+def _check_permissions(role: str, permissions: dict[str, str]) -> bool:
+    policy = _PERMISSION_POLICY.get(role, {})
+    forbidden_write = _FORBIDDEN_WRITE.get(role, [])
+    passed = True
+
+    print(f"\n[{role}] Permission check:")
+    for resource, required_level in policy.items():
+        actual = permissions.get(resource)
+        if required_level is None:
+            # Must not be write.
+            if actual == "write":
+                _warn(f"{resource}: got 'write' — must NOT have write access")
+                passed = False
+            else:
+                _ok(f"{resource}: '{actual or 'absent'}' (write not permitted — OK)")
+        else:
+            if actual == required_level or (
+                required_level == "read" and actual in ("read", "write")
+            ):
+                _ok(f"{resource}: '{actual}' (required: {required_level})")
+            else:
+                _warn(f"{resource}: got '{actual or 'absent'}' — expected '{required_level}'")
+                passed = False
+
+    print(f"\n[{role}] Forbidden write-access check:")
+    for resource in forbidden_write:
+        actual = permissions.get(resource)
+        if actual == "write":
+            _warn(f"{resource}: has 'write' access — this identity must NOT have this permission")
+            passed = False
+        else:
+            _ok(f"{resource}: '{actual or 'absent'}' — write access absent")
+
+    return passed
+
+
+def _connectivity_check(token: str, repo: str | None) -> bool:
+    passed = True
+    print("\n[connectivity] GET /rate_limit:")
+    req = urllib.request.Request(
+        "https://api.github.com/rate_limit",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "uio-validate-identity/1.0",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            _ok(f"HTTP {resp.status} — token is valid")
+    except urllib.error.HTTPError as exc:
+        _warn(f"GET /rate_limit returned HTTP {exc.code}")
+        passed = False
+    except OSError as exc:
+        _warn(f"GET /rate_limit network error: {exc}")
+        passed = False
+
+    if repo:
+        print(f"\n[connectivity] GET /repos/{repo}:")
+        req2 = urllib.request.Request(
+            f"https://api.github.com/repos/{repo}",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "User-Agent": "uio-validate-identity/1.0",
+            },
+        )
+        try:
+            with urllib.request.urlopen(req2, timeout=10) as resp:
+                body = json.loads(resp.read())
+                _ok(f"HTTP {resp.status} — repo '{body.get('full_name')}' accessible")
+        except urllib.error.HTTPError as exc:
+            _warn(f"GET /repos/{repo} returned HTTP {exc.code}")
+            passed = False
+        except OSError as exc:
+            _warn(f"GET /repos/{repo} network error: {exc}")
+            passed = False
+
+    return passed
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(1)
+
+    role = sys.argv[1].lower()
+    repo = sys.argv[2] if len(sys.argv) > 2 else None
+
+    valid_roles = ("planner", "coder", "reviewer")
+    if role not in valid_roles:
+        _die(f"Unknown role '{role}'. Must be one of: {', '.join(valid_roles)}")
+
+    print(f"[{role}] Checking environment variables...")
+    _check_env(role)
+    _ok("All required env vars are set")
+
+    print(f"\n[{role}] Authenticating with GitHub App...")
+    token, expires_at, permissions = _exchange_token(role)
+    _ok(f"Token obtained — expires {expires_at}")
+
+    perms_passed = _check_permissions(role, permissions)
+    conn_passed = _connectivity_check(token, repo)
+
+    print()
+    if perms_passed and conn_passed:
+        print(f"✅ {role.title()} GitHub App identity validated successfully.")
+        sys.exit(0)
+    else:
+        print(
+            "❌ Validation failed — review warnings above and check the app's permission\n"
+            "   settings at https://github.com/settings/apps",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **`docs/provisioning/ai-planner.md`** — step-by-step guide to create the `uio-ai-planner` GitHub App: exact permission settings in the GitHub UI, private key storage pattern (`~/.config/uio/`), env var layout, and an acceptance criteria checklist
- **`scripts/validate_github_identity.py`** — generic validation script covering all three roles (`planner`, `coder`, `reviewer`); checks env vars, obtains an installation token, validates the permissions reported by GitHub match the approved matrix, checks forbidden write-access is absent, and runs a live connectivity probe

The script is written generically so it serves M2b (#59) and M2c (#60) without modification — just swap the role argument.

Closes #58.

## Test plan

- [ ] Run `python scripts/validate_github_identity.py` (no args) — confirm usage text prints
- [ ] Run `python scripts/validate_github_identity.py badRole` — confirm exit 1 + error message
- [ ] Run `python scripts/validate_github_identity.py planner` (no env vars set) — confirm it lists the three missing vars
- [ ] After manual app provisioning: run `python scripts/validate_github_identity.py planner jomkz/uio` and confirm all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)