### PR TITLE
feat: github-identity validate warnings and runner hard-fail (M3b)

### DIFF
--- a/docs/04-frontmatter.md
+++ b/docs/04-frontmatter.md
@@ -38,6 +38,7 @@ tools:
   - terminal
   - github
 timeout: 300
+github-identity: planner
 ---
 ```
 
@@ -48,6 +49,7 @@ timeout: 300
 | `complexity` | `large` \| `small` | No | `small` | Model tier selection — see below |
 | `tools` | list of strings | No | — | Informational only; documents which tool families the agent uses; not enforced by the runtime |
 | `timeout` | integer (seconds) | No | 300 | Per-command shell timeout for `run_command` calls |
+| `github-identity` | `planner` \| `coder` \| `reviewer` | No | — | GitHub App identity to use for this agent's GitHub operations — see below |
 
 ### Complexity tier resolution
 
@@ -67,6 +69,32 @@ Once the tier is resolved, the model is selected based on the provider:
 | `ollama` | `qwen2.5-coder:32b` | `qwen2.5-coder:7b` |
 
 Use `complexity: large` for multi-step analysis tasks, code review, or anything where reasoning quality matters more than cost. Use `complexity: small` (the default) for most agents.
+
+### `github-identity`
+
+When set, uio obtains a short-lived GitHub App installation token for the named identity before the agent's tool loop starts, and exports it as `GH_TOKEN`. Both the `gh` CLI and the GitHub MCP server read `GH_TOKEN`, so all GitHub operations in the run execute as the declared App identity rather than the user's personal account.
+
+| Value | Identity | Permitted GitHub operations |
+|---|---|---|
+| `planner` | AI Planner | Issue create/edit · Issue comments · PR comments |
+| `coder` | AI Coder | Branch create · Commit/push · PR create |
+| `reviewer` | AI Reviewer | PR review · Inline PR comments · Diff summary |
+
+**Prerequisites:** three environment variables must be set for the chosen identity:
+
+```
+GITHUB_APP_PLANNER_ID               — App's numeric ID
+GITHUB_APP_PLANNER_INSTALLATION_ID  — Installation ID for the target repo
+GITHUB_APP_PLANNER_PRIVATE_KEY      — PEM key (literal or path to .pem file)
+```
+
+Replace `PLANNER` with `CODER` or `REVIEWER` for the other identities.
+
+If the env vars are absent at run time, uio emits a warning and falls back to `GITHUB_PERSONAL_ACCESS_TOKEN` / `GH_TOKEN`. An invalid identity value (anything other than `planner`, `coder`, `reviewer`) causes a hard error at startup.
+
+`uio validate` warns (non-fatally) when `github-identity` is declared but the corresponding env vars are not set, so you can catch configuration drift in CI.
+
+See `docs/provisioning/` for setup instructions and `docs/github-permission-matrix.md` for the approved permission model.
 
 ---
 
@@ -150,10 +178,12 @@ When run as `uio prompt run ask-docs "what does the cost ledger store?"`, the fi
 Known keys (do not produce warnings):
 
 ```
-name  description  complexity  tools  timeout  argument-hint  invokable
+name  description  complexity  tools  timeout  argument-hint  invokable  github-identity
 ```
 
-Any other key produces a warning. This is intentional — it catches typos like `Complexity: large` (capitalised) that would silently be ignored.
+Any other key produces an error. This is intentional — it catches typos like `Complexity: large` (capitalised) that would silently be ignored.
+
+In addition, `uio validate` emits a **non-fatal warning** (exits zero) when `github-identity` is declared but the corresponding `GITHUB_APP_<ROLE>_*` env vars are absent. This flags configuration drift without blocking CI pipelines that run without App credentials.
 
 ---
 

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -240,3 +240,43 @@ def test_parse_iso8601_invalid_returns_fallback() -> None:
     before = time.time()
     ts = _parse_iso8601("not-a-date")
     assert ts >= before
+
+
+# ---------------------------------------------------------------------------
+# _maybe_inject_github_identity — runner integration
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_role_exits(tmp_path, monkeypatch):
+    """An unsupported github-identity value must produce a hard error at startup."""
+    import pytest
+    from uio.core.runner import _maybe_inject_github_identity
+
+    with pytest.raises(SystemExit) as exc_info:
+        _maybe_inject_github_identity({"github-identity": "supervillain"})
+    assert exc_info.value.code != 0
+    assert "supervillain" in str(exc_info.value.code)
+
+
+def test_no_identity_is_noop(monkeypatch):
+    """When github-identity is absent the function is a no-op."""
+    from uio.core.runner import _maybe_inject_github_identity
+
+    original = dict(os.environ)
+    _maybe_inject_github_identity({})
+    assert os.environ == original
+
+
+def test_missing_env_vars_falls_back(monkeypatch, capsys):
+    """When github-identity is valid but env vars are absent, fall back gracefully."""
+    from uio.core.runner import _maybe_inject_github_identity
+
+    for var in (
+        "GITHUB_APP_CODER_ID",
+        "GITHUB_APP_CODER_INSTALLATION_ID",
+        "GITHUB_APP_CODER_PRIVATE_KEY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    _maybe_inject_github_identity({"github-identity": "coder"})
+    captured = capsys.readouterr()
+    assert "falling back" in captured.err

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3,7 +3,7 @@
 import textwrap
 
 
-from uio.schema.parser import parse_definition_file, validate_definition
+from uio.schema.parser import check_identity_env, parse_definition_file, validate_definition
 
 
 def test_standard_frontmatter(tmp_path):
@@ -99,6 +99,55 @@ def test_validate_unknown_key_warns(tmp_path):
     fm, _ = parse_definition_file(str(f))
     errors = validate_definition(str(f), fm)
     assert any("weird_key" in e for e in errors)
+
+
+def test_validate_github_identity_valid(tmp_path):
+    f = tmp_path / "planner.agent.md"
+    f.write_text("---\nname: P\ndescription: D.\ngithub-identity: planner\n---\nBody.")
+    fm, _ = parse_definition_file(str(f))
+    errors = validate_definition(str(f), fm)
+    assert errors == []
+
+
+def test_validate_github_identity_invalid_value(tmp_path):
+    f = tmp_path / "bad.agent.md"
+    f.write_text("---\nname: P\ndescription: D.\ngithub-identity: wizard\n---\nBody.")
+    fm, _ = parse_definition_file(str(f))
+    errors = validate_definition(str(f), fm)
+    assert any("wizard" in e for e in errors)
+
+
+def test_check_identity_env_no_identity(tmp_path):
+    f = tmp_path / "no-identity.agent.md"
+    f.write_text("---\nname: A\ndescription: D.\n---\nBody.")
+    fm, _ = parse_definition_file(str(f))
+    assert check_identity_env(str(f), fm) == []
+
+
+def test_check_identity_env_vars_absent(tmp_path, monkeypatch):
+    for var in (
+        "GITHUB_APP_PLANNER_ID",
+        "GITHUB_APP_PLANNER_INSTALLATION_ID",
+        "GITHUB_APP_PLANNER_PRIVATE_KEY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    f = tmp_path / "planner.agent.md"
+    f.write_text("---\nname: P\ndescription: D.\ngithub-identity: planner\n---\nBody.")
+    fm, _ = parse_definition_file(str(f))
+    warnings = check_identity_env(str(f), fm)
+    assert len(warnings) == 1
+    assert "GITHUB_APP_PLANNER_ID" in warnings[0]
+    assert "planner" in warnings[0]
+
+
+def test_check_identity_env_vars_present(tmp_path, monkeypatch):
+    monkeypatch.setenv("GITHUB_APP_REVIEWER_ID", "123")
+    monkeypatch.setenv("GITHUB_APP_REVIEWER_INSTALLATION_ID", "456")
+    monkeypatch.setenv("GITHUB_APP_REVIEWER_PRIVATE_KEY", "fake-pem")
+    f = tmp_path / "reviewer.agent.md"
+    f.write_text("---\nname: R\ndescription: D.\ngithub-identity: reviewer\n---\nBody.")
+    fm, _ = parse_definition_file(str(f))
+    assert check_identity_env(str(f), fm) == []
 
 
 def test_argument_hint_list_field(tmp_path):

--- a/uio/cli/main.py
+++ b/uio/cli/main.py
@@ -18,7 +18,7 @@ from uio.cli.registry import registry_group
 from uio.cli.skill import skill_group
 from uio.config import load_config
 from uio.examples import EXAMPLES
-from uio.schema.parser import parse_definition_file, validate_definition
+from uio.schema.parser import check_identity_env, parse_definition_file, validate_definition
 
 _EXAMPLE_AGENT = """\
 ---
@@ -164,6 +164,7 @@ def validate_cmd() -> None:
     ]
 
     errors: list[str] = []
+    warnings: list[str] = []
     total = 0
 
     for directory, pattern in patterns:
@@ -175,10 +176,14 @@ def validate_cmd() -> None:
                 errors.append(f"{path}: could not parse: {e}")
                 continue
             errors.extend(validate_definition(path, fm))
+            warnings.extend(check_identity_env(path, fm))
 
     if total == 0:
         click.echo("  No definition files found.")
         return
+
+    for warn in warnings:
+        click.echo(f"  WARNING: {warn}", err=True)
 
     if errors:
         for err in errors:
@@ -186,7 +191,10 @@ def validate_cmd() -> None:
         click.echo(f"\n{len(errors)} error(s) in {total} file(s).", err=True)
         sys.exit(1)
 
-    click.echo(f"  OK — {total} definition file(s) valid.")
+    if warnings:
+        click.echo(f"  OK — {total} definition file(s) valid ({len(warnings)} warning(s)).")
+    else:
+        click.echo(f"  OK — {total} definition file(s) valid.")
 
 
 @main.command("completion")

--- a/uio/core/runner.py
+++ b/uio/core/runner.py
@@ -6,7 +6,12 @@ import os
 import sys
 
 from uio.core.clients import make_client
-from uio.core.github_app import GitHubAppError, env_vars_present, get_token_for_identity
+from uio.core.github_app import (
+    KNOWN_ROLES,
+    GitHubAppError,
+    env_vars_present,
+    get_token_for_identity,
+)
 from uio.core.ledger import DEFAULT_LEDGER_PATH, write_cost_ledger
 from uio.core.mcp import make_mcp_clients
 from uio.core.routing import infer_complexity, select_model, select_provider_chain
@@ -29,6 +34,12 @@ def _maybe_inject_github_identity(frontmatter: dict) -> None:
     role = frontmatter.get("github-identity")
     if not role:
         return
+
+    if role not in KNOWN_ROLES:
+        sys.exit(
+            f"Error: unsupported 'github-identity' value '{role}'"
+            f" — must be one of {sorted(KNOWN_ROLES)}"
+        )
 
     if not env_vars_present(role):
         print(

--- a/uio/schema/parser.py
+++ b/uio/schema/parser.py
@@ -52,3 +52,25 @@ def validate_definition(path: str, frontmatter: dict) -> list[str]:
             )
 
     return errors
+
+
+def check_identity_env(path: str, frontmatter: dict) -> list[str]:
+    """Return warning strings when github-identity is declared but env vars are absent.
+
+    Non-fatal — the agent can still run using the fallback credential.
+    """
+    from uio.core.github_app import KNOWN_ROLES, env_vars_present
+
+    identity = frontmatter.get("github-identity")
+    if not identity or identity not in KNOWN_ROLES:
+        return []
+
+    if not env_vars_present(identity):
+        role_upper = identity.upper()
+        prefix = f"GITHUB_APP_{role_upper}_"
+        missing = [f"{prefix}{s}" for s in ("ID", "INSTALLATION_ID", "PRIVATE_KEY")]
+        return [
+            f"{path}: 'github-identity: {identity}' declared but env vars not set: "
+            + ", ".join(missing)
+        ]
+    return []


### PR DESCRIPTION
## Summary

- **`uio/schema/parser.py`** — new `check_identity_env()` function that returns a non-fatal warning string when `github-identity` is declared but the corresponding `GITHUB_APP_<ROLE>_*` env vars are absent
- **`uio/cli/main.py`** — `uio validate` now calls `check_identity_env` per file; warnings print with `WARNING:` prefix and exit 0; the OK line appends a warning count when any are present
- **`uio/core/runner.py`** — `_maybe_inject_github_identity` now hard-fails (`sys.exit`) on any `github-identity` value that is not `planner`, `coder`, or `reviewer`, rather than silently falling back
- **`docs/04-frontmatter.md`** — documents `github-identity` in the agent fields table, adds a dedicated section covering permitted values, env var layout, fallback behaviour, and the validate warning; updates known-keys list
- **`tests/`** — 6 new tests: valid identity passes validation, invalid value caught, `check_identity_env` with env absent/present, runner no-op without identity, runner hard-fail on bad value, runner graceful fallback when env vars missing

Closes #62.

## Test plan

- [ ] `pytest` — all 197 tests pass
- [ ] `uio validate` with a definition declaring `github-identity: planner` and no env vars set → exits 0, prints `WARNING:`
- [ ] `uio validate` with `github-identity: wizard` → exits 1, prints `ERROR:`
- [ ] Agent with `github-identity: wizard` → `sys.exit` with clear message before the tool loop starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)