### PR TITLE
docs: monitoring, audit, and incident response runbooks (M5c #70)

### DIFF
--- a/docs/runbooks/github-app-audit.md
+++ b/docs/runbooks/github-app-audit.md
@@ -1,0 +1,89 @@
+# Runbook — GitHub App Audit
+
+> **M5c deliverable** for epic #53 (Enterprise GitHub Identity Architecture for AI Agents).
+> Covers logging requirements and audit review for actions taken by the three uio GitHub
+> App identities (AI Planner, AI Coder, AI Reviewer).
+
+---
+
+## What uio logs
+
+The uio runner emits a structured log line whenever it authenticates as a GitHub App
+identity. Log output goes to `stderr` and is captured by whatever process invokes
+`uio agent run`.
+
+### Log fields
+
+| Field | Example | Description |
+|---|---|---|
+| `identity` | `planner` | The `github-identity` value from the agent frontmatter |
+| `app_name` | `uio-ai-planner` | Display name of the GitHub App |
+| `agent` | `github-planner` | Agent definition filename (without extension) |
+| `action` | `token_exchange` | Type of authentication event |
+| `repo` | `jomkz/uio` | Repository the token was scoped to (from `GITHUB_APP_*_INSTALLATION_ID`) |
+| `token_expires` | `2026-05-01T12:34:00Z` | ISO-8601 expiry of the installation token |
+| `timestamp` | `2026-05-01T12:24:00Z` | UTC time of the event |
+
+### Capturing logs
+
+Redirect `stderr` to a log file when running agents in production:
+
+```bash
+uio agent run github-planner "Create issue in jomkz/uio ..." 2>>~/.local/share/uio/audit.log
+```
+
+Or capture both streams with timestamps using `ts` (from `moreutils`):
+
+```bash
+uio agent run github-coder "..." 2>&1 | ts '[%Y-%m-%dT%H:%M:%S]' >>~/.local/share/uio/audit.log
+```
+
+---
+
+## GitHub audit log review
+
+GitHub records all API actions taken by an App installation in the organisation or
+account audit log. For a personal account (`jomkz`), use the GitHub web UI or API.
+
+### Web UI review
+
+1. Go to **github.com → Settings → Security log** (personal account) or
+   **github.com/organisations/<org> → Settings → Audit log** (organisation).
+2. Filter by actor: type `actor:app/uio-ai-planner` (or `uio-ai-coder`, `uio-ai-reviewer`).
+3. Set a date range covering the last 90 days.
+4. Review the event list. Expected event types:
+   - `issues.create`, `issues.comment` — AI Planner
+   - `pull_request.create`, `git.push` — AI Coder
+   - `pull_request.comment` — AI Reviewer
+5. Flag any event type not in the expected list and open an incident issue (see
+   `docs/runbooks/github-app-incident-response.md`).
+
+### API review
+
+```bash
+# Fetch the last 100 audit events for the AI Planner app
+gh api "/users/jomkz/events" --jq '.[] | select(.actor.login | startswith("uio-ai-"))' | head -50
+
+# Fetch repo-level events for a specific app
+gh api "repos/jomkz/uio/events" \
+  --jq '.[] | select(.actor.login | startswith("uio-ai-")) | {type, created_at, actor: .actor.login, repo: .repo.name}'
+```
+
+---
+
+## Quarterly audit checklist
+
+Run this during each quarterly governance review (see `docs/governance.md`):
+
+- [ ] Review the last 90 days of GitHub audit log for each of the three app identities.
+- [ ] Confirm no event types outside the expected set occurred.
+- [ ] Confirm no action was taken against a repository outside the approved installation scope.
+- [ ] Review the local `audit.log` (if captured) for token exchange frequency anomalies.
+- [ ] Confirm all tokens expired normally (no manual revocation events).
+- [ ] If anomalies are found, open an incident issue immediately (see
+      `docs/runbooks/github-app-incident-response.md`).
+
+---
+
+*See `docs/runbooks/github-app-incident-response.md` for incident escalation steps.*
+*See `docs/governance.md` for the quarterly review process.*

--- a/docs/runbooks/github-app-credential-rotation.md
+++ b/docs/runbooks/github-app-credential-rotation.md
@@ -1,0 +1,142 @@
+# Runbook — GitHub App Credential Rotation
+
+> **M5c deliverable** for epic #53 (Enterprise GitHub Identity Architecture for AI Agents).
+> Procedure for rotating the private key of a uio GitHub App identity without service
+> interruption.
+
+---
+
+## When to rotate
+
+| Trigger | Timeline |
+|---|---|
+| Routine annual rotation | Within 30 days of the 12-month anniversary of the last rotation |
+| Quarterly review finding (key > 12 months old) | Within 2 weeks of the review |
+| P3 incident (local exposure, no confirmed exfiltration) | Within 24 hours |
+| P1/P2 incident | Immediately — follow `docs/runbooks/github-app-incident-response.md` instead |
+
+---
+
+## How GitHub App key rotation works
+
+GitHub Apps support **multiple private keys simultaneously**. This means:
+
+1. Generate and upload the new key — both old and new keys are valid.
+2. Deploy the new key to all machines using it.
+3. Delete the old key — only the new key is valid.
+
+There is **no downtime** if you follow this order. Never delete the old key before
+deploying the new one.
+
+---
+
+## Rotation procedure
+
+### Step 1 — Generate a new private key (keep the old one active)
+
+1. Go to the app settings page:
+   - AI Planner: `github.com/settings/apps/uio-ai-planner`
+   - AI Coder: `github.com/settings/apps/uio-ai-coder`
+   - AI Reviewer: `github.com/settings/apps/uio-ai-reviewer`
+
+2. Under **Private keys**, click **Generate a private key**.
+   GitHub downloads `uio-ai-<role>.YYYY-MM-DD.private-key.pem`.
+
+   At this point, **both the old key and the new key are valid**. The old key continues
+   to work — no agent runs will be interrupted.
+
+### Step 2 — Store and permission the new key
+
+```bash
+# Move to the standard location (use a temp name first)
+mv ~/Downloads/uio-ai-<role>.*.private-key.pem \
+   ~/.config/uio/uio-ai-<role>.private-key.new.pem
+chmod 600 ~/.config/uio/uio-ai-<role>.private-key.new.pem
+```
+
+### Step 3 — Validate the new key before activating it
+
+```bash
+# Temporarily point the env var at the new key
+GITHUB_APP_<ROLE>_PRIVATE_KEY=~/.config/uio/uio-ai-<role>.private-key.new.pem \
+  python scripts/validate_github_identity.py <role> jomkz/uio
+```
+
+If validation fails (token exchange error, permission mismatch), stop here. Do not
+rename or delete the old key. Investigate the failure and retry from Step 1.
+
+### Step 4 — Activate the new key
+
+```bash
+# Replace the active key file atomically
+mv ~/.config/uio/uio-ai-<role>.private-key.new.pem \
+   ~/.config/uio/uio-ai-<role>.private-key.pem
+```
+
+The `GITHUB_APP_<ROLE>_PRIVATE_KEY` env var already points to this path — no env
+change is needed. Source the secrets file to pick up any env changes:
+
+```bash
+source ~/.config/uio/secrets
+```
+
+### Step 5 — Validate with the active key
+
+```bash
+python scripts/validate_github_identity.py <role> jomkz/uio
+```
+
+Confirm output shows `✅` before proceeding.
+
+### Step 6 — Delete the old key from GitHub
+
+1. Return to the app settings page.
+2. Under **Private keys**, identify the old key by its fingerprint or creation date.
+3. Click **Delete** next to the old key.
+4. Confirm deletion.
+
+The old key is now invalid. Any cached JWTs signed with it will be rejected after their
+9-minute TTL expires naturally.
+
+### Step 7 — Record the rotation
+
+Update the **Last key rotation** field in the app documentation record in
+`docs/governance.md` by opening a PR:
+
+```
+**Last key rotation:** YYYY-MM-DD
+```
+
+Post a comment on the quarterly review issue (or open one if outside the review cycle)
+noting the rotation date and reason.
+
+---
+
+## Multi-machine deployment
+
+If the private key is used on more than one machine (e.g., a CI runner and a developer
+workstation):
+
+1. Complete Steps 1–3 on **all machines** before executing Step 4 on any of them.
+2. Execute Steps 4–5 on all machines.
+3. Then execute Step 6 (delete old key) only after all machines have validated Step 5.
+
+---
+
+## Verifying key age
+
+Check the key creation date from the GitHub UI or via the API:
+
+```bash
+gh api /app/installations --jq '.[0].app_id'
+# Then visit: github.com/settings/apps/<app-name> → Private keys
+```
+
+The key creation date is shown next to each key's fingerprint. Keys older than 12 months
+should be flagged in the quarterly review.
+
+---
+
+*See `docs/runbooks/github-app-incident-response.md` for emergency rotation (P1/P2).*
+*See `docs/runbooks/github-app-emergency-disable.md` for fast-path disable.*
+*See `docs/governance.md` for the quarterly review process.*

--- a/docs/runbooks/github-app-emergency-disable.md
+++ b/docs/runbooks/github-app-emergency-disable.md
@@ -1,0 +1,150 @@
+# Runbook — GitHub App Emergency Disable
+
+> **M5c deliverable** for epic #53 (Enterprise GitHub Identity Architecture for AI Agents).
+> Fast-path procedure for immediately revoking a uio GitHub App installation when
+> suspicious activity is detected or a security incident is declared.
+
+---
+
+## When to use this runbook
+
+Use this runbook when you need to **stop all GitHub API activity from an App identity
+immediately** and cannot wait to investigate first. Examples:
+
+- Audit log shows unexpected repository access or unexpected event types
+- A private key file has been confirmed exfiltrated
+- An agent is running amok (creating many issues/PRs/commits unexpectedly)
+- A security researcher reports a vulnerability in the GitHub App identity chain
+
+For confirmed P1/P2 incidents requiring a full post-mortem, continue into
+`docs/runbooks/github-app-incident-response.md` after completing this runbook.
+
+---
+
+## Fast-path disable (< 2 minutes)
+
+### Option A — Suspend the installation (recommended)
+
+Suspending an installation revokes all currently-valid tokens and prevents new tokens
+from being issued, without deleting the App or its configuration. This is reversible.
+
+```bash
+# Suspend AI Planner
+gh api installations/$GITHUB_APP_PLANNER_INSTALLATION_ID/suspended --method PUT
+
+# Suspend AI Coder
+gh api installations/$GITHUB_APP_CODER_INSTALLATION_ID/suspended --method PUT
+
+# Suspend AI Reviewer
+gh api installations/$GITHUB_APP_REVIEWER_INSTALLATION_ID/suspended --method PUT
+```
+
+Verify suspension:
+
+```bash
+gh api installations/$GITHUB_APP_PLANNER_INSTALLATION_ID \
+  --jq '{suspended_at, suspended_by: .suspended_by.login}'
+```
+
+Expected: `suspended_at` is a recent timestamp.
+
+Any currently running `uio agent run` process will fail on its next API call (within
+seconds to minutes, depending on cached token TTL). Kill the process if needed:
+
+```bash
+pkill -f "uio agent run"
+```
+
+### Option B — Delete the private key (irreversible until new key generated)
+
+If you cannot access the installation ID env vars (e.g., secrets file is inaccessible),
+delete the private key directly from the GitHub UI:
+
+1. Go to `github.com/settings/apps/uio-ai-planner` (or coder / reviewer).
+2. Under **Private keys**, click **Delete** next to the active key.
+3. Confirm deletion.
+
+Any JWT signed with the deleted key will be rejected immediately, and no new JWTs can
+be issued until a new key is generated.
+
+### Option C — Uninstall the app from the repository
+
+If you only need to stop the app from acting on a specific repository (not all repos):
+
+```bash
+# List installations to find the installation ID for the specific repo
+gh api app/installations --jq '.[] | {id, account: .account.login}'
+
+# Delete the installation for that repo
+gh api installations/<INSTALLATION_ID> --method DELETE
+```
+
+**Warning:** This permanently removes the installation. The app must be reinstalled
+(including approval per the installation policy) to restore access.
+
+---
+
+## After the emergency disable
+
+1. **Open an incident issue immediately:**
+
+   ```bash
+   gh issue create --repo jomkz/uio \
+     --label "ai-governance,incident" \
+     --title "Emergency disable: <identity> — <date>" \
+     --body "**Disabled at:** $(date -u '+%Y-%m-%dT%H:%M:%SZ')
+   **Reason:** <brief description>
+   **Method used:** Option A / B / C (see runbook)
+   **Follow-up:** See docs/runbooks/github-app-incident-response.md"
+   ```
+
+2. **Do not re-enable** until the incident issue has been investigated and a root cause
+   documented (see `docs/runbooks/github-app-incident-response.md`).
+
+3. **To re-enable** after investigation is complete:
+
+   ```bash
+   # Unsuspend (reverses Option A)
+   gh api installations/$GITHUB_APP_<ROLE>_INSTALLATION_ID/suspended --method DELETE
+
+   # Validate
+   python scripts/validate_github_identity.py <role> jomkz/uio
+   ```
+
+---
+
+## Quick reference — installation IDs
+
+Your installation IDs are stored in `~/.config/uio/secrets`:
+
+```bash
+grep INSTALLATION_ID ~/.config/uio/secrets
+```
+
+If the secrets file is unavailable, retrieve installation IDs from GitHub:
+
+```bash
+gh api /app/installations --jq '.[] | {id, account: .account.login, app_id}'
+```
+
+Note: this requires the App's JWT, which requires the private key. If the private key
+is also unavailable, use **Option C** (delete via GitHub UI) instead.
+
+---
+
+## Testing this runbook (non-production apps only)
+
+Before the M6 pilot launch, test the emergency disable procedure against a non-production
+copy of one of the apps:
+
+1. Create a test GitHub App with identical permissions.
+2. Run `uio agent run github-planner "..."` in the background.
+3. Execute Option A (suspend) and confirm the running process fails within 5 minutes.
+4. Unsuspend and validate.
+5. Document the test result in the M6 pilot issue.
+
+---
+
+*See `docs/runbooks/github-app-incident-response.md` for the full P1/P2 incident process.*
+*See `docs/runbooks/github-app-credential-rotation.md` for key rotation after re-enable.*
+*See `docs/governance.md` for the escalation path and quarterly review process.*

--- a/docs/runbooks/github-app-incident-response.md
+++ b/docs/runbooks/github-app-incident-response.md
@@ -1,0 +1,142 @@
+# Runbook — GitHub App Incident Response
+
+> **M5c deliverable** for epic #53 (Enterprise GitHub Identity Architecture for AI Agents).
+> Steps for responding to credential compromise or app misuse for the three uio GitHub
+> App identities (AI Planner, AI Coder, AI Reviewer).
+
+---
+
+## Incident severity tiers
+
+| Tier | Trigger | Target response |
+|---|---|---|
+| **P1 — Critical** | Private key confirmed stolen or exposed; malicious actions observed in audit log | Immediate (within 1 hour) |
+| **P2 — High** | Suspicious audit log events; unexpected permission use; app installed in unintended repo | Same day (within 4 hours) |
+| **P3 — Low** | Credential file exposed locally but not exfiltrated; misconfigured permissions detected | Next business day |
+
+---
+
+## P1 — Immediate response (compromise confirmed)
+
+Execute these steps in order. Do not skip ahead.
+
+### Step 1 — Suspend the app installation immediately
+
+```bash
+# Suspend installation — replaces all tokens and blocks new ones
+gh api installations/<INSTALLATION_ID>/suspended --method PUT
+```
+
+Replace `<INSTALLATION_ID>` with the value from `GITHUB_APP_*_INSTALLATION_ID`:
+
+```bash
+# Planner
+gh api installations/$GITHUB_APP_PLANNER_INSTALLATION_ID/suspended --method PUT
+
+# Coder
+gh api installations/$GITHUB_APP_CODER_INSTALLATION_ID/suspended --method PUT
+
+# Reviewer
+gh api installations/$GITHUB_APP_REVIEWER_INSTALLATION_ID/suspended --method PUT
+```
+
+### Step 2 — Revoke the private key
+
+1. Go to **github.com/settings/apps/uio-ai-planner** (or coder / reviewer).
+2. Under **Private keys**, click **Delete** next to the compromised key.
+3. Confirm deletion. All JWTs signed with this key become immediately invalid.
+
+### Step 3 — Open an incident issue
+
+```bash
+gh issue create --repo jomkz/uio \
+  --label "ai-governance,security,incident" \
+  --title "INCIDENT [P1]: GitHub App credential compromise — <identity>" \
+  --body "## Incident report
+
+**Identity affected:** <planner | coder | reviewer>
+**Detected:** $(date -u '+%Y-%m-%dT%H:%M:%SZ')
+**Detected by:** <name>
+**Initial indicators:** <describe what was observed>
+
+## Actions taken
+- [ ] App installation suspended (Step 1)
+- [ ] Private key revoked (Step 2)
+- [ ] Audit log review in progress (Step 4)
+- [ ] New key generated and deployed (Step 5)
+
+## Audit findings
+_Fill in after Step 4_"
+```
+
+### Step 4 — Review audit log for blast radius
+
+```bash
+# Review all actions by the compromised identity in the last 30 days
+gh api "repos/jomkz/uio/events" \
+  --jq '.[] | select(.actor.login | startswith("uio-ai-")) | {type, created_at, actor: .actor.login}'
+```
+
+Document any unauthorised actions (unexpected repos, unexpected event types, unexpected
+volume) in the incident issue. If code was pushed by AI Coder to unexpected locations,
+review those commits immediately.
+
+### Step 5 — Generate a new private key and redeploy
+
+1. Go to the app settings page.
+2. Under **Private keys**, click **Generate a private key**.
+3. Download and store the new key:
+
+```bash
+mv ~/Downloads/uio-ai-<role>.*.private-key.pem ~/.config/uio/uio-ai-<role>.private-key.pem
+chmod 600 ~/.config/uio/uio-ai-<role>.private-key.pem
+```
+
+4. Update the `GITHUB_APP_<ROLE>_PRIVATE_KEY` env var if the filename changed.
+5. Source the secrets file: `source ~/.config/uio/secrets`
+
+### Step 6 — Unsuspend the installation
+
+```bash
+gh api installations/$GITHUB_APP_<ROLE>_INSTALLATION_ID/suspended --method DELETE
+```
+
+### Step 7 — Validate
+
+```bash
+python scripts/validate_github_identity.py <role> jomkz/uio
+```
+
+Confirm the output shows `✅` before returning to normal operations.
+
+### Step 8 — Post-incident review
+
+Within 5 business days of the incident, post a post-mortem to the incident issue
+covering: timeline, root cause, corrective actions, and any governance rule changes.
+Close the issue after the post-mortem is complete.
+
+---
+
+## P2 — Suspicious activity (unconfirmed compromise)
+
+1. Do **not** suspend the installation yet — investigate first to avoid false-positive
+   disruption.
+2. Open a P2 incident issue using the template above (change label to `incident`).
+3. Review the audit log (see `docs/runbooks/github-app-audit.md`).
+4. If suspicious activity is confirmed, escalate to P1 immediately.
+5. If activity is explained (misconfiguration, test run), document the explanation and
+   close the issue.
+
+---
+
+## P3 — Local exposure (no exfiltration)
+
+1. Rotate the private key (see `docs/runbooks/github-app-credential-rotation.md`).
+2. Document the incident in the quarterly review issue.
+3. Review local filesystem access controls: `ls -la ~/.config/uio/`.
+
+---
+
+*See `docs/runbooks/github-app-credential-rotation.md` for credential rotation steps.*
+*See `docs/runbooks/github-app-emergency-disable.md` for the fast-path disable procedure.*
+*See `docs/runbooks/github-app-audit.md` for audit log review steps.*


### PR DESCRIPTION
## Summary

Adds `docs/runbooks/` with four operational runbooks for the uio GitHub App identity lifecycle:

| File | Covers |
|---|---|
| `github-app-audit.md` | Logging requirements, GitHub audit log review, quarterly audit checklist |
| `github-app-incident-response.md` | P1/P2/P3 severity tiers, 8-step P1 response, post-mortem template |
| `github-app-credential-rotation.md` | Zero-downtime rotation using dual-key overlap, multi-machine deployment |
| `github-app-emergency-disable.md` | Three fast-path disable options (suspend / delete-key / uninstall), re-enable steps |

## Test plan

- [ ] Read each runbook end-to-end — confirm all commands reference the correct env var names (`GITHUB_APP_*_INSTALLATION_ID`, etc.)
- [ ] Verify the emergency disable Option A (`/suspended` endpoint) against a test app installation
- [ ] Confirm credential rotation procedure produces no downtime window (dual-key overlap)
- [ ] Check all cross-references between runbooks resolve correctly

Closes #70

🤖 Generated by **uio / github-coder** · feat/issue-70-runbooks · uio 0.1.x