### PR TITLE
feat: hard-fail on missing App credentials for github-identity agents (M6b #72)

### DIFF
--- a/docs/06-configuration.md
+++ b/docs/06-configuration.md
@@ -120,7 +120,9 @@ Override when `npx` is not available or you want a pinned version:
 command = "bun x @github/github-mcp-server@1.2.0 stdio"
 ```
 
-This section only affects the MCP server launch command. The server still requires `GITHUB_PERSONAL_ACCESS_TOKEN` or `GITHUB_TOKEN` to be set.
+This section only affects the MCP server launch command. The server still requires
+`GITHUB_PERSONAL_ACCESS_TOKEN` or `GITHUB_TOKEN` to be set for agents that do **not**
+declare `github-identity`. See [GitHub authentication](#github-authentication) below.
 
 ---
 
@@ -152,6 +154,40 @@ enabled = true
 ```
 
 See [Registry](11-registry.md) for full registry documentation.
+
+---
+
+## GitHub authentication
+
+uio supports two authentication tracks for GitHub tools:
+
+### Personal Access Token (default)
+
+Set `GITHUB_PERSONAL_ACCESS_TOKEN` (or `GH_TOKEN`) in your environment. The `gh` CLI
+and the GitHub MCP server both pick this up automatically. This is the standard path
+for agents that do **not** declare `github-identity`.
+
+### GitHub App identity (identity agents)
+
+Agents that declare `github-identity: planner | coder | reviewer` in their frontmatter
+**must** authenticate via the corresponding GitHub App installation token. The uio
+runner exchanges App credentials for a short-lived token and sets `GH_TOKEN`
+automatically before the agent loop begins.
+
+This is not optional — if an agent declares `github-identity` but the App credentials
+are not present, the runner hard-fails with an actionable error. Falling back to
+`GITHUB_PERSONAL_ACCESS_TOKEN` is explicitly blocked for identity agents.
+
+Required environment variables per identity (store in `~/.config/uio/secrets`):
+
+| Identity | Variables |
+|---|---|
+| `planner` | `GITHUB_APP_PLANNER_ID`, `GITHUB_APP_PLANNER_INSTALLATION_ID`, `GITHUB_APP_PLANNER_PRIVATE_KEY` |
+| `coder` | `GITHUB_APP_CODER_ID`, `GITHUB_APP_CODER_INSTALLATION_ID`, `GITHUB_APP_CODER_PRIVATE_KEY` |
+| `reviewer` | `GITHUB_APP_REVIEWER_ID`, `GITHUB_APP_REVIEWER_INSTALLATION_ID`, `GITHUB_APP_REVIEWER_PRIVATE_KEY` |
+
+See [`docs/04-frontmatter.md`](04-frontmatter.md) for the `github-identity` field reference
+and [`docs/provisioning/`](provisioning/) for App setup guides.
 
 ---
 

--- a/docs/14-container.md
+++ b/docs/14-container.md
@@ -106,6 +106,28 @@ docker run --rm \
   ghcr.io/jomkz/uio agent run my-agent
 ```
 
+### GitHub authentication in containers
+
+**Standard agents** (no `github-identity`): pass `GITHUB_PERSONAL_ACCESS_TOKEN` as above.
+
+**Identity agents** (`github-identity: planner | coder | reviewer`): pass the three App
+credential variables instead. The private key must be mounted into the container — never
+embed the key as an env var value:
+
+```bash
+docker run --rm \
+  -e GITHUB_APP_CODER_ID=$GITHUB_APP_CODER_ID \
+  -e GITHUB_APP_CODER_INSTALLATION_ID=$GITHUB_APP_CODER_INSTALLATION_ID \
+  -e GITHUB_APP_CODER_PRIVATE_KEY=/run/secrets/uio-ai-coder.pem \
+  -v ~/.config/uio/uio-ai-coder.private-key.pem:/run/secrets/uio-ai-coder.pem:ro \
+  -v $(pwd):/workspace \
+  ghcr.io/jomkz/uio agent run github-coder "..."
+```
+
+Identity agents will **not** fall back to `GITHUB_PERSONAL_ACCESS_TOKEN` — if the App
+credentials are absent the runner exits with an actionable error. See
+[`docs/06-configuration.md`](06-configuration.md#github-authentication) for details.
+
 ## Ollama sidecar (no cloud API keys)
 
 The bundled `docker-compose.yml` runs `uio` alongside a local Ollama instance. No cloud API
@@ -239,7 +261,7 @@ reliably fail to format tool calls correctly.
 Run `uio` as a step in any container-native pipeline:
 
 ```yaml
-# GitHub Actions example
+# GitHub Actions example — standard agent (no github-identity)
 - name: Run repo health check
   run: |
     docker run --rm \
@@ -248,6 +270,11 @@ Run `uio` as a step in any container-native pipeline:
       -v ${{ github.workspace }}:/workspace \
       ghcr.io/jomkz/uio agent run repo-health
 ```
+
+For identity agents in CI, store the App credentials as repository secrets and pass them
+via `-e GITHUB_APP_<ROLE>_ID`, `-e GITHUB_APP_<ROLE>_INSTALLATION_ID`, and
+`-e GITHUB_APP_<ROLE>_PRIVATE_KEY` (pointing to a mounted secret file). Do not pass
+`GITHUB_PERSONAL_ACCESS_TOKEN` — identity agents do not use it.
 
 ## Building from source
 

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -267,8 +267,8 @@ def test_no_identity_is_noop(monkeypatch):
     assert os.environ == original
 
 
-def test_missing_env_vars_falls_back(monkeypatch, capsys):
-    """When github-identity is valid but env vars are absent, fall back gracefully."""
+def test_missing_env_vars_exits(monkeypatch):
+    """When github-identity is set but env vars are absent, the runner must hard-fail."""
     from uio.core.runner import _maybe_inject_github_identity
 
     for var in (
@@ -277,6 +277,7 @@ def test_missing_env_vars_falls_back(monkeypatch, capsys):
         "GITHUB_APP_CODER_PRIVATE_KEY",
     ):
         monkeypatch.delenv(var, raising=False)
-    _maybe_inject_github_identity({"github-identity": "coder"})
-    captured = capsys.readouterr()
-    assert "falling back" in captured.err
+    with pytest.raises(SystemExit) as exc_info:
+        _maybe_inject_github_identity({"github-identity": "coder"})
+    assert exc_info.value.code != 0
+    assert "GITHUB_APP_CODER_" in str(exc_info.value.code)

--- a/uio/core/runner.py
+++ b/uio/core/runner.py
@@ -26,12 +26,11 @@ MAX_ITERATIONS = 10
 def _maybe_inject_github_identity(frontmatter: dict) -> None:
     """Set GH_TOKEN from a GitHub App installation token when github-identity is declared.
 
-    If ``github-identity`` is not set, or if the required env vars are absent (e.g.
-    during local development without App credentials), this is a no-op — the caller's
-    existing GITHUB_PERSONAL_ACCESS_TOKEN or GH_TOKEN is left untouched.
+    If ``github-identity`` is not set this is a no-op — the caller's existing
+    GITHUB_PERSONAL_ACCESS_TOKEN or GH_TOKEN is left untouched.
 
-    When the vars are present but the token exchange fails, a warning is printed and
-    the run continues without overriding GH_TOKEN (graceful degradation).
+    When ``github-identity`` IS set, App credentials are mandatory. Missing env vars or
+    a failed token exchange are hard errors — no fallback to PAT is permitted.
     """
     role = frontmatter.get("github-identity")
     if not role:
@@ -44,21 +43,24 @@ def _maybe_inject_github_identity(frontmatter: dict) -> None:
         )
 
     if not env_vars_present(role):
-        print(
-            f"  [github-identity] '{role}' env vars not set — "
-            "falling back to GITHUB_PERSONAL_ACCESS_TOKEN / GH_TOKEN",
-            file=sys.stderr,
+        role_upper = role.upper()
+        prefix = f"GITHUB_APP_{role_upper}_"
+        missing = ", ".join(f"{prefix}{s}" for s in ("ID", "INSTALLATION_ID", "PRIVATE_KEY"))
+        sys.exit(
+            f"Error: 'github-identity: {role}' requires App credentials but env vars are not set.\n"
+            f"  Missing: {missing}\n"
+            f"  Falling back to GITHUB_PERSONAL_ACCESS_TOKEN is not permitted for identity agents.\n"
+            f"  See docs/provisioning/ for setup instructions."
         )
-        return
 
     try:
         token = get_token_for_identity(role)
         os.environ["GH_TOKEN"] = token
         print(f"  [github-identity] authenticated as '{role}' GitHub App identity")
     except GitHubAppError as exc:
-        print(
-            f"  [github-identity] Warning: could not obtain token for '{role}': {exc}",
-            file=sys.stderr,
+        sys.exit(
+            f"Error: could not obtain GitHub App token for identity '{role}': {exc}\n"
+            f"  Falling back to GITHUB_PERSONAL_ACCESS_TOKEN is not permitted for identity agents."
         )
 
 


### PR DESCRIPTION
## Summary

- **Runner**: `_maybe_inject_github_identity` now hard-fails with an actionable error when `github-identity` is declared but App env vars are absent — no silent fallback to `GITHUB_PERSONAL_ACCESS_TOKEN`
- **Runner**: failed token exchange also hard-fails (was a warning that allowed the run to continue)
- **Tests**: `test_missing_env_vars_falls_back` → `test_missing_env_vars_exits`; asserts `SystemExit` with non-zero code and error message containing the missing var names
- **`docs/06-configuration.md`**: new "GitHub authentication" section documenting both PAT (standard agents) and App identity (identity agents) tracks, including required env vars per role
- **`docs/14-container.md`**: new subsection on GitHub auth in containers with a private-key mount example; CI/CD note clarifying identity agents don't use PAT

## Behaviour change

| Scenario | Before | After |
|---|---|---|
| `github-identity` set, env vars absent | Warning on stderr, run continues with PAT | `sys.exit(1)` with clear error listing missing vars |
| `github-identity` set, token exchange fails | Warning on stderr, run continues | `sys.exit(1)` with error |
| `github-identity` not set | No change | No change |

## Test plan

- [ ] `pytest tests/test_github_app.py` — 19 pass including `test_missing_env_vars_exits`
- [ ] `pytest` — 209 pass
- [ ] `ruff format` + `ruff check` — clean

Closes #72

🤖 Generated by **uio / github-coder** · feat/issue-72-remove-pat-fallback · uio 0.1.x