### PR TITLE
docs: use-cases guide, docs index, and README updates (epic #53 wrap-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@
 
 ## Documentation
 
-Full documentation lives in [`docs/`](docs/README.md) — covering installation, core concepts, a step-by-step quickstart, CLI reference, configuration, providers, MCP integration, the chat REPL, cost ledger, registry, writing definitions, and package internals.
+Full documentation lives in [`docs/`](docs/README.md) — covering installation, core concepts, a step-by-step quickstart, CLI reference, configuration, providers, MCP integration, the chat REPL, cost ledger, registry, writing definitions, package internals, and [GitHub App identity agents](docs/governance.md).
+
+See [Use Cases](docs/15-use-cases.md) for end-to-end worked examples.
 
 ## Quickstart
 
@@ -46,6 +48,33 @@ my-project/
 ```
 
 See [Writing Definitions](docs/12-writing-definitions.md) for the full file format and authoring guide.
+
+## GitHub App identities
+
+uio supports dedicated GitHub App identities for agents that act on GitHub — separate
+non-human service accounts for planning, coding, and reviewing work:
+
+| Identity | Agent | Operations |
+|---|---|---|
+| AI Planner | `github-planner` | Create issues · Comment on issues and PRs · Summarize milestones |
+| AI Coder | `github-coder` | Create branches · Commit code · Open pull requests |
+| AI Reviewer | `github-reviewer` | Read diffs · Post structured review comments |
+
+Declare the identity in your agent's frontmatter:
+
+```yaml
+---
+name: my-github-agent
+github-identity: coder   # planner | coder | reviewer
+tools: [terminal, github]
+---
+```
+
+uio obtains a short-lived GitHub App installation token before the agent loop starts and
+sets `GH_TOKEN` — both the `gh` CLI and GitHub MCP server pick it up automatically. All
+three agents are available in [uio-registry](https://github.com/jomkz/uio-registry).
+
+See [Governance](docs/governance.md) and [Provisioning guides](docs/provisioning/) for setup.
 
 ## Registry
 

--- a/docs/04-frontmatter.md
+++ b/docs/04-frontmatter.md
@@ -90,7 +90,7 @@ GITHUB_APP_PLANNER_PRIVATE_KEY      — PEM key (literal or path to .pem file)
 
 Replace `PLANNER` with `CODER` or `REVIEWER` for the other identities.
 
-If the env vars are absent at run time, uio emits a warning and falls back to `GITHUB_PERSONAL_ACCESS_TOKEN` / `GH_TOKEN`. An invalid identity value (anything other than `planner`, `coder`, `reviewer`) causes a hard error at startup.
+If the env vars are absent at run time, uio exits with an error listing the missing variables — falling back to `GITHUB_PERSONAL_ACCESS_TOKEN` / `GH_TOKEN` is not permitted for identity agents. An invalid identity value (anything other than `planner`, `coder`, `reviewer`) also causes a hard error at startup.
 
 `uio validate` warns (non-fatally) when `github-identity` is declared but the corresponding env vars are not set, so you can catch configuration drift in CI.
 

--- a/docs/15-use-cases.md
+++ b/docs/15-use-cases.md
@@ -1,0 +1,255 @@
+# Use Cases
+
+> Worked examples of uio in practice — from single-agent runs to multi-identity pipelines.
+> Each section shows a real pattern with the commands you'd actually run.
+
+---
+
+## 1. Repository health monitoring
+
+**Agent:** `repo-health` (bundled example)  
+**Pattern:** on-demand or scheduled single-agent run
+
+`repo-health` produces a structured report covering failing tests, lint issues, open TODOs,
+stale branches, and PR backlog. Run it before a release or wire it into CI to surface
+regressions before they reach production.
+
+```bash
+# On-demand run against the current repo
+uio agent run repo-health
+
+# Pin a specific provider and model
+uio agent run repo-health --provider gemini --model gemini-2.5-flash
+
+# Run in CI (GitHub Actions)
+- name: Repository health check
+  run: uio agent run repo-health
+  env:
+    GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+    GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+The agent reads the local filesystem, runs `git`, and calls `gh` to check open PRs and
+issues. No configuration beyond an API key and a GitHub token is required.
+
+---
+
+## 2. Automated code review
+
+**Agent:** `github-reviewer` (uio-registry)  
+**Pattern:** event-driven, triggered when a PR opens
+
+`github-reviewer` reads the full PR diff, checks context files, and posts a structured
+review with a severity table (🔴 High / 🟡 Medium / 🟢 Low). It uses the `AI Reviewer`
+GitHub App identity — its comments appear under a non-human account, making AI vs. human
+authorship immediately visible.
+
+```bash
+# Install from registry
+uio registry install github-reviewer
+
+# Review a specific PR
+uio agent run github-reviewer "jomkz/uio#42"
+
+# Or with a full URL
+uio agent run github-reviewer "https://github.com/jomkz/uio/pull/42"
+```
+
+Prerequisites: `GITHUB_APP_REVIEWER_*` env vars set (see
+[Provisioning — AI Reviewer](provisioning/ai-reviewer.md)).
+
+The agent never approves or merges — it posts a comment and stops. Human sign-off is
+always required before merge.
+
+---
+
+## 3. Issue triage and planning
+
+**Agent:** `github-planner` (uio-registry)  
+**Pattern:** multi-step planning loop
+
+`github-planner` turns natural-language descriptions into structured GitHub issues with
+context, goal, and acceptance criteria sections. It can also decompose a large feature
+into child issues. This is how the GitHub identity architecture (epic #53) in this very
+repo was planned:
+
+```bash
+# Install from registry
+uio registry install github-planner
+
+# Create a single issue
+uio agent run github-planner \
+  "Create an issue in jomkz/uio titled 'Add rate limiting to the API' \
+   describing exponential backoff with a 10 req/s default"
+
+# Decompose a feature into child issues
+uio agent run github-planner \
+  "Break down the feature 'Enterprise GitHub Identity Architecture' \
+   into implementable child issues in jomkz/uio"
+
+# Comment on an existing issue with a triage assessment
+uio agent run github-planner "jomkz/uio#53"
+```
+
+The planner has no code write access — it creates and comments on issues only.
+
+---
+
+## 4. AI-authored pull requests
+
+**Agent:** `github-coder` (uio-registry)  
+**Pattern:** code-change pipeline with mandatory human review gate
+
+`github-coder` takes a natural-language change description, clones the repo, applies the
+minimal change, commits with a non-human author identity, and opens a PR with an
+AI-disclosure footer. The human review gate is enforced by branch protection — the PR
+cannot be merged without a human approval.
+
+```bash
+# Install from registry
+uio registry install github-coder
+
+# Apply a change and open a PR
+uio agent run github-coder \
+  "Add input validation to the login endpoint | repo: jomkz/uio | branch: ai-coder/login-validation"
+
+# With an explicit base branch
+uio agent run github-coder \
+  "Fix the off-by-one error in the token cache refresh | repo: jomkz/uio | base: develop"
+```
+
+Commits are authored as `uio AI Coder <uio-coder[bot]@users.noreply.github.com>`. The PR
+body includes the AI disclosure footer automatically. The agent never merges — it stops
+after opening the PR and reporting the URL.
+
+Prerequisites: `GITHUB_APP_CODER_*` env vars set (see
+[Provisioning — AI Coder](provisioning/ai-coder.md)).
+
+---
+
+## 5. Release notes generation
+
+**Skill:** `changelog-entry` (bundled example)  
+**Pattern:** invokable skill in a release workflow
+
+Generate a conventional-commit changelog block from a git commit range, ready to paste
+into `CHANGELOG.md` or a GitHub Release:
+
+```bash
+# Last 20 commits
+uio skill run changelog-entry HEAD~20
+
+# Between two tags
+uio skill run changelog-entry v0.1.0..v0.2.0
+
+# Or pipe directly into a file
+uio skill run changelog-entry HEAD~10 >> CHANGELOG.md
+```
+
+Skills are single-shot — they produce output and exit without a tool-use loop, making
+them fast and predictable for scripted workflows.
+
+---
+
+## 6. Multi-agent pipeline
+
+**Pattern:** sequential plan → code → review with handoffs
+
+The full value of GitHub App identities emerges when you chain agents: each identity acts
+in its own lane, and human decisions gate each transition.
+
+```bash
+# 1. Plan — create the issue
+uio agent run github-planner \
+  "Create an issue in jomkz/uio for 'Add rate limiting to the MCP client'"
+# → Creates issue #N
+
+# 2. Code — implement the issue and open a PR
+uio agent run github-coder \
+  "Implement issue #N — add rate limiting to the MCP client | repo: jomkz/uio"
+# → Opens PR #M with AI Coder identity
+
+# 3. Review — post a structured review
+uio agent run github-reviewer "jomkz/uio#M"
+# → Posts review comment with severity table using AI Reviewer identity
+
+# 4. Human reviews the findings and approves
+# → Merge is gated on human approval; no agent can merge
+```
+
+This demonstrates the separation-of-duties model from
+[`docs/github-permission-matrix.md`](github-permission-matrix.md): Planner writes issues,
+Coder writes code, Reviewer reads and comments — no identity can act outside its lane.
+
+---
+
+## 7. CI/CD integration
+
+**Pattern:** uio as a container step in GitHub Actions
+
+The `ghcr.io/jomkz/uio` image runs uio agents without a local install. Use it to run
+health checks, generate reports, or trigger planning agents on a schedule.
+
+```yaml
+name: Weekly repo health
+
+on:
+  schedule:
+    - cron: "0 9 * * 1"   # Every Monday at 09:00 UTC
+
+jobs:
+  health:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run repo health check
+        run: |
+          docker run --rm \
+            -e GEMINI_API_KEY=${{ secrets.GEMINI_API_KEY }} \
+            -e GITHUB_PERSONAL_ACCESS_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+            -v ${{ github.workspace }}:/workspace \
+            ghcr.io/jomkz/uio agent run repo-health
+```
+
+For identity agents in CI, pass the App credentials as repository secrets and mount the
+private key file (see [Container image](14-container.md#github-authentication-in-containers)).
+
+---
+
+## 8. Bootstrapping a new project
+
+**Pattern:** init + registry install + first run
+
+The fastest path from zero to a working multi-agent pipeline:
+
+```bash
+# 1. Install uio
+pip install uio-ai
+
+# 2. Scaffold .uio/ with bundled examples
+uio init --examples
+
+# 3. Add the official registry to uio.toml
+cat >> uio.toml <<'EOF'
+[[registries]]
+name    = "official"
+url     = "https://github.com/jomkz/uio-registry"
+ref     = "main"
+enabled = true
+EOF
+
+# 4. Install the GitHub identity agents
+uio registry install github-planner github-coder github-reviewer
+
+# 5. Set credentials and run
+source ~/.config/uio/secrets   # GITHUB_APP_* vars
+uio agent run github-planner "scaffold the backlog for my new API project in owner/repo"
+```
+
+From here, add `github-identity` to your own agent definitions to give them dedicated
+GitHub identities — see [Frontmatter schema](04-frontmatter.md#github-identity).
+
+---
+
+*See [`docs/README.md`](README.md) for the full documentation index and suggested reading paths.*

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,28 @@
 | [12 — Writing definitions](12-writing-definitions.md) | How to write effective agents, skills, and prompts; tool-use patterns; common failure modes |
 | [13 — Internals](13-internals.md) | Package architecture, every module's role, how to add a provider or tool, and contributing |
 | [14 — Container image](14-container.md) | Dockerfile, bundled MCP servers, Ollama sidecar, CI/CD usage, and building from source |
+| [15 — Use cases](15-use-cases.md) | Worked examples: repo health, code review, issue planning, AI-authored PRs, multi-agent pipelines |
+
+---
+
+## GitHub App identity reference
+
+The following documents cover the enterprise GitHub identity architecture — dedicated GitHub App
+identities (`planner`, `coder`, `reviewer`) for uio agents that act on GitHub.
+
+| Document | What it covers |
+|---|---|
+| [GitHub identity inventory](github-identity-inventory.md) | Current-state survey of GitHub auth usage across uio definitions |
+| [Permission matrix](github-permission-matrix.md) | Minimum permissions, explicit exclusions, and identity routing map |
+| [Governance](governance.md) | Attribution standard, app ownership, quarterly review, change control, installation policy |
+| [Provisioning — AI Planner](provisioning/ai-planner.md) | Step-by-step setup for the `uio-ai-planner` GitHub App |
+| [Provisioning — AI Coder](provisioning/ai-coder.md) | Step-by-step setup for the `uio-ai-coder` GitHub App |
+| [Provisioning — AI Reviewer](provisioning/ai-reviewer.md) | Step-by-step setup for the `uio-ai-reviewer` GitHub App |
+| [Runbook — Audit](runbooks/github-app-audit.md) | Logging requirements and GitHub audit log review process |
+| [Runbook — Incident response](runbooks/github-app-incident-response.md) | P1/P2/P3 incident tiers, 8-step response, post-mortem template |
+| [Runbook — Credential rotation](runbooks/github-app-credential-rotation.md) | Zero-downtime private key rotation using dual-key overlap |
+| [Runbook — Emergency disable](runbooks/github-app-emergency-disable.md) | Fast-path: suspend, delete key, or uninstall in under 2 minutes |
+| [Runbook — Branch protection](runbooks/github-branch-protection.md) | Applied baseline, reconfiguration command, AI Coder bypass verification |
 
 ---
 
@@ -54,3 +76,16 @@
 
 - [Internals](13-internals.md) — architecture, extension points, contributing
 - [Core concepts](02-concepts.md) — mental model first
+
+### I want to run agents with dedicated GitHub App identities
+
+1. [Permission matrix](github-permission-matrix.md) — understand what each identity can do
+2. [Provisioning guides](provisioning/) — create and install the GitHub Apps
+3. [Frontmatter schema](04-frontmatter.md#github-identity) — add `github-identity` to your agent
+4. [Configuration](06-configuration.md#github-authentication) — set the required env vars
+5. [Governance](governance.md) — ownership, review cadence, and change control
+6. [Runbooks](runbooks/) — audit, incident response, credential rotation, emergency disable
+
+### I want to see what uio can do end-to-end
+
+- [Use cases](15-use-cases.md) — repo health, code review, issue planning, AI-authored PRs, multi-agent pipelines


### PR DESCRIPTION
## Summary

Final documentation wrap-up for epic #53 (Enterprise GitHub Identity Architecture).

- **`docs/15-use-cases.md`** (new) — 8 worked examples: repo health, code review, issue planning, AI-authored PRs, release notes, multi-agent pipeline (plan→code→review with handoffs), CI/CD integration, bootstrapping a new project
- **`docs/README.md`** — new "GitHub App identity reference" table linking all governance/provisioning/runbook docs; new reading path "I want to run agents with dedicated GitHub App identities"; added use-cases to the contents table
- **`README.md`** — new "GitHub App identities" section with identity table, frontmatter example, and links to registry agents; use-cases link in the documentation blurb
- **`docs/04-frontmatter.md`** — fixes line 93: "emits a warning and falls back" → "exits with an error — falling back is not permitted" (reflects M6b behaviour)

## Note on M6b (#85)

The frontmatter fix in this PR is compatible with M6b (#85, `feat/issue-72-remove-pat-fallback`). Merge order doesn't matter — both update different sections of the same file.

## Test plan

- [ ] Read `docs/15-use-cases.md` — every command example references a real agent/skill available in uio or uio-registry
- [ ] Check all links in `docs/README.md` resolve (governance.md, provisioning/, runbooks/ all exist on main)
- [ ] Verify `docs/04-frontmatter.md` no longer says "falls back"

Closes #74

🤖 Generated by **uio / github-coder** · feat/epic-53-docs-wrap-up · uio 0.1.x