### PR TITLE
docs: add CHANGELOG entry for M6a pilot completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Completed M6a controlled end-to-end pilot with the github-planner, github-coder, and github-reviewer GitHub App identities.
+
 ### Added
 
 - CI workflow: pytest across Python 3.11–3.13, ruff lint/format checks


### PR DESCRIPTION
## Summary

- Adds `### Changed` entry under `## [Unreleased]` noting successful completion of the M6a GitHub App identity pilot
- The three App identities (`github-planner`, `github-coder`, `github-reviewer`) were exercised end-to-end as part of epic #53

---
> **AI-generated pull request** — authored by the uio AI Coder agent.
> Human review is required before merging.
> Powered by [uio](https://github.com/jomkz/uio).

Closes #71