### PR TITLE
fix: replace broken npm package with gh extension + community npm fallback

### DIFF
--- a/docs/08-mcp.md
+++ b/docs/08-mcp.md
@@ -12,7 +12,7 @@ uio itself does not implement any MCP tools — it delegates entirely to the ser
 
 ## GitHub MCP server
 
-The most common use case is the official GitHub MCP server (`@github/github-mcp-server`), which exposes ~30 GitHub API operations as typed tools: create/list issues, read file contents, list pull requests, manage branches, and more.
+The most common use case is the official GitHub MCP server ([github/github-mcp-server](https://github.com/github/github-mcp-server)), which exposes ~30 GitHub API operations as typed tools: create/list issues, read file contents, list pull requests, manage branches, and more.
 
 Using the GitHub MCP server instead of `gh` CLI shell commands gives the agent:
 - Typed, structured JSON responses (no shell output parsing)
@@ -23,10 +23,33 @@ When MCP tools are available, uio injects a preamble into the system prompt advi
 
 ---
 
+## Installing the GitHub MCP server
+
+uio probes for the best available command in this order:
+
+| Priority | Method | Install | Notes |
+|---|---|---|---|
+| **1** | **gh extension** (recommended) | `gh extension install github/gh-mcp` | Uses `gh`'s ambient auth; no extra token needed |
+| **2** | Standalone binary | Download from [GitHub Releases](https://github.com/github/github-mcp-server/releases) | Place `github-mcp-server` on `$PATH` |
+| **3** | Community npm | `npx @modelcontextprotocol/server-github` | Requires `GITHUB_PERSONAL_ACCESS_TOKEN`; widely available |
+
+**Recommended setup (one-time):**
+
+```bash
+# Install the gh extension
+gh extension install github/gh-mcp
+
+# Verify it starts and lists tools
+echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | gh mcp server | head -c 500
+```
+
+---
+
 ## Prerequisites
 
-- **Node.js** (any recent LTS version) and **npx**. The MCP server is launched as `npx -y @github/github-mcp-server stdio`.
-- A GitHub personal access token with the scopes your agent needs.
+- **`gh` CLI** (recommended) — install from <https://cli.github.com>. Run `gh auth login` once.
+- *Or* **Node.js + npx** (any recent LTS) if using the community npm fallback.
+- A GitHub token with the scopes your agent needs (handled automatically when using `gh`).
 
 ---
 
@@ -103,23 +126,19 @@ Use this when:
 
 ## Overriding the launch command
 
-By default, the server is launched as:
-
-```
-npx -y @github/github-mcp-server stdio
-```
-
-Override via `uio.toml` (preferred):
+By default, uio probes for the best available command (see the priority table above). You can override this in `uio.toml` (preferred):
 
 ```toml
 [mcp.github]
-command = "bun x @github/github-mcp-server@1.2.0 stdio"
+command = "gh mcp server"   # gh extension (recommended)
+# command = "github-mcp-server stdio"  # standalone binary
+# command = "npx -y @modelcontextprotocol/server-github"  # community npm
 ```
 
 Or via the `MCP_GITHUB_COMMAND` environment variable (applies only to the backwards-compat auto-start path, i.e. when `[mcp.github]` is absent from `uio.toml`):
 
 ```bash
-export MCP_GITHUB_COMMAND="bun x @github/github-mcp-server stdio"
+export MCP_GITHUB_COMMAND="gh mcp server"
 ```
 
 ---
@@ -144,7 +163,7 @@ Communication uses newline-delimited JSON. Each request includes an incrementing
 
 ```toml
 [mcp.github]
-command = "npx -y @github/github-mcp-server stdio"
+command = "gh mcp server"
 
 [mcp.filesystem]
 command = "npx -y @modelcontextprotocol/server-filesystem /workspace"
@@ -172,9 +191,10 @@ If a server fails to start, uio prints a warning and continues without it — th
 
 This warning is printed to stderr when the server fails to start. The run continues without MCP tools. Common causes:
 
-- `npx` not found — install Node.js
+- `gh` extension not installed — run `gh extension install github/gh-mcp`
+- `gh` not authenticated — run `gh auth login`
+- `npx` not found (community npm fallback) — install Node.js
 - Token is invalid or expired — regenerate it at GitHub
-- Node.js version is too old — upgrade to LTS (18+)
 
 **The agent keeps using `gh` CLI even though MCP is enabled**
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -5,7 +5,37 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 
-from uio.core.mcp import make_mcp_clients
+from uio.core.mcp import _default_github_mcp_command, make_mcp_clients
+
+
+class TestDefaultGithubMcpCommand:
+    def test_gh_present_returns_gh_mcp_server(self):
+        with patch(
+            "uio.core.mcp.shutil.which", side_effect=lambda x: "/usr/bin/gh" if x == "gh" else None
+        ):
+            assert _default_github_mcp_command() == ["gh", "mcp", "server"]
+
+    def test_no_gh_but_binary_present_returns_binary(self):
+        def which(name):
+            if name == "github-mcp-server":
+                return "/usr/local/bin/github-mcp-server"
+            return None
+
+        with patch("uio.core.mcp.shutil.which", side_effect=which):
+            assert _default_github_mcp_command() == ["/usr/local/bin/github-mcp-server", "stdio"]
+
+    def test_neither_falls_back_to_community_npm(self):
+        with patch("uio.core.mcp.shutil.which", return_value=None):
+            assert _default_github_mcp_command() == [
+                "npx",
+                "-y",
+                "@modelcontextprotocol/server-github",
+            ]
+
+    def test_gh_takes_priority_over_binary(self):
+        with patch("uio.core.mcp.shutil.which", return_value="/some/path"):
+            # shutil.which returns truthy for both, but gh is checked first
+            assert _default_github_mcp_command() == ["gh", "mcp", "server"]
 
 
 def _make_mock_client(server_name: str) -> MagicMock:

--- a/uio/core/mcp.py
+++ b/uio/core/mcp.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import shlex
+import shutil
 import subprocess
 import sys
 
@@ -96,6 +97,22 @@ class MCPClient:
             pass
 
 
+def _default_github_mcp_command() -> list[str]:
+    """Return the best available command to start the GitHub MCP server.
+
+    Probe order:
+    1. gh extension (gh extension install github/gh-mcp) — official, zero extra binary
+    2. Standalone binary downloaded from GitHub Releases
+    3. Community npm package (@modelcontextprotocol/server-github) — PAT-only but widely available
+    """
+    if shutil.which("gh"):
+        return ["gh", "mcp", "server"]
+    binary = shutil.which("github-mcp-server")
+    if binary:
+        return [binary, "stdio"]
+    return ["npx", "-y", "@modelcontextprotocol/server-github"]
+
+
 def make_mcp_client(server_name: str = "github") -> "MCPClient | None":
     """Try to start the GitHub MCP server; return None if env token is missing."""
     token = os.environ.get("GITHUB_PERSONAL_ACCESS_TOKEN") or os.environ.get("GITHUB_TOKEN")
@@ -104,11 +121,15 @@ def make_mcp_client(server_name: str = "github") -> "MCPClient | None":
     command_env = os.environ.copy()
     command_env["GITHUB_PERSONAL_ACCESS_TOKEN"] = token
     raw = os.environ.get("MCP_GITHUB_COMMAND")
-    command = shlex.split(raw) if raw else ["npx", "-y", "@github/github-mcp-server", "stdio"]
+    command = shlex.split(raw) if raw else _default_github_mcp_command()
     try:
         return MCPClient(command, server_name=server_name, env=command_env)
     except Exception as e:
-        print(f"  [mcp] Warning: could not start GitHub MCP server: {e}", file=sys.stderr)
+        print(
+            f"  [mcp] Warning: could not start GitHub MCP server: {e}\n"
+            f"  Hint: run 'gh extension install github/gh-mcp' or set MCP_GITHUB_COMMAND.",
+            file=sys.stderr,
+        )
         return None
 
 


### PR DESCRIPTION
Fixes #91.

## Summary

- Adds `_default_github_mcp_command()` in `uio/core/mcp.py` that probes for the best available GitHub MCP server command in priority order:
  1. **`gh mcp server`** — official gh extension (`gh extension install github/gh-mcp`); zero extra binary to manage
  2. **`github-mcp-server stdio`** — standalone binary downloaded from GitHub Releases
  3. **`npx -y @modelcontextprotocol/server-github`** — community npm fallback (PAT-only but widely available, works in Docker images that already have npm)
- Replaces the broken hardcoded `npx -y @github/github-mcp-server stdio` default (that package does not exist on npm — returns 404)
- Improves the failure warning to include a setup hint
- Updates `docs/08-mcp.md`: installation priority table, one-time setup commands, updated override examples, updated troubleshooting

## Test plan

- [ ] 4 new unit tests in `TestDefaultGithubMcpCommand` cover each probe path and priority order
- [ ] All 213 existing tests pass
- [ ] `ruff format` and `ruff check` clean
- [ ] Manual: `gh extension install github/gh-mcp` then `uio agent run github-planner` — MCP server starts without warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)