### PR TITLE
fix: thread GH_TOKEN into MCP startup so identity agents don't auth as PAT

### DIFF
--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 
-from uio.core.mcp import _default_github_mcp_command, make_mcp_clients
+from uio.core.mcp import _default_github_mcp_command, make_mcp_client, make_mcp_clients
 
 
 class TestDefaultGithubMcpCommand:
@@ -36,6 +36,54 @@ class TestDefaultGithubMcpCommand:
         with patch("uio.core.mcp.shutil.which", return_value="/some/path"):
             # shutil.which returns truthy for both, but gh is checked first
             assert _default_github_mcp_command() == ["gh", "mcp", "server"]
+
+
+class TestMakeMcpClientTokenPriority:
+    def test_gh_token_wins_over_pat(self, monkeypatch):
+        """GH_TOKEN (App identity) takes priority over GITHUB_PERSONAL_ACCESS_TOKEN."""
+        monkeypatch.setenv("GH_TOKEN", "app-token")
+        monkeypatch.setenv("GITHUB_PERSONAL_ACCESS_TOKEN", "pat-token")
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+        captured_env = {}
+
+        def fake_mcp_cls(command, server_name, env=None, **kwargs):
+            captured_env.update(env or {})
+            return MagicMock()
+
+        with patch("uio.core.mcp.MCPClient", side_effect=fake_mcp_cls):
+            result = make_mcp_client()
+
+        assert result is not None
+        assert captured_env["GH_TOKEN"] == "app-token"
+        assert captured_env["GITHUB_TOKEN"] == "app-token"
+        assert captured_env["GITHUB_PERSONAL_ACCESS_TOKEN"] == "app-token"
+
+    def test_all_three_vars_set_in_child_env(self, monkeypatch):
+        """Selected token is exported under all three env var names."""
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.setenv("GITHUB_PERSONAL_ACCESS_TOKEN", "pat-token")
+
+        captured_env = {}
+
+        def fake_mcp_cls(command, server_name, env=None, **kwargs):
+            captured_env.update(env or {})
+            return MagicMock()
+
+        with patch("uio.core.mcp.MCPClient", side_effect=fake_mcp_cls):
+            result = make_mcp_client()
+
+        assert result is not None
+        assert captured_env["GH_TOKEN"] == "pat-token"
+        assert captured_env["GITHUB_TOKEN"] == "pat-token"
+        assert captured_env["GITHUB_PERSONAL_ACCESS_TOKEN"] == "pat-token"
+
+    def test_no_token_returns_none(self, monkeypatch):
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_PERSONAL_ACCESS_TOKEN", raising=False)
+        assert make_mcp_client() is None
 
 
 def _make_mock_client(server_name: str) -> MagicMock:

--- a/uio/core/mcp.py
+++ b/uio/core/mcp.py
@@ -114,12 +114,31 @@ def _default_github_mcp_command() -> list[str]:
 
 
 def make_mcp_client(server_name: str = "github") -> "MCPClient | None":
-    """Try to start the GitHub MCP server; return None if env token is missing."""
-    token = os.environ.get("GITHUB_PERSONAL_ACCESS_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    """Try to start the GitHub MCP server; return None if no token is available.
+
+    Token priority: GH_TOKEN (set by App identity injection) → GITHUB_TOKEN → GITHUB_PERSONAL_ACCESS_TOKEN.
+    The selected token is exported under all three names so that any MCP server implementation
+    (gh extension, standalone binary, community npm) can find it regardless of which var it reads.
+    """
+    token = (
+        os.environ.get("GH_TOKEN")
+        or os.environ.get("GITHUB_TOKEN")
+        or os.environ.get("GITHUB_PERSONAL_ACCESS_TOKEN")
+    )
     if not token:
         return None
+
     command_env = os.environ.copy()
+    command_env["GH_TOKEN"] = token
+    command_env["GITHUB_TOKEN"] = token
     command_env["GITHUB_PERSONAL_ACCESS_TOKEN"] = token
+
+    using_app_identity = os.environ.get("GH_TOKEN") == token
+    if using_app_identity:
+        print(f"  [mcp] '{server_name}' starting with App identity token (GH_TOKEN)")
+    else:
+        print(f"  [mcp] '{server_name}' starting with personal token")
+
     raw = os.environ.get("MCP_GITHUB_COMMAND")
     command = shlex.split(raw) if raw else _default_github_mcp_command()
     try:


### PR DESCRIPTION
Fixes #92. Stacked on #94 (fix/issue-91-gh-mcp-server-command).

## Summary

- `make_mcp_client()` now reads tokens in priority order: `GH_TOKEN` → `GITHUB_TOKEN` → `GITHUB_PERSONAL_ACCESS_TOKEN`
- The selected token is exported under all three names in the MCP child process, covering `gh mcp server`, the standalone binary, and the community npm package
- Logs which identity (App token vs personal token) is being used at startup

## Why this matters

Identity agents (`github-planner`, `github-coder`, `github-reviewer`) call `_maybe_inject_github_identity()` which sets `GH_TOKEN` to a short-lived App installation token. Before this fix, the MCP server was always started with `GITHUB_PERSONAL_ACCESS_TOKEN` — meaning GitHub API calls via MCP would be attributed to the user's personal account, not the App identity.

## Test plan

- [ ] 3 new unit tests in `TestMakeMcpClientTokenPriority` — `GH_TOKEN` priority, all three vars set in child env, no-token returns `None`
- [ ] All 216 tests pass
- [ ] `ruff format` and `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)