### PR TITLE
fix: Ollama tool-call probe, model swap, and large-complexity routing gate

### DIFF
--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -1,0 +1,33 @@
+"""Tests for probe_tool_calling()."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from uio.core.clients import LLMResponse, probe_tool_calling
+from uio.core.tools import ToolCall
+
+
+def _mock_client(tool_calls: list, text: str | None = None) -> MagicMock:
+    client = MagicMock()
+    client.build_history.return_value = [{"role": "user", "content": "probe"}]
+    client.chat.return_value = LLMResponse(text=text, tool_calls=tool_calls)
+    return client
+
+
+def test_probe_returns_true_when_tool_call_present():
+    tc = ToolCall(name="run_command", args={"command": "echo probe"}, call_id="probe-1")
+    client = _mock_client(tool_calls=[tc])
+    assert probe_tool_calling(client) is True
+
+
+def test_probe_returns_false_when_no_tool_calls():
+    client = _mock_client(tool_calls=[], text='{"name": "run_command"}')
+    assert probe_tool_calling(client) is False
+
+
+def test_probe_returns_false_on_exception():
+    client = MagicMock()
+    client.build_history.return_value = []
+    client.chat.side_effect = Exception("connection refused")
+    assert probe_tool_calling(client) is False

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -140,6 +140,26 @@ def test_provider_chain_always_includes_ollama(monkeypatch):
     assert "ollama" in chain
 
 
+def test_provider_chain_large_complexity_excludes_ollama(monkeypatch):
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    chain = select_provider_chain(None, complexity="large")
+    assert "ollama" not in chain
+
+
+def test_provider_chain_large_complexity_forced_provider_keeps_ollama(monkeypatch):
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    chain = select_provider_chain("ollama", complexity="large")
+    assert chain == ["ollama"]
+
+
+def test_provider_chain_small_complexity_includes_ollama(monkeypatch):
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    chain = select_provider_chain(None, complexity="small")
+    assert "ollama" in chain
+
+
 def test_provider_chain_full_when_all_keys_present(monkeypatch):
     monkeypatch.setenv("GEMINI_API_KEY", "g-key")
     monkeypatch.setenv("OPENAI_API_KEY", "o-key")

--- a/uio/core/clients.py
+++ b/uio/core/clients.py
@@ -12,13 +12,13 @@ from uio.core.tools import TOOL_SCHEMA, ToolCall
 PROVIDER_DEFAULTS = {
     "gemini": "gemini-2.5-flash",
     "openai": "gpt-4o",
-    "ollama": "qwen2.5-coder:32b",
+    "ollama": "llama3.1:8b",
 }
 
 PROVIDER_SMALL_MODELS = {
     "gemini": "gemini-2.0-flash-lite",
     "openai": "gpt-4o-mini",
-    "ollama": "qwen2.5-coder:7b",
+    "ollama": "llama3.1:8b",
 }
 
 OLLAMA_BASE_URL = "http://localhost:11434/v1"
@@ -224,6 +224,22 @@ class OllamaClient(OpenAIClient):
             base_url=effective_url,
             api_key=effective_key,
         )
+
+
+def probe_tool_calling(client: LLMClient) -> bool:
+    """Return True if the client correctly returns a structured ToolCall.
+
+    Used to verify Ollama models honour the OpenAI function-calling spec before
+    committing them to a multi-step agentic run.
+    """
+    try:
+        history = client.build_history("Call run_command with command='echo probe'")
+        response = client.chat(
+            system="You are a tool caller. Always call tools when asked.", history=history
+        )
+        return len(response.tool_calls) > 0
+    except Exception:
+        return False
 
 
 def make_client(

--- a/uio/core/routing.py
+++ b/uio/core/routing.py
@@ -46,18 +46,27 @@ def select_model(provider: str, complexity: str, model_override: str | None) -> 
     return PROVIDER_DEFAULTS.get(provider, "")
 
 
-def select_provider_chain(provider_override: str | None) -> list[str]:
+def select_provider_chain(provider_override: str | None, complexity: str = "small") -> list[str]:
     """Return ordered providers to try.
 
     If --provider is set, returns that single provider. Otherwise returns all
-    providers in ROUTING_CHAIN that have their required API key available, with
-    Ollama (keyless) always included as the final fallback.
+    providers in ROUTING_CHAIN that have their required API key available.
+
+    Ollama is excluded from auto-routing for large-complexity runs because
+    local models are unlikely to reliably execute multi-step tool-call chains.
+    --provider ollama forces Ollama regardless of complexity.
     """
     if provider_override:
         return [provider_override]
     available = []
     for p in ROUTING_CHAIN:
+        if p == "ollama" and complexity == "large":
+            continue
         key_env = PROVIDER_KEY_ENV.get(p)
         if key_env is None or os.environ.get(key_env):
             available.append(p)
-    return available or [ROUTING_CHAIN[-1]]
+    # For small complexity, always fall back to Ollama if nothing else is available.
+    # For large complexity, Ollama is excluded — an empty list tells the runner to exit cleanly.
+    if not available and complexity != "large":
+        return [ROUTING_CHAIN[-1]]
+    return available

--- a/uio/core/runner.py
+++ b/uio/core/runner.py
@@ -8,7 +8,7 @@ import time
 
 from uio import __version__
 from uio.core.attribution import build_attribution_instructions
-from uio.core.clients import make_client
+from uio.core.clients import make_client, probe_tool_calling
 from uio.core.github_app import (
     KNOWN_ROLES,
     GitHubAppError,
@@ -173,7 +173,7 @@ def run_agent(
         user_message = f"Begin your workflow now. Argument: {arg}"
 
     resolved_complexity = infer_complexity(agent_name, frontmatter, complexity, large_agent_names)
-    provider_chain = select_provider_chain(provider)
+    provider_chain = select_provider_chain(provider, resolved_complexity)
 
     try:
         last_error: Exception | None = None
@@ -189,6 +189,15 @@ def run_agent(
                     file=sys.stderr,
                 )
                 last_error = e
+                continue
+
+            if candidate_provider == "ollama" and not probe_tool_calling(client):
+                print(
+                    "  [router] ollama: tool-calling probe failed —"
+                    " model does not return structured tool calls. Skipping.",
+                    file=sys.stderr,
+                )
+                last_error = RuntimeError("ollama tool-calling probe failed")
                 continue
 
             print(f"\n🤖 Agent: {frontmatter.get('name', agent_name)}")


### PR DESCRIPTION
Fixes #90.

## Summary

- **Model swap**: `PROVIDER_DEFAULTS["ollama"]` changed from `qwen2.5-coder:32b` to `llama3.1:8b` — Meta's function-calling fine-tune has reliable `tool_calls` output via Ollama's OpenAI-compat layer; the old model emitted raw JSON strings in text output, silently skipping all tool execution
- **Probe gate**: `probe_tool_calling(client)` added to `clients.py`; the runner calls it after building an Ollama client and before starting the iteration loop — if the model returns text instead of structured tool calls the run is skipped with a clear stderr warning
- **Routing gate**: `select_provider_chain()` now accepts `complexity`; large-complexity runs exclude Ollama from auto-routing entirely (belt-and-suspenders on top of the probe); `--provider ollama` still forces Ollama regardless

## Why this matters

During the M6a pilot, Gemini fell back to Ollama (`qwen2.5-coder:32b`) on a 503. The model appeared to run fine — printed output, exited cleanly — but zero tool calls were executed. The runner printed `✅ Agent finished.` and nothing happened. This triple-layer fix makes that class of silent failure impossible.

## Test plan

- [ ] `test_probe.py` — 3 tests: tool call present → True, empty tool_calls → False, exception → False
- [ ] `test_routing.py` — 3 new tests: large excludes Ollama, `--provider ollama` forces it, small still includes it
- [ ] All 231 tests pass; `ruff` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)