### PR TITLE
feat: per-complexity iteration caps configurable via uio.toml

### DIFF
--- a/tests/test_iteration_cap.py
+++ b/tests/test_iteration_cap.py
@@ -1,0 +1,77 @@
+"""Tests for per-complexity MAX_ITERATIONS caps."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from uio.core.clients import LLMResponse
+from uio.core.runner import _DEFAULT_MAX_ITERATIONS, _DEFAULT_MAX_ITERATIONS_LARGE, run_agent
+from uio.core.tools import ToolCall
+
+
+def _make_run_args(tmp_path, complexity: str = "small"):
+    defn = tmp_path / "test.agent.md"
+    defn.write_text(f"---\nname: test-agent\ncomplexity: {complexity}\n---\nDo the task.\n")
+    return {
+        "agent_name": "test-agent",
+        "definition_path": str(defn),
+        "no_mcp": True,
+        "ledger_path": str(tmp_path / "ledger.jsonl"),
+    }
+
+
+def _always_tool_client():
+    """Client that always returns a tool call, forcing the runner to hit the cap."""
+    tc = ToolCall(name="run_command", args={"command": "echo x"}, call_id="t1")
+    client = MagicMock()
+    client.build_history.return_value = [{"role": "user", "content": "begin"}]
+    client.chat.return_value = LLMResponse(text=None, tool_calls=[tc])
+    client.usage = None
+    return client
+
+
+class TestDefaultCaps:
+    def test_default_small_cap(self):
+        assert _DEFAULT_MAX_ITERATIONS == 10
+
+    def test_default_large_cap(self):
+        assert _DEFAULT_MAX_ITERATIONS_LARGE == 25
+
+
+class TestIterationCapPerComplexity:
+    def test_small_agent_stops_at_small_cap(self, tmp_path):
+        client = _always_tool_client()
+        with (
+            patch("uio.core.runner.make_client", return_value=client),
+            patch("uio.core.runner.select_provider_chain", return_value=["gemini"]),
+            patch("uio.core.runner.execute_tool", return_value="ok"),
+        ):
+            run_agent(
+                **_make_run_args(tmp_path, "small"), max_iterations=3, max_iterations_large=99
+            )
+
+        assert client.chat.call_count == 3
+
+    def test_large_agent_uses_large_cap(self, tmp_path):
+        client = _always_tool_client()
+        with (
+            patch("uio.core.runner.make_client", return_value=client),
+            patch("uio.core.runner.select_provider_chain", return_value=["gemini"]),
+            patch("uio.core.runner.execute_tool", return_value="ok"),
+        ):
+            run_agent(**_make_run_args(tmp_path, "large"), max_iterations=3, max_iterations_large=5)
+
+        assert client.chat.call_count == 5
+
+    def test_small_agent_does_not_use_large_cap(self, tmp_path):
+        client = _always_tool_client()
+        with (
+            patch("uio.core.runner.make_client", return_value=client),
+            patch("uio.core.runner.select_provider_chain", return_value=["gemini"]),
+            patch("uio.core.runner.execute_tool", return_value="ok"),
+        ):
+            run_agent(
+                **_make_run_args(tmp_path, "small"), max_iterations=2, max_iterations_large=99
+            )
+
+        assert client.chat.call_count == 2

--- a/uio/cli/agent.py
+++ b/uio/cli/agent.py
@@ -105,6 +105,8 @@ def agent_run_cmd(
         ledger_path=cfg["runtime"]["cost_ledger"],
         large_agent_names=cfg["large_agents"]["names"],
         shell_override=shell,
+        max_iterations=cfg["runtime"]["max_iterations"],
+        max_iterations_large=cfg["runtime"]["max_iterations_large"],
     )
 
 

--- a/uio/config.py
+++ b/uio/config.py
@@ -22,6 +22,8 @@ _DEFAULTS: dict = {
         "default_provider": None,
         "cost_ledger": "uio_cost.jsonl",
         "timeout": 300,
+        "max_iterations": 10,
+        "max_iterations_large": 25,
     },
     "large_agents": {
         "names": [],
@@ -37,8 +39,10 @@ prompts = ".uio/prompts"
 
 [runtime]
 # default_provider = "gemini"
-cost_ledger      = "uio_cost.jsonl"
-timeout          = 300
+cost_ledger          = "uio_cost.jsonl"
+timeout              = 300
+max_iterations       = 10   # small agents (summarise, comment, query)
+max_iterations_large = 25   # large agents (github-coder, multi-step workflows)
 
 [large_agents]
 # Agent names that always use the large model tier (in addition to

--- a/uio/core/runner.py
+++ b/uio/core/runner.py
@@ -21,7 +21,8 @@ from uio.core.routing import infer_complexity, select_model, select_provider_cha
 from uio.core.tools import DEFAULT_TIMEOUT, TOOL_SCHEMA, execute_tool
 from uio.schema.parser import parse_definition_file
 
-MAX_ITERATIONS = 10
+_DEFAULT_MAX_ITERATIONS = 10
+_DEFAULT_MAX_ITERATIONS_LARGE = 25
 
 _RETRYABLE_SUBSTRINGS = ("503", "429", "UNAVAILABLE", "Too Many Requests", "rate limit")
 _MAX_CHAT_RETRIES = 3
@@ -125,6 +126,8 @@ def run_agent(
     ledger_path: str = DEFAULT_LEDGER_PATH,
     large_agent_names: list[str] | None = None,
     shell_override: str | None = None,
+    max_iterations: int = _DEFAULT_MAX_ITERATIONS,
+    max_iterations_large: int = _DEFAULT_MAX_ITERATIONS_LARGE,
 ) -> None:
     if definition_path is None:
         raise ValueError("definition_path must be provided")
@@ -174,6 +177,7 @@ def run_agent(
 
     resolved_complexity = infer_complexity(agent_name, frontmatter, complexity, large_agent_names)
     provider_chain = select_provider_chain(provider, resolved_complexity)
+    cap = max_iterations_large if resolved_complexity == "large" else max_iterations
 
     try:
         last_error: Exception | None = None
@@ -211,7 +215,7 @@ def run_agent(
             total_completion = 0
 
             try:
-                for iteration in range(1, MAX_ITERATIONS + 1):
+                for iteration in range(1, cap + 1):
                     print(f"[iteration {iteration}]")
                     for attempt in range(_MAX_CHAT_RETRIES):
                         try:
@@ -262,7 +266,11 @@ def run_agent(
                     ]
                     client.append_turn(history, response, tool_results)
 
-                print(f"\n⚠️  Reached iteration cap ({MAX_ITERATIONS}). Stopping.")
+                print(f"\n⚠️  Reached iteration cap ({cap}). Stopping.")
+                print(
+                    f"   The agent did not finish. Increase max_iterations{'_large' if resolved_complexity == 'large' else ''}"
+                    " in uio.toml or use --complexity to change the tier."
+                )
                 write_cost_ledger(
                     agent_name,
                     candidate_provider,


### PR DESCRIPTION
Fixes #93.

## Summary

- Replaces the single `MAX_ITERATIONS = 10` constant in `runner.py` with two tier-based parameters: `max_iterations` (small, default 10) and `max_iterations_large` (large, default 25)
- Both are configurable in `uio.toml` under `[runtime]` — no code change needed to tune budgets per environment
- `cli/agent.py` reads the values from config and passes them to `run_agent()`
- Cap-hit message now names the specific key to raise (`max_iterations` or `max_iterations_large`) and suggests `--complexity` as an alternative

## Why this matters

During the M6a pilot, `github-coder` hit the 10-iteration cap mid-workflow and the remaining steps (commit, push, open PR) had to be completed manually. Large agents have a minimum of ~8 sequential tool calls for a clean run; 25 gives comfortable headroom. Small agents (summarise, comment, query) rarely exceed 4 iterations — they keep the tighter budget.

## Test plan

- [ ] `TestDefaultCaps` — asserts 10 and 25 as the module-level defaults
- [ ] `TestIterationCapPerComplexity` — 3 tests: small agent stops at small cap, large agent uses large cap, small agent ignores large cap
- [ ] All 236 tests pass; `ruff` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)