### PR TITLE
feat: bundle @modelcontextprotocol/server-git in container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ RUN for pkg in \
         @github/github-mcp-server \
         @modelcontextprotocol/server-filesystem \
         @modelcontextprotocol/server-fetch \
-        @modelcontextprotocol/server-memory; \
+        @modelcontextprotocol/server-memory \
+        @modelcontextprotocol/server-git; \
     do npx -y "$pkg" --version 2>/dev/null || true; done
 
 # /workspace is the default mount point for uio.toml and .uio/ definitions.

--- a/docs/08-mcp.md
+++ b/docs/08-mcp.md
@@ -183,6 +183,37 @@ If a server fails to start, uio prints a warning and continues without it — th
 
 **Backwards compatibility:** If no `[mcp.github]` section is present in `uio.toml`, uio auto-starts the GitHub server whenever `GITHUB_PERSONAL_ACCESS_TOKEN` is set. Existing setups that rely on the token-based auto-start require no config changes.
 
+---
+
+## Git MCP server
+
+`@modelcontextprotocol/server-git` exposes local Git repository operations as typed JSON tools. Agents that frequently call `run_command` with `git log`, `git diff`, or `git blame` get structured responses instead of raw shell output — fewer parse errors and fewer context tokens consumed.
+
+### Tools exposed
+
+| Tool | Description |
+|---|---|
+| `mcp__git__git_log` | Structured commit history — author, date, message, sha |
+| `mcp__git__git_diff` | Typed diff between refs or against the working tree |
+| `mcp__git__git_show` | File content at a specific commit |
+| `mcp__git__git_blame` | Per-line attribution |
+| `mcp__git__git_status` | Working tree status |
+| `mcp__git__git_branch` | List or create branches |
+| `mcp__git__git_commit` | Stage and commit changes |
+
+### Configuration
+
+The server requires a `path` argument — the absolute path to the repository root inside the container:
+
+```toml
+[mcp.git]
+command = "npx -y @modelcontextprotocol/server-git /workspace"
+```
+
+`/workspace` is the default mount point in the uio container image. Adjust the path if you mount your repository elsewhere.
+
+`server-git` has no token requirement and starts unconditionally when `[mcp.git]` is present in `uio.toml`.
+
 **Duplicate server names** are not possible via `uio.toml` (TOML forbids duplicate keys). If `make_mcp_clients` is called programmatically with a dict that happens to have collisions, the first entry wins and subsequent ones are silently skipped.
 
 ---

--- a/docs/14-container.md
+++ b/docs/14-container.md
@@ -15,6 +15,7 @@ The following MCP servers are pre-warmed in the image (no download on first use)
 | Filesystem | `@modelcontextprotocol/server-filesystem` | `mcp__filesystem__*` — typed file read/write/list |
 | Fetch | `@modelcontextprotocol/server-fetch` | `mcp__fetch__*` — typed HTTP GET/POST |
 | Memory | `@modelcontextprotocol/server-memory` | `mcp__memory__*` — persistent KV store per session |
+| Git | `@modelcontextprotocol/server-git` | `mcp__git__*` — structured git log, diff, blame, show, status, branch, commit. Requires a `path` argument pointing to the repository root. |
 
 MCP server configuration is managed via `uio.toml`. See [MCP integration](08-mcp.md) for details.
 
@@ -79,6 +80,9 @@ command = "npx -y @modelcontextprotocol/server-fetch"
 
 [mcp.memory]
 command = "npx -y @modelcontextprotocol/server-memory"
+
+[mcp.git]
+command = "npx -y @modelcontextprotocol/server-git /workspace"
 ```
 
 ## Stateful paths

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -385,3 +385,65 @@ class TestMcpPlugins:
         # MCPClient called exactly once (for the plugin), not twice
         assert calls == ["linear"]
         assert "linear" in result
+
+
+class TestMcpGitServer:
+    def test_git_server_starts_from_config(self, monkeypatch):
+        """[mcp.git] config entry launches MCPClient with the git server command."""
+        monkeypatch.delenv("GITHUB_PERSONAL_ACCESS_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+        git_client = _make_mock_client("git")
+        captured = {}
+
+        def fake_mcp(command, server_name, **kwargs):
+            captured["command"] = command
+            captured["server_name"] = server_name
+            return git_client
+
+        with patch("uio.core.mcp.MCPClient", side_effect=fake_mcp):
+            result = make_mcp_clients(
+                {"git": {"command": "npx -y @modelcontextprotocol/server-git /workspace"}}
+            )
+
+        assert "git" in result
+        assert result["git"] is git_client
+        assert captured["server_name"] == "git"
+        assert "@modelcontextprotocol/server-git" in " ".join(captured["command"])
+
+    def test_git_server_no_token_required(self, monkeypatch):
+        """server-git starts without any GitHub token set."""
+        monkeypatch.delenv("GITHUB_PERSONAL_ACCESS_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+
+        git_client = _make_mock_client("git")
+        with patch("uio.core.mcp.MCPClient", return_value=git_client):
+            result = make_mcp_clients(
+                {"git": {"command": "npx -y @modelcontextprotocol/server-git /workspace"}}
+            )
+
+        assert "git" in result
+
+    def test_git_server_coexists_with_github_server(self, monkeypatch):
+        """git and github servers can run alongside each other."""
+        monkeypatch.setenv("GITHUB_PERSONAL_ACCESS_TOKEN", "tok")
+
+        clients = {
+            "github": _make_mock_client("github"),
+            "git": _make_mock_client("git"),
+        }
+
+        def fake_mcp(command, server_name, **kwargs):
+            return clients[server_name]
+
+        with (
+            patch("uio.core.mcp.MCPClient", side_effect=fake_mcp),
+            patch("uio.core.mcp.make_mcp_client", return_value=clients["github"]),
+        ):
+            result = make_mcp_clients(
+                {"git": {"command": "npx -y @modelcontextprotocol/server-git /workspace"}}
+            )
+
+        assert "git" in result
+        assert "github" in result

--- a/uio/config.py
+++ b/uio/config.py
@@ -53,6 +53,9 @@ names = []
 # [mcp.github]
 # command = "npx -y @github/github-mcp-server stdio"
 
+# [mcp.git]
+# command = "npx -y @modelcontextprotocol/server-git /workspace"
+
 # MCP plugin registry — external-provider servers loaded alongside bundled ones.
 # 'type' declares the capability class (vcs, db, browser, search, chat, tracker, ci, …).
 # 'env_keys' lists required environment variables; uio warns and skips if any are absent.


### PR DESCRIPTION
## Summary

- Pre-warms `@modelcontextprotocol/server-git` in the Dockerfile npm cache step alongside the existing four bundled MCP servers — no download penalty on first agent run
- Adds a commented `[mcp.git]` example to the `uio config init` starter TOML
- Documents `server-git` in `docs/14-container.md` (bundled servers table + minimal `uio.toml` snippet) and `docs/08-mcp.md` (tools table, `path` argument, configuration section)
- Adds three mock tests in `TestMcpGitServer` covering: config-driven launch, no-token requirement, and co-existence with the GitHub MCP server

Closes #106.

## Test plan

- [x] `pytest` — 260 passed
- [x] `ruff format` and `ruff check` — clean
- [ ] Docker image build with the updated `Dockerfile` (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)