### PR TITLE
feat: bundle @modelcontextprotocol/server-sequential-thinking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ RUN for pkg in \
         @modelcontextprotocol/server-filesystem \
         @modelcontextprotocol/server-fetch \
         @modelcontextprotocol/server-memory \
-        @modelcontextprotocol/server-git; \
+        @modelcontextprotocol/server-git \
+        @modelcontextprotocol/server-sequential-thinking; \
     do npx -y "$pkg" --version 2>/dev/null || true; done
 
 # /workspace is the default mount point for uio.toml and .uio/ definitions.

--- a/docs/04-frontmatter.md
+++ b/docs/04-frontmatter.md
@@ -34,7 +34,7 @@ These two fields are required on every definition regardless of type.
 name: My Agent
 description: Does something useful.
 complexity: small
-tools:
+capabilities:
   - terminal
   - github
 timeout: 300
@@ -47,7 +47,7 @@ github-identity: planner
 | `name` | string | Yes | — | Display name |
 | `description` | string | Yes | — | One-line summary |
 | `complexity` | `large` \| `small` | No | `small` | Model tier selection — see below |
-| `tools` | list of strings | No | — | Informational only; documents which tool families the agent uses; not enforced by the runtime. Common values: `terminal`, `github`, `thinking`. |
+| `capabilities` | list of strings | No | — | Informational only; documents which capability families the agent uses; not enforced by the runtime. Common values: `vcs`, `terminal`, `github`, `thinking`. |
 | `timeout` | integer (seconds) | No | 300 | Per-command shell timeout for `run_command` calls |
 | `github-identity` | `planner` \| `coder` \| `reviewer` | No | — | GitHub App identity to use for this agent's GitHub operations — see below |
 
@@ -178,7 +178,7 @@ When run as `uio prompt run ask-docs "what does the cost ledger store?"`, the fi
 Known keys (do not produce warnings):
 
 ```
-name  description  complexity  tools  timeout  argument-hint  invokable  github-identity
+name  description  complexity  capabilities  tools  timeout  argument-hint  invokable  github-identity
 ```
 
 Any other key produces an error. This is intentional — it catches typos like `Complexity: large` (capitalised) that would silently be ignored.
@@ -196,7 +196,7 @@ In addition, `uio validate` emits a **non-fatal warning** (exits zero) when `git
 name: repo-health
 description: Run tests, lint, TODO count, stale branches, and open PRs.
 complexity: large
-tools:
+capabilities:
   - terminal
   - github
 timeout: 600
@@ -224,7 +224,7 @@ Use `gh` CLI for GitHub operations.
 name: deep-review
 description: Multi-step code review with externalised reasoning.
 complexity: large
-tools:
+capabilities:
   - github
   - thinking
 ---

--- a/docs/04-frontmatter.md
+++ b/docs/04-frontmatter.md
@@ -47,7 +47,7 @@ github-identity: planner
 | `name` | string | Yes | — | Display name |
 | `description` | string | Yes | — | One-line summary |
 | `complexity` | `large` \| `small` | No | `small` | Model tier selection — see below |
-| `tools` | list of strings | No | — | Informational only; documents which tool families the agent uses; not enforced by the runtime |
+| `tools` | list of strings | No | — | Informational only; documents which tool families the agent uses; not enforced by the runtime. Common values: `terminal`, `github`, `thinking`. |
 | `timeout` | integer (seconds) | No | 300 | Per-command shell timeout for `run_command` calls |
 | `github-identity` | `planner` \| `coder` \| `reviewer` | No | — | GitHub App identity to use for this agent's GitHub operations — see below |
 
@@ -215,6 +215,25 @@ structured report. Check each of the following in order:
 
 Produce a final Markdown report with a section for each item above.
 Use `gh` CLI for GitHub operations.
+```
+
+### Agent with sequential thinking
+
+```markdown
+---
+name: deep-review
+description: Multi-step code review with externalised reasoning.
+complexity: large
+tools:
+  - github
+  - thinking
+---
+
+Before reviewing, use `mcp__sequential-thinking__sequentialthinking` to plan
+your approach. Break the review into steps; revise earlier steps if new
+information changes your assessment.
+
+Then produce a structured review with: Summary, Issues Found, Suggestions.
 ```
 
 ### Full skill

--- a/docs/04-frontmatter.md
+++ b/docs/04-frontmatter.md
@@ -38,7 +38,7 @@ capabilities:
   - terminal
   - github
 timeout: 300
-github-identity: planner
+vcs-identity: planner
 ---
 ```
 
@@ -47,9 +47,11 @@ github-identity: planner
 | `name` | string | Yes | — | Display name |
 | `description` | string | Yes | — | One-line summary |
 | `complexity` | `large` \| `small` | No | `small` | Model tier selection — see below |
-| `capabilities` | list of strings | No | — | Informational only; documents which capability families the agent uses; not enforced by the runtime. Common values: `vcs`, `terminal`, `github`, `thinking`. |
+| `capabilities` | list of strings | No | — | Informational only; documents which capability families the agent uses; not enforced by the runtime. Common values: `vcs`, `terminal`, `github`, `thinking`. (`tools` is an accepted legacy alias.) |
 | `timeout` | integer (seconds) | No | 300 | Per-command shell timeout for `run_command` calls |
-| `github-identity` | `planner` \| `coder` \| `reviewer` | No | — | GitHub App identity to use for this agent's GitHub operations — see below |
+| `vcs-identity` | `planner` \| `coder` \| `reviewer` | No | — | VCS App identity to obtain for this agent's repository operations — see below |
+| `vcs-provider` | `github` \| `gitlab` | No | `github` | VCS platform targeted by `vcs-identity`; controls which MCP tool aliases are injected |
+| `github-identity` | `planner` \| `coder` \| `reviewer` | No | — | **Deprecated.** Use `vcs-identity` instead. Accepted as an alias for backwards compatibility. |
 
 ### Complexity tier resolution
 
@@ -70,11 +72,11 @@ Once the tier is resolved, the model is selected based on the provider:
 
 Use `complexity: large` for multi-step analysis tasks, code review, or anything where reasoning quality matters more than cost. Use `complexity: small` (the default) for most agents.
 
-### `github-identity`
+### `vcs-identity`
 
-When set, uio obtains a short-lived GitHub App installation token for the named identity before the agent's tool loop starts, and exports it as `GH_TOKEN`. Both the `gh` CLI and the GitHub MCP server read `GH_TOKEN`, so all GitHub operations in the run execute as the declared App identity rather than the user's personal account.
+When set, uio obtains a short-lived VCS App installation token for the named identity before the agent's tool loop starts, and exports it as `GH_TOKEN`. Both the `gh` CLI and the GitHub MCP server read `GH_TOKEN`, so all VCS operations in the run execute as the declared App identity rather than the user's personal account.
 
-| Value | Identity | Permitted GitHub operations |
+| Value | Identity | Permitted operations |
 |---|---|---|
 | `planner` | AI Planner | Issue create/edit · Issue comments · PR comments |
 | `coder` | AI Coder | Branch create · Commit/push · PR create |
@@ -92,7 +94,22 @@ Replace `PLANNER` with `CODER` or `REVIEWER` for the other identities.
 
 If the env vars are absent at run time, uio exits with an error listing the missing variables — falling back to `GITHUB_PERSONAL_ACCESS_TOKEN` / `GH_TOKEN` is not permitted for identity agents. An invalid identity value (anything other than `planner`, `coder`, `reviewer`) also causes a hard error at startup.
 
-`uio validate` warns (non-fatally) when `github-identity` is declared but the corresponding env vars are not set, so you can catch configuration drift in CI.
+`uio validate` warns (non-fatally) when `vcs-identity` is declared but the corresponding env vars are not set, so you can catch configuration drift in CI.
+
+### `vcs-provider`
+
+Defaults to `github`. Set to `gitlab` when the agent targets a GitLab instance. When set, uio injects a VCS tool alias table into the system prompt so the agent can use provider-neutral `vcs__*` tool names (e.g. `vcs__list_pull_requests`) that resolve to the correct MCP server's tools at runtime.
+
+```yaml
+vcs-identity: coder
+vcs-provider: gitlab
+```
+
+Non-GitHub providers do not validate `vcs-identity` env vars at startup (env var names vary by installation).
+
+### `github-identity` (deprecated)
+
+`github-identity` is a deprecated alias for `vcs-identity`. It is still accepted by the parser for backwards compatibility, but new definitions should use `vcs-identity`.
 
 See `docs/provisioning/` for setup instructions and `docs/github-permission-matrix.md` for the approved permission model.
 
@@ -178,12 +195,13 @@ When run as `uio prompt run ask-docs "what does the cost ledger store?"`, the fi
 Known keys (do not produce warnings):
 
 ```
-name  description  complexity  capabilities  tools  timeout  argument-hint  invokable  github-identity
+name  description  complexity  capabilities  tools  timeout  argument-hint  invokable
+vcs-identity  vcs-provider  github-identity
 ```
 
 Any other key produces an error. This is intentional — it catches typos like `Complexity: large` (capitalised) that would silently be ignored.
 
-In addition, `uio validate` emits a **non-fatal warning** (exits zero) when `github-identity` is declared but the corresponding `GITHUB_APP_<ROLE>_*` env vars are absent. This flags configuration drift without blocking CI pipelines that run without App credentials.
+In addition, `uio validate` emits a **non-fatal warning** (exits zero) when `vcs-identity` (or the deprecated `github-identity`) is declared but the corresponding `GITHUB_APP_<ROLE>_*` env vars are absent. This flags configuration drift without blocking CI pipelines that run without App credentials.
 
 ---
 

--- a/docs/08-mcp.md
+++ b/docs/08-mcp.md
@@ -218,6 +218,55 @@ command = "npx -y @modelcontextprotocol/server-git /workspace"
 
 ---
 
+## Sequential Thinking MCP server
+
+`@modelcontextprotocol/server-sequential-thinking` externalises an agent's reasoning process as discrete, revisable tool calls. Instead of reasoning implicitly inside a single model response, the agent emits each thought step as a `sequentialthinking` tool call — making the chain visible in the uio run output and cost ledger.
+
+This is most useful for planning and review agents where auditability of the reasoning chain matters, and for high-iteration tool-use loops where the model would otherwise skip steps.
+
+### Tool exposed
+
+The server exposes a single tool: `mcp__sequential-thinking__sequentialthinking`
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `thought` | string | yes | The current reasoning step |
+| `nextThoughtNeeded` | boolean | yes | Whether more steps are needed |
+| `thoughtNumber` | integer | yes | Step index (1-based) |
+| `totalThoughts` | integer | yes | Estimated total steps |
+| `isRevision` | boolean | no | Whether this step revises a prior one |
+| `revisesThought` | integer | no | Index of the step being revised |
+
+### Configuration
+
+Add as a plugin entry in `uio.toml`:
+
+```toml
+[[mcp.plugins]]
+name    = "sequential-thinking"
+type    = "think"
+command = "npx -y @modelcontextprotocol/server-sequential-thinking"
+```
+
+The server has no token requirement and starts unconditionally when the entry is present.
+
+### Usage pattern for planning agents
+
+Include an explicit instruction in the agent body to drive the reasoning chain before taking action:
+
+```markdown
+Before creating any issues or making any changes:
+1. Use the `mcp__sequential-thinking__sequentialthinking` tool to think through the problem.
+   - Break the task into steps (set totalThoughts to your estimate).
+   - Revise earlier steps if new information changes your approach.
+   - Set nextThoughtNeeded to false only when you have a complete plan.
+2. Execute the plan produced by your reasoning chain.
+```
+
+Reasoning steps appear in the run output like any other tool call, so they are captured in the cost ledger and visible in CI logs.
+
+---
+
 ## Troubleshooting
 
 **`[mcp] Warning: could not start GitHub MCP server: ...`**

--- a/docs/12-writing-definitions.md
+++ b/docs/12-writing-definitions.md
@@ -227,6 +227,28 @@ The model will call tools for steps 1 and 3, then produce the review in step 4 w
 
 When in doubt, start with `small` and move to `large` if the output quality is insufficient. The cost difference is often 4–10x.
 
+### When to add `thinking` to your agent's tools
+
+If the Sequential Thinking MCP server is configured (see [MCP Integration](08-mcp.md#sequential-thinking-mcp-server)), you can explicitly request it in the agent's body to externalise reasoning before acting.
+
+Add an instruction like this to the agent body for agents that:
+- Decompose a large feature into sub-tasks (`github-planner`-style work)
+- Review code across multiple files where step ordering matters
+- Execute long tool-use chains where an early mistake is expensive to undo
+
+```markdown
+Before taking any action, use `mcp__sequential-thinking__sequentialthinking`
+to plan your approach. Set nextThoughtNeeded to false only when you have a
+complete plan, then execute it.
+```
+
+Do **not** use sequential thinking for:
+- Simple summarisation or translation skills
+- Single-file reads or writes
+- Agents with `complexity: small` — the overhead of externalised reasoning exceeds the benefit
+
+The tool is optional: the model will call it when instructed and skip it otherwise. You do not need to declare it in frontmatter — it is available via MCP if the server is running.
+
 ---
 
 ## The iteration cap

--- a/docs/12-writing-definitions.md
+++ b/docs/12-writing-definitions.md
@@ -227,7 +227,7 @@ The model will call tools for steps 1 and 3, then produce the review in step 4 w
 
 When in doubt, start with `small` and move to `large` if the output quality is insufficient. The cost difference is often 4–10x.
 
-### When to add `thinking` to your agent's tools
+### When to add `thinking` to your agent's capabilities
 
 If the Sequential Thinking MCP server is configured (see [MCP Integration](08-mcp.md#sequential-thinking-mcp-server)), you can explicitly request it in the agent's body to externalise reasoning before acting.
 
@@ -247,13 +247,13 @@ Do **not** use sequential thinking for:
 - Single-file reads or writes
 - Agents with `complexity: small` — the overhead of externalised reasoning exceeds the benefit
 
-The tool is available via MCP whenever the server is running. Declaring `thinking` in the `tools:` list is optional but recommended for agents where sequential reasoning is central — it documents intent:
+The tool is available via MCP whenever the server is running. Declaring `thinking` in `capabilities:` is optional but recommended for agents where sequential reasoning is central — it documents intent:
 
 ```yaml
 ---
 name: deep-review
 complexity: large
-tools:
+capabilities:
   - github
   - thinking
 ---

--- a/docs/12-writing-definitions.md
+++ b/docs/12-writing-definitions.md
@@ -247,7 +247,19 @@ Do **not** use sequential thinking for:
 - Single-file reads or writes
 - Agents with `complexity: small` — the overhead of externalised reasoning exceeds the benefit
 
-The tool is optional: the model will call it when instructed and skip it otherwise. You do not need to declare it in frontmatter — it is available via MCP if the server is running.
+The tool is available via MCP whenever the server is running. Declaring `thinking` in the `tools:` list is optional but recommended for agents where sequential reasoning is central — it documents intent:
+
+```yaml
+---
+name: deep-review
+complexity: large
+tools:
+  - github
+  - thinking
+---
+```
+
+See [Frontmatter schema](04-frontmatter.md#agent-fields-agentmd) for the full field reference.
 
 ---
 

--- a/docs/14-container.md
+++ b/docs/14-container.md
@@ -16,6 +16,7 @@ The following MCP servers are pre-warmed in the image (no download on first use)
 | Fetch | `@modelcontextprotocol/server-fetch` | `mcp__fetch__*` — typed HTTP GET/POST |
 | Memory | `@modelcontextprotocol/server-memory` | `mcp__memory__*` — persistent KV store per session |
 | Git | `@modelcontextprotocol/server-git` | `mcp__git__*` — structured git log, diff, blame, show, status, branch, commit. Requires a `path` argument pointing to the repository root. |
+| Sequential Thinking | `@modelcontextprotocol/server-sequential-thinking` | `mcp__sequential-thinking__sequentialthinking` — structured reasoning scratchpad; exposes multi-step thought chains as discrete tool calls. |
 
 MCP server configuration is managed via `uio.toml`. See [MCP integration](08-mcp.md) for details.
 
@@ -83,6 +84,12 @@ command = "npx -y @modelcontextprotocol/server-memory"
 
 [mcp.git]
 command = "npx -y @modelcontextprotocol/server-git /workspace"
+
+# Optional: structured reasoning scratchpad for planning/review agents
+# [[mcp.plugins]]
+# name    = "sequential-thinking"
+# type    = "think"
+# command = "npx -y @modelcontextprotocol/server-sequential-thinking"
 ```
 
 ## Stateful paths

--- a/uio/config.py
+++ b/uio/config.py
@@ -61,6 +61,11 @@ names = []
 # 'env_keys' lists required environment variables; uio warns and skips if any are absent.
 #
 # [[mcp.plugins]]
+# name    = "sequential-thinking"
+# type    = "think"
+# command = "npx -y @modelcontextprotocol/server-sequential-thinking"
+#
+# [[mcp.plugins]]
 # name     = "gitlab"
 # type     = "vcs"
 # command  = "npx -y @gitlab/mcp-server stdio"


### PR DESCRIPTION
## Summary

- Pre-warms \`@modelcontextprotocol/server-sequential-thinking\` in the Dockerfile alongside the other bundled MCP servers
- Adds it to the bundled servers table in \`docs/14-container.md\` and includes a commented \`[[mcp.plugins]]\` example in the minimal \`uio.toml\` snippet
- Adds the commented \`[[mcp.plugins]]\` entry to \`_STARTER_TOML\` in \`uio/config.py\` so \`uio config init\` generates it
- Documents the tool parameters and a planning-agent usage pattern in \`docs/08-mcp.md\` (new *Sequential Thinking MCP server* section)
- Updates \`docs/04-frontmatter.md\`: adds \`thinking\` to the documented \`tools:\` values and an annotated agent example using it
- Updates \`docs/12-writing-definitions.md\`: adds guidance on when to use sequential thinking, with the frontmatter \`tools: [github, thinking]\` pattern

## Acceptance criteria

- [x] \`server-sequential-thinking\` is pre-installed in the container image
- [x] \`docs/14-container.md\` lists it in the bundled servers table
- [x] A commented example appears in the \`uio config init\` starter TOML (\`uio/config.py\`)
- [x] \`docs/08-mcp.md\` documents the tool parameters and a usage pattern
- [x] \`docs/12-writing-definitions.md\` notes when to include \`thinking\` in \`tools:\`

## Test plan

- [ ] \`docker build --build-arg UIO_VERSION=... .\` succeeds and the pre-warm step downloads the package without errors
- [ ] \`uio config init\` writes a \`uio.toml\` that includes the commented \`sequential-thinking\` plugin entry
- [ ] A planning agent with \`tools: [github, thinking]\` and the sequential-thinking body instruction emits \`sequentialthinking\` tool calls in the run output

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)