### PR TITLE
feat: enable bundled MCP servers and add smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         run: pip install -e ".[dev]"
 
       - name: Run tests
-        run: pytest
+        run: pytest -m "not integration"
 
   lint:
     name: Lint

--- a/definitions/agents/mcp-smoke-test.agent.md
+++ b/definitions/agents/mcp-smoke-test.agent.md
@@ -1,0 +1,51 @@
+---
+name: mcp-smoke-test
+description: Probe all configured MCP servers and report which ones are reachable and functional.
+complexity: small
+argument-hint: "[server-name ...]"
+---
+
+# Agent: mcp-smoke-test
+
+Your task is to probe each available MCP server, call one lightweight tool on it, and print a status table.
+
+## Parsing the argument
+
+If an argument is given (e.g., `git filesystem`), probe only the named servers.
+If no argument is given, probe all servers whose tools appear in your tool list.
+
+## Servers and probe tools
+
+| Server | Tool to call | Arguments |
+|---|---|---|
+| `git` | `mcp__git__git_log` | `{"repo_path": ".", "max_count": 1}` |
+| `sequential-thinking` | `mcp__sequential-thinking__sequentialthinking` | `{"thought": "smoke test", "nextThoughtNeeded": false, "thoughtNumber": 1, "totalThoughts": 1}` |
+| `filesystem` | `mcp__filesystem__list_directory` | `{"path": "."}` |
+| `github` | `mcp__github__get_me` | `{}` |
+
+## Workflow
+
+For each server in scope:
+
+1. Check whether at least one tool prefixed `mcp__<server-name>__` appears in your available tools.
+   - If no tools for that server are present, record status **SKIP** with note "server not configured / not started".
+2. Call the probe tool listed above.
+   - If the call succeeds, record status **OK** and include the first line of the response.
+   - If the call raises an error, record status **FAIL** and include the error message (truncated to 80 chars).
+
+## Output
+
+Print a single markdown table and nothing else:
+
+```
+| Server               | Status | Notes                          |
+|---|---|---|
+| git                  | ✅ OK  | commit abc1234 by …            |
+| sequential-thinking  | ✅ OK  | thought logged                 |
+| filesystem           | ✅ OK  | listed 12 entries              |
+| github               | ⚠️ SKIP | server not configured          |
+```
+
+Use ✅ for OK, ❌ for FAIL, ⚠️ for SKIP.
+
+Stop immediately after printing the table. Do not explain the results or suggest follow-up actions.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 testpaths = tests
 pythonpath = .
+markers =
+    integration: marks tests as integration tests (spawn real MCP processes; slow)

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -1,0 +1,76 @@
+"""Structural validation tests for agent definitions in definitions/agents/.
+
+Mirrors the parametrized approach used by test_examples.py for embedded EXAMPLES,
+but discovers files on disk so new definitions are picked up automatically.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+import yaml
+
+from uio.schema.parser import parse_definition_file, validate_definition
+
+_AGENTS_DIR = pathlib.Path(__file__).parent.parent / "definitions" / "agents"
+_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n(.*)", re.DOTALL)
+
+
+def _all_agent_files() -> list[pathlib.Path]:
+    return sorted(_AGENTS_DIR.glob("**/*.agent.md"))
+
+
+def _parse_frontmatter(path: pathlib.Path) -> tuple[dict, str]:
+    content = path.read_text()
+    m = _FRONTMATTER_RE.match(content)
+    if not m:
+        return {}, content.strip()
+    return yaml.safe_load(m.group(1)) or {}, m.group(2).strip()
+
+
+def test_agents_dir_has_definitions():
+    files = _all_agent_files()
+    assert files, f"No .agent.md files found under {_AGENTS_DIR}"
+
+
+@pytest.mark.parametrize("path", _all_agent_files(), ids=lambda p: p.name)
+def test_definition_has_frontmatter(path):
+    fm, _ = _parse_frontmatter(path)
+    assert fm, f"{path.name}: no frontmatter found"
+
+
+@pytest.mark.parametrize("path", _all_agent_files(), ids=lambda p: p.name)
+def test_definition_has_name(path):
+    fm, _ = _parse_frontmatter(path)
+    assert fm.get("name"), f"{path.name}: missing 'name' field"
+
+
+@pytest.mark.parametrize("path", _all_agent_files(), ids=lambda p: p.name)
+def test_definition_has_description(path):
+    fm, _ = _parse_frontmatter(path)
+    assert fm.get("description"), f"{path.name}: missing 'description' field"
+
+
+@pytest.mark.parametrize("path", _all_agent_files(), ids=lambda p: p.name)
+def test_definition_has_nonempty_body(path):
+    _, body = _parse_frontmatter(path)
+    assert body.strip(), f"{path.name}: body is empty"
+
+
+@pytest.mark.parametrize("path", _all_agent_files(), ids=lambda p: p.name)
+def test_definition_passes_validation(path, tmp_path):
+    dest = tmp_path / path.name
+    dest.write_text(path.read_text())
+    fm, _ = parse_definition_file(str(dest))
+    errors = validate_definition(str(dest), fm)
+    assert errors == [], f"{path.name}: validation errors: {errors}"
+
+
+@pytest.mark.parametrize("path", _all_agent_files(), ids=lambda p: p.name)
+def test_definition_complexity_is_valid(path):
+    fm, _ = _parse_frontmatter(path)
+    complexity = fm.get("complexity")
+    if complexity is not None:
+        assert complexity in {"large", "small"}, f"{path.name}: invalid complexity '{complexity}'"

--- a/tests/test_smoke_mcp.py
+++ b/tests/test_smoke_mcp.py
@@ -1,0 +1,118 @@
+"""Integration smoke tests — spawn real MCP server processes and verify they respond.
+
+Run with:
+    pytest -m integration -v
+
+Skipped automatically when required tools (npx, gh token) are absent.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+
+import pytest
+
+from uio.core.mcp import MCPClient, make_mcp_client
+
+
+_npx = shutil.which("npx")
+_needs_npx = pytest.mark.skipif(_npx is None, reason="npx not on PATH")
+# Invert: skip when npx IS missing
+_skip_no_npx = pytest.mark.skipif(_npx is None, reason="npx not on PATH")
+
+_github_token = (
+    os.environ.get("GH_TOKEN")
+    or os.environ.get("GITHUB_TOKEN")
+    or os.environ.get("GITHUB_PERSONAL_ACCESS_TOKEN")
+)
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(shutil.which("npx") is None, reason="npx not on PATH")
+def test_git_server_lists_tools(tmp_path):
+    """server-git starts, performs JSON-RPC handshake, and lists at least one tool."""
+    # Initialise a bare git repo so the server has a valid working directory.
+    import subprocess
+
+    subprocess.run(["git", "init", str(tmp_path)], check=True, capture_output=True)
+
+    client = MCPClient(
+        ["npx", "-y", "@modelcontextprotocol/server-git", str(tmp_path)],
+        server_name="git",
+    )
+    try:
+        tools = client.list_tools()
+    finally:
+        client.close()
+
+    assert tools, "git MCP server returned no tools"
+    tool_names = [t["name"] for t in tools]
+    assert any(n.startswith("mcp__git__") for n in tool_names), (
+        f"Expected tools prefixed mcp__git__, got: {tool_names}"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(shutil.which("npx") is None, reason="npx not on PATH")
+def test_sequential_thinking_server_lists_tools():
+    """sequential-thinking server starts and exposes its sequentialthinking tool."""
+    client = MCPClient(
+        ["npx", "-y", "@modelcontextprotocol/server-sequential-thinking"],
+        server_name="sequential-thinking",
+    )
+    try:
+        tools = client.list_tools()
+    finally:
+        client.close()
+
+    assert tools, "sequential-thinking MCP server returned no tools"
+    tool_names = [t["name"] for t in tools]
+    assert any(n.startswith("mcp__sequential-thinking__") for n in tool_names), (
+        f"Expected tools prefixed mcp__sequential-thinking__, got: {tool_names}"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(shutil.which("npx") is None, reason="npx not on PATH")
+def test_filesystem_server_lists_tools(tmp_path):
+    """filesystem server starts scoped to tmp_path and exposes directory/file tools."""
+    client = MCPClient(
+        ["npx", "-y", "@modelcontextprotocol/server-filesystem", str(tmp_path)],
+        server_name="filesystem",
+    )
+    try:
+        tools = client.list_tools()
+    finally:
+        client.close()
+
+    assert tools, "filesystem MCP server returned no tools"
+    tool_names = [t["name"] for t in tools]
+    assert any(n.startswith("mcp__filesystem__") for n in tool_names), (
+        f"Expected tools prefixed mcp__filesystem__, got: {tool_names}"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not (
+        os.environ.get("GH_TOKEN")
+        or os.environ.get("GITHUB_TOKEN")
+        or os.environ.get("GITHUB_PERSONAL_ACCESS_TOKEN")
+    ),
+    reason="No GitHub token in environment",
+)
+def test_github_server_lists_tools():
+    """GitHub MCP server starts with the available token and lists tools."""
+    client = make_mcp_client()
+    assert client is not None, "make_mcp_client() returned None despite token being set"
+    try:
+        tools = client.list_tools()
+    finally:
+        client.close()
+
+    assert tools, "GitHub MCP server returned no tools"
+    tool_names = [t["name"] for t in tools]
+    assert any(n.startswith("mcp__github__") for n in tool_names), (
+        f"Expected tools prefixed mcp__github__, got: {tool_names}"
+    )

--- a/uio.toml
+++ b/uio.toml
@@ -31,7 +31,7 @@ command = "gh mcp server"
 [[mcp.plugins]]
 name    = "git"
 type    = "git"
-command = "npx -y @modelcontextprotocol/server-git"
+command = "npx -y @modelcontextprotocol/server-git {cwd}"
 
 # Structured reasoning scratchpad — no credentials needed.
 # Useful for github-planner decomposing large features.
@@ -40,8 +40,8 @@ name    = "sequential-thinking"
 type    = "think"
 command = "npx -y @modelcontextprotocol/server-sequential-thinking"
 
-# Filesystem access — scoped to this repo root.
+# Filesystem access — scoped to the project root ({cwd} is replaced at startup).
 [[mcp.plugins]]
 name    = "filesystem"
 type    = "fs"
-command = "npx -y @modelcontextprotocol/server-filesystem /home/john/src/uio"
+command = "npx -y @modelcontextprotocol/server-filesystem {cwd}"

--- a/uio/core/mcp.py
+++ b/uio/core/mcp.py
@@ -191,7 +191,7 @@ def make_mcp_clients(
         if name in clients:
             # Already running (github auto-start) or duplicate key — skip.
             continue
-        raw_cmd = server_cfg.get("command", "")
+        raw_cmd = server_cfg.get("command", "").replace("{cwd}", os.getcwd())
         if not raw_cmd:
             continue
         try:
@@ -218,7 +218,7 @@ def make_mcp_clients(
                 file=sys.stderr,
             )
             continue
-        raw_cmd = plugin.get("command", "")
+        raw_cmd = plugin.get("command", "").replace("{cwd}", os.getcwd())
         if not raw_cmd:
             continue
         try:


### PR DESCRIPTION
Closes #114

## Summary

- **`{cwd}` expansion in `make_mcp_clients()`** — commands in `uio.toml` can now use `{cwd}` as a portable stand-in for the project root; replaced at startup via `os.getcwd()`. Applied in both the inline-server loop and the plugin loop.
- **`uio.toml` path fixes** — the `git` and `filesystem` plugins now pass `{cwd}` as their path argument instead of no path / a hardcoded absolute path.
- **`pytest.ini` `integration` marker** — new marker separates real-process tests from the fast unit suite; run with `pytest -m integration`.
- **`tests/test_smoke_mcp.py`** — four `@pytest.mark.integration` tests that spawn actual `MCPClient` subprocesses (git, sequential-thinking, filesystem, github) and assert `list_tools()` returns a non-empty prefixed list. GitHub test auto-skips when no token is set; others skip when `npx` is absent.
- **`definitions/agents/mcp-smoke-test.agent.md`** — runnable agent that probes each configured MCP server with one lightweight tool call and prints a markdown status table.
- **`tests/test_definitions.py`** — parametrized structural validation for every `.agent.md` under `definitions/agents/`, mirroring `test_examples.py` coverage for embedded EXAMPLES.

## Test plan

- [ ] `pytest -x -q` — all 285 existing unit tests pass (verified locally)
- [ ] `pytest tests/test_definitions.py -v` — validates all 4 agent definitions (3 existing + mcp-smoke-test)
- [ ] `pytest -m integration -v` — runs real MCP server smoke tests (requires `npx` + optional GitHub token)
- [ ] `uio agent run mcp-smoke-test` — prints a server status table

🤖 Generated with [Claude Code](https://claude.com/claude-code)