### PR TITLE
feat: add mcp-smoke-test agent with robustness fixes

### DIFF
--- a/definitions/agents/mcp-smoke-test.agent.md
+++ b/definitions/agents/mcp-smoke-test.agent.md
@@ -7,45 +7,50 @@ argument-hint: "[server-name ...]"
 
 # Agent: mcp-smoke-test
 
-Your task is to probe each available MCP server, call one lightweight tool on it, and print a status table.
+Your task is to probe each available MCP server and print a status table.
+
+**Do not narrate or explain. Issue all probe tool calls in a single step, then immediately print the table.**
 
 ## Parsing the argument
 
 If an argument is given (e.g., `git filesystem`), probe only the named servers.
 If no argument is given, probe all servers whose tools appear in your tool list.
 
-## Servers and probe tools
+## Step 1 — Call all probe tools simultaneously
 
-| Server | Tool to call | Arguments |
+In a single response, issue every applicable tool call at once (do not call them one at a time):
+
+| Server | Tool | Arguments |
 |---|---|---|
 | `git` | `mcp__git__git_log` | `{"repo_path": ".", "max_count": 1}` |
 | `sequential-thinking` | `mcp__sequential-thinking__sequentialthinking` | `{"thought": "smoke test", "nextThoughtNeeded": false, "thoughtNumber": 1, "totalThoughts": 1}` |
 | `filesystem` | `mcp__filesystem__list_directory` | `{"path": "."}` |
-| `github` | `mcp__github__get_me` | `{}` |
+| `github` | `mcp__github__search_repositories` | `{"query": "repo:jomkz/uio"}` |
 
-## Workflow
+Skip any server whose tools are absent from your tool list — record it as ⚠️ SKIP in the table.
 
-For each server in scope:
+## Step 2 — Print the table
 
-1. Check whether at least one tool prefixed `mcp__<server-name>__` appears in your available tools.
-   - If no tools for that server are present, record status **SKIP** with note "server not configured / not started".
-2. Call the probe tool listed above.
-   - If the call succeeds, record status **OK** and include the first line of the response.
-   - If the call raises an error, record status **FAIL** and include the error message (truncated to 80 chars).
-
-## Output
-
-Print a single markdown table and nothing else:
+After all tool results are in, print exactly this table and nothing else:
 
 ```
-| Server               | Status | Notes                          |
+| Server               | Status  | Notes                          |
 |---|---|---|
-| git                  | ✅ OK  | commit abc1234 by …            |
-| sequential-thinking  | ✅ OK  | thought logged                 |
-| filesystem           | ✅ OK  | listed 12 entries              |
-| github               | ⚠️ SKIP | server not configured          |
+| git                  | ✅ OK   | commit 6916a28                 |
+| sequential-thinking  | ✅ OK   | thought logged                 |
+| filesystem           | ✅ OK   | listed 12 entries              |
+| github               | ✅ OK   | jomkz/uio — Universal I/O     |
 ```
 
-Use ✅ for OK, ❌ for FAIL, ⚠️ for SKIP.
+Use ✅ OK · ❌ FAIL · ⚠️ SKIP.
 
-Stop immediately after printing the table. Do not explain the results or suggest follow-up actions.
+### Notes rules — enforce these strictly
+
+| Server | Note format | Hard limit |
+|---|---|---|
+| `git` | `commit <7-char hash>` | Hash only — omit the commit message |
+| `sequential-thinking` | `thought logged` | — |
+| `filesystem` | `listed <N> entries` | — |
+| `github` | `<full_name>` only | 20 chars max, no description |
+
+Never include raw JSON, full sentences, URLs, or object literals in the Notes column.

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 
-from uio.core.mcp import _default_github_mcp_command, make_mcp_client, make_mcp_clients
+from uio.core.mcp import MCPClient, _default_github_mcp_command, make_mcp_client, make_mcp_clients
 
 
 class TestDefaultGithubMcpCommand:
@@ -409,3 +410,35 @@ class TestMcpGitServer:
 
         assert "git" in result
         assert "github" in result
+
+
+class TestMCPClientCallTool:
+    """Unit tests for MCPClient.call_tool without spawning a real process."""
+
+    def _make_client(self, server_name: str = "github") -> MCPClient:
+        client = MCPClient.__new__(MCPClient)
+        client.server_name = server_name
+        client._id = 0
+        return client
+
+    def test_mcp_tool_error_returned_as_string(self):
+        client = self._make_client()
+        err = RuntimeError("MCP error: {'code': -32603, 'message': 'Unknown tool: get_me'}")
+        with patch.object(client, "_rpc", side_effect=err):
+            result = client.call_tool("mcp__github__get_me", {})
+        assert "MCP error:" in result
+        assert "Unknown tool" in result
+
+    def test_server_closed_error_still_raises(self):
+        client = self._make_client()
+        err = RuntimeError("MCP server closed connection unexpectedly")
+        with patch.object(client, "_rpc", side_effect=err):
+            with pytest.raises(RuntimeError, match="closed connection"):
+                client.call_tool("mcp__github__search_repositories", {})
+
+    def test_successful_call_returns_text_content(self):
+        client = self._make_client()
+        payload = {"content": [{"type": "text", "text": "found 1 repo"}]}
+        with patch.object(client, "_rpc", return_value=payload):
+            result = client.call_tool("mcp__github__search_repositories", {"query": "uio"})
+        assert result == "found 1 repo"

--- a/tests/test_runner_retry.py
+++ b/tests/test_runner_retry.py
@@ -23,6 +23,9 @@ class TestIsRetryable:
     def test_rate_limit_is_retryable(self):
         assert _is_retryable(Exception("rate limit exceeded"))
 
+    def test_resource_exhausted_is_retryable(self):
+        assert _is_retryable(Exception("RESOURCE_EXHAUSTED: quota exceeded"))
+
     def test_auth_error_is_not_retryable(self):
         assert not _is_retryable(Exception("401 Unauthorized"))
 

--- a/uio/core/mcp.py
+++ b/uio/core/mcp.py
@@ -84,7 +84,12 @@ class MCPClient:
         """Call a tool by prefixed name and return text output."""
         prefix = f"mcp__{self.server_name}__"
         actual = name[len(prefix) :] if name.startswith(prefix) else name
-        result = self._rpc("tools/call", {"name": actual, "arguments": args})
+        try:
+            result = self._rpc("tools/call", {"name": actual, "arguments": args})
+        except RuntimeError as e:
+            if str(e).startswith("MCP error:"):
+                return str(e)
+            raise
         parts = [item["text"] for item in result.get("content", []) if item.get("type") == "text"]
         return "\n".join(parts) or "(no output)"
 

--- a/uio/core/runner.py
+++ b/uio/core/runner.py
@@ -25,9 +25,16 @@ from uio.schema.parser import parse_definition_file
 _DEFAULT_MAX_ITERATIONS = 10
 _DEFAULT_MAX_ITERATIONS_LARGE = 25
 
-_RETRYABLE_SUBSTRINGS = ("503", "429", "UNAVAILABLE", "Too Many Requests", "rate limit")
+_RETRYABLE_SUBSTRINGS = (
+    "503",
+    "429",
+    "UNAVAILABLE",
+    "RESOURCE_EXHAUSTED",
+    "Too Many Requests",
+    "rate limit",
+)
 _MAX_CHAT_RETRIES = 3
-_RETRY_BACKOFF = [1, 2, 4]  # seconds
+_RETRY_BACKOFF = [5, 15, 30]  # seconds — enough for Gemini high-demand 503s to clear
 
 
 def _is_retryable(exc: Exception) -> bool:


### PR DESCRIPTION
## Summary

- **New agent** `mcp-smoke-test` — probes all configured MCP servers (git, sequential-thinking, filesystem, github) and prints a clean status table; instructs parallel tool calls and enforces strict per-server Notes formatting (hash-only for git, `full_name` for github, etc.)
- **`MCPClient.call_tool` error handling** — MCP tool errors (e.g. unknown tool name) are now returned as strings to the LLM instead of raising, preventing the router from misidentifying them as provider failures and triggering unwanted fallback
- **Retry backoff increase** — `_RETRY_BACKOFF` raised from `[1, 2, 4]`s to `[5, 15, 30]`s so Gemini 503 high-demand spikes have time to clear before the next attempt; `RESOURCE_EXHAUSTED` added to retryable substrings

## Test plan

- [ ] `pytest -x -q` — all 290 unit tests pass
- [ ] `ruff format . && ruff check .` — clean
- [ ] `uio agent run mcp-smoke-test` — table prints cleanly in ≤2 iterations with no raw JSON in Notes column

🤖 Generated with [Claude Code](https://claude.com/claude-code)