### PR TITLE
docs: add origin story, trim README, consolidate docs index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # uio
 
-> Just as Linux UIO lets kernel device drivers export their interfaces directly to userspace — eliminating the need for a full kernel module per device — **uio** lets AI agent definitions (plain markdown files) export their capabilities directly to a CLI, eliminating the need for a custom integration per project.
+`uio` is a lightweight, provider-agnostic framework for defining and running AI agents, skills, and prompts. Definitions live as markdown files with YAML frontmatter. The `uio` CLI discovers and executes them against any supported LLM provider. The [origin story](docs/16-about.md) covers how and why.
 
-`uio` is a lightweight, provider-agnostic framework for defining and running AI agents, skills, and prompts. Definitions live as markdown files with YAML frontmatter. The `uio` CLI discovers and executes them against any supported LLM provider.
-
-## Key concepts
+## Concepts
 
 | Concept | What it is |
 |---|---|
@@ -14,7 +12,7 @@
 
 ## Documentation
 
-Full documentation lives in [`docs/`](docs/README.md) — covering installation, core concepts, a step-by-step quickstart, CLI reference, configuration, providers, MCP integration, the chat REPL, cost ledger, registry, writing definitions, package internals, and [GitHub App identity agents](docs/governance.md).
+Full documentation lives in [`docs/`](docs/README.md) — covering installation, core concepts, a quickstart, CLI reference, configuration, providers, MCP integration, the chat REPL, cost ledger, registry, writing definitions, etc.
 
 See [Use Cases](docs/15-use-cases.md) for end-to-end worked examples.
 
@@ -48,88 +46,6 @@ my-project/
 ```
 
 See [Writing Definitions](docs/12-writing-definitions.md) for the full file format and authoring guide.
-
-## GitHub App identities
-
-uio supports dedicated GitHub App identities for agents that act on GitHub — separate
-non-human service accounts for planning, coding, and reviewing work:
-
-| Identity | Agent | Operations |
-|---|---|---|
-| AI Planner | `github-planner` | Create issues · Comment on issues and PRs · Summarize milestones |
-| AI Coder | `github-coder` | Create branches · Commit code · Open pull requests |
-| AI Reviewer | `github-reviewer` | Read diffs · Post structured review comments |
-
-Declare the identity in your agent's frontmatter:
-
-```yaml
----
-name: my-github-agent
-github-identity: coder   # planner | coder | reviewer
-tools: [terminal, github]
----
-```
-
-uio obtains a short-lived GitHub App installation token before the agent loop starts and
-sets `GH_TOKEN` — both the `gh` CLI and GitHub MCP server pick it up automatically. All
-three agents are available in [uio-registry](https://github.com/jomkz/uio-registry).
-
-See [Governance](docs/governance.md) and [Provisioning guides](docs/provisioning/) for setup.
-
-## Registry
-
-Discover and install community definitions from remote registries — Git repos with a `registry.yaml` manifest. No central server required.
-
-```bash
-# Add a registry to uio.toml:
-# [[registries]]
-# name = "official"
-# url  = "https://github.com/jomkz/uio-registry"
-# ref  = "main"
-
-uio registry list                   # show configured registries
-uio registry search summarise       # search by name, description, or tag
-uio registry install summarise      # copy definition into .uio/
-uio registry install repo-health --pin  # install and print a pinnable SHA
-uio registry update                 # refresh cached manifests
-```
-
-Installed definitions are plain local files — no live runtime dependency on the registry.
-
-## Providers
-
-Auto-routes across available providers in order: **Gemini → OpenAI → Ollama**. Override with `--provider` or `uio.toml`.
-
-| Provider | Large model | Small model |
-|---|---|---|
-| `gemini` | `gemini-2.5-flash` | `gemini-2.5-flash-lite` |
-| `openai` | `gpt-4o` | `gpt-4o-mini` |
-| `ollama` | `llama3.1:8b` | `llama3.1:8b` |
-
-## Container image
-
-```bash
-# bash/zsh
-docker run --rm \
-  -e GEMINI_API_KEY=your-key \
-  -e GITHUB_PERSONAL_ACCESS_TOKEN=ghp_... \
-  -v $(pwd):/workspace \
-  ghcr.io/jomkz/uio agent run repo-health
-
-# PowerShell (Windows) — use ${PWD} instead of $(pwd)
-docker run --rm `
-  -e GEMINI_API_KEY=your-key `
-  -e GITHUB_PERSONAL_ACCESS_TOKEN=ghp_... `
-  -v ${PWD}:/workspace `
-  ghcr.io/jomkz/uio agent run repo-health
-
-# Cross-platform — docker compose avoids the $(pwd) issue entirely
-docker compose run --rm uio agent run repo-health
-```
-
-The image includes Node.js and pre-warmed MCP servers (`@github/github-mcp-server`,
-`server-filesystem`, `server-fetch`, `server-memory`). A `docker-compose.yml` for local Ollama
-use is included in the repo. See [Container image](docs/14-container.md) for full details.
 
 ## License
 

--- a/docs/16-about.md
+++ b/docs/16-about.md
@@ -1,0 +1,98 @@
+# About uio
+
+## Origin
+
+uio didn't start as a design. It started as duplication.
+
+The immediate predecessor was a custom agent runner built inside another personal project — a multi-repo
+workspace with a handful of automated AI workflows: a manager agent that triaged CI failures, a scanner
+that audited code health, a finisher that opened pull requests, a release manager that gated environment
+promotions. Each agent was a markdown file with YAML frontmatter. Each run was a tool-use loop: send a
+system prompt to an LLM, receive a response, execute any tool calls, feed results back, repeat.
+
+The runner itself was about 800 lines of Python across two files. It handled provider selection (Gemini,
+OpenAI, Ollama), model routing by task complexity, MCP server integration for GitHub operations, a
+cost ledger, and a Click CLI for local and CI invocation. It worked well. It also looked very familiar.
+
+The pattern — definition files, a tool loop, provider abstraction, cost tracking — had appeared before
+in experiments with other tools. The runner wasn't solving a problem specific to that project; it was
+re-implementing a general capability that any project would eventually want. Maintaining it alongside
+the project it served meant two things were always slightly out of sync: improvements to one didn't
+automatically help the other.
+
+---
+
+## The extraction
+
+The decision to extract wasn't taken lightly. Premature abstraction is its own kind of maintenance
+burden. The test was: *could a second project drop this in and get the same result without modification?*
+
+The answer was yes, provided a few things were true:
+
+1. **The definition format had to be stable.** Frontmatter fields needed a clear schema — `name`,
+   `description`, `complexity`, `capabilities` — with known semantics and validation.
+2. **The CLI had to be generic.** `uio agent run manager` had to mean the same thing in any project,
+   not just the one where the runner was born.
+3. **Project-specific commands had to stay out.** Commands like `myapp env` or `myapp issue`
+   belonged to the host project, not the runtime. The runtime's job was to execute definitions.
+4. **Configuration had to be layered.** A `uio.toml` in the project root could override defaults
+   without the caller needing to pass flags on every invocation.
+
+The extraction happened incrementally. The core tool loop became `uio/core/runner.py`. The client
+abstractions became `uio/core/clients.py`. The CLI grew subcommand groups for `agent`, `prompt`,
+`skill`, `chat`, `cost`, and `config`. The definition files stayed exactly as they were — the format
+that worked in the source project worked unchanged in the library.
+
+---
+
+## Why "uio"
+
+The name carries two readings that reinforce each other.
+
+The first is borrowed from the Linux kernel's **UIO** subsystem — Userspace I/O. In Linux, UIO lets
+device driver logic live in userspace rather than inside the kernel. The kernel module exposes a
+minimal interface; the real behaviour is implemented in a plain userspace process. This dramatically
+lowers the barrier to writing drivers: no kernel module build, no kernel memory management, no risk
+of a bug crashing the whole system. The kernel provides the plumbing; you provide the logic.
+
+uio applies the same idea to AI agents. The runtime provides the plumbing — the tool loop, provider
+routing, MCP integration, cost ledger. The agent logic lives in a plain markdown file. You don't
+need to write a custom runner, wire up an LLM client, or build a CLI. The framework exposes a minimal
+interface; the real behaviour is in the definition files.
+
+The second reading — **Universal Input/Output** — describes what the runtime does at a practical level.
+Input: definition files. Any project, any provider, any LLM. You write a markdown file; that's the
+input interface. Output: LLM responses, tool execution results, cost ledger entries. Whatever the
+agent produces flows back out. The runtime is the universal channel between the two.
+
+What makes this more than a coincidence is that both readings map to the same underlying structure.
+In Linux UIO, hardware events come in, control signals go out, and userspace logic sits in between —
+the kernel is the universal channel. In uio, definition files come in, responses and actions go out,
+and your markdown logic sits in between — the runtime is the universal channel. The analogy holds at
+both levels: the design philosophy and the runtime behaviour describe the same thing from different
+angles.
+
+The analogy isn't perfect — nothing involving LLMs is as deterministic as a kernel interface — but
+the design principle holds: **push logic to the edge, keep the core minimal and stable**.
+
+One footnote on how the name was actually found: the only initial constraint given to an AI when
+brainstorming was "three characters, easy to type." `uio` came back in the candidate list. The Linux
+UIO connection was discovered afterwards — which made it an easy choice. Sometimes the right name
+finds you.
+
+---
+
+## What it is now
+
+uio is a lightweight, provider-agnostic framework for defining and running AI agents, skills, and
+prompts. Definitions live as markdown files with YAML frontmatter. The `uio` CLI discovers and
+executes them against any supported LLM provider.
+
+The framework deliberately avoids opinions about *what your agents do*. It has opinions about *how
+definitions are structured* (the frontmatter schema), *how providers are selected* (the routing
+chain), and *how costs are tracked* (the ledger format). Everything else — the system prompt, the
+tool-use strategy, the stopping condition — is yours.
+
+That scope came directly from the extraction: the runner that existed before was already scoped that
+way. Nothing was added to make it "a framework." The abstraction boundary was already there; uio
+just made it explicit and standalone.

--- a/docs/17-github-app-identities.md
+++ b/docs/17-github-app-identities.md
@@ -1,0 +1,47 @@
+# GitHub App Identities
+
+uio supports dedicated GitHub App identities for agents that act on GitHub — separate
+non-human service accounts for planning, coding, and reviewing work. Each identity has a
+distinct permission scope, enforcing separation of duties at the GitHub App layer.
+
+## The three identities
+
+| Identity | Frontmatter value | Operations |
+|---|---|---|
+| AI Planner | `planner` | Create issues · Comment on issues and PRs · Summarize milestones |
+| AI Coder | `coder` | Create branches · Commit code · Open pull requests |
+| AI Reviewer | `reviewer` | Read diffs · Post structured review comments |
+
+## Declaring an identity
+
+Add `github-identity` to your agent's frontmatter:
+
+```yaml
+---
+name: my-github-agent
+description: An agent that opens pull requests.
+github-identity: coder   # planner | coder | reviewer
+capabilities:
+  - terminal
+  - vcs
+---
+```
+
+uio obtains a short-lived GitHub App installation token before the agent loop starts and
+sets `GH_TOKEN` — both the `gh` CLI and GitHub MCP server pick it up automatically.
+
+## Further reading
+
+| Document | What it covers |
+|---|---|
+| [GitHub identity inventory](github-identity-inventory.md) | Current-state survey of GitHub auth usage across uio definitions |
+| [Permission matrix](github-permission-matrix.md) | Minimum permissions, explicit exclusions, and identity routing map |
+| [Governance](governance.md) | Attribution standard, app ownership, quarterly review, change control, installation policy |
+| [Provisioning — AI Planner](provisioning/ai-planner.md) | Step-by-step setup for the `uio-ai-planner` GitHub App |
+| [Provisioning — AI Coder](provisioning/ai-coder.md) | Step-by-step setup for the `uio-ai-coder` GitHub App |
+| [Provisioning — AI Reviewer](provisioning/ai-reviewer.md) | Step-by-step setup for the `uio-ai-reviewer` GitHub App |
+| [Runbook — Audit](runbooks/github-app-audit.md) | Logging requirements and GitHub audit log review process |
+| [Runbook — Incident response](runbooks/github-app-incident-response.md) | P1/P2/P3 incident tiers, 8-step response, post-mortem template |
+| [Runbook — Credential rotation](runbooks/github-app-credential-rotation.md) | Zero-downtime private key rotation using dual-key overlap |
+| [Runbook — Emergency disable](runbooks/github-app-emergency-disable.md) | Fast-path: suspend, delete key, or uninstall in under 2 minutes |
+| [Runbook — Branch protection](runbooks/github-branch-protection.md) | Applied baseline, reconfiguration command, AI Coder bypass verification |

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,27 +25,8 @@
 | [13 — Internals](13-internals.md) | Package architecture, every module's role, how to add a provider or tool, and contributing |
 | [14 — Container image](14-container.md) | Dockerfile, bundled MCP servers, Ollama sidecar, CI/CD usage, and building from source |
 | [15 — Use cases](15-use-cases.md) | Worked examples: repo health, code review, issue planning, AI-authored PRs, multi-agent pipelines |
-
----
-
-## GitHub App identity reference
-
-The following documents cover the enterprise GitHub identity architecture — dedicated GitHub App
-identities (`planner`, `coder`, `reviewer`) for uio agents that act on GitHub.
-
-| Document | What it covers |
-|---|---|
-| [GitHub identity inventory](github-identity-inventory.md) | Current-state survey of GitHub auth usage across uio definitions |
-| [Permission matrix](github-permission-matrix.md) | Minimum permissions, explicit exclusions, and identity routing map |
-| [Governance](governance.md) | Attribution standard, app ownership, quarterly review, change control, installation policy |
-| [Provisioning — AI Planner](provisioning/ai-planner.md) | Step-by-step setup for the `uio-ai-planner` GitHub App |
-| [Provisioning — AI Coder](provisioning/ai-coder.md) | Step-by-step setup for the `uio-ai-coder` GitHub App |
-| [Provisioning — AI Reviewer](provisioning/ai-reviewer.md) | Step-by-step setup for the `uio-ai-reviewer` GitHub App |
-| [Runbook — Audit](runbooks/github-app-audit.md) | Logging requirements and GitHub audit log review process |
-| [Runbook — Incident response](runbooks/github-app-incident-response.md) | P1/P2/P3 incident tiers, 8-step response, post-mortem template |
-| [Runbook — Credential rotation](runbooks/github-app-credential-rotation.md) | Zero-downtime private key rotation using dual-key overlap |
-| [Runbook — Emergency disable](runbooks/github-app-emergency-disable.md) | Fast-path: suspend, delete key, or uninstall in under 2 minutes |
-| [Runbook — Branch protection](runbooks/github-branch-protection.md) | Applied baseline, reconfiguration command, AI Coder bypass verification |
+| [16 — About](16-about.md) | The origin story — why uio exists and where the name comes from |
+| [17 — GitHub App identities](17-github-app-identities.md) | Dedicated GitHub App identities for agents — setup, frontmatter, and links to governance and runbooks |
 
 ---
 
@@ -79,12 +60,13 @@ identities (`planner`, `coder`, `reviewer`) for uio agents that act on GitHub.
 
 ### I want to run agents with dedicated GitHub App identities
 
-1. [Permission matrix](github-permission-matrix.md) — understand what each identity can do
-2. [Provisioning guides](provisioning/) — create and install the GitHub Apps
-3. [Frontmatter schema](04-frontmatter.md#github-identity) — add `github-identity` to your agent
-4. [Configuration](06-configuration.md#github-authentication) — set the required env vars
-5. [Governance](governance.md) — ownership, review cadence, and change control
-6. [Runbooks](runbooks/) — audit, incident response, credential rotation, emergency disable
+1. [GitHub App identities](17-github-app-identities.md) — overview, frontmatter, and further reading index
+2. [Permission matrix](github-permission-matrix.md) — understand what each identity can do
+3. [Provisioning guides](provisioning/) — create and install the GitHub Apps
+4. [Frontmatter schema](04-frontmatter.md#github-identity) — add `github-identity` to your agent
+5. [Configuration](06-configuration.md#github-authentication) — set the required env vars
+6. [Governance](governance.md) — ownership, review cadence, and change control
+7. [Runbooks](runbooks/) — audit, incident response, credential rotation, emergency disable
 
 ### I want to see what uio can do end-to-end
 


### PR DESCRIPTION
## Summary

- Adds `docs/16-about.md` — the origin story for uio covering genesis, extraction rationale, the Linux UIO / Universal I/O dual naming, and a footnote on how the name was found
- Adds `docs/17-github-app-identities.md` — a new numbered overview entry that consolidates links to the scattered governance, provisioning, and runbook docs
- Updates `docs/README.md` — adds entries 16 and 17 to the numbered contents table; collapses the separate GitHub App identity reference section in favour of the new numbered entry; updates the GitHub App reading path
- Trims `README.md` — removes the GitHub App identities, Registry, Providers, and Container image sections (all fully covered in the numbered docs); folds the UIO/Universal I/O naming context into the opening paragraph with a link to the origin story

## Test plan

- [ ] All links in `docs/README.md` contents table resolve to existing files
- [ ] `docs/16-about.md` contains no references to specific project names
- [ ] `docs/17-github-app-identities.md` links to all existing governance/provisioning/runbook docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)