### PR TITLE
feat: add structural and cross-reference validation checks

### DIFF
--- a/uio/cli/main.py
+++ b/uio/cli/main.py
@@ -18,7 +18,17 @@ from uio.cli.registry import registry_group
 from uio.cli.skill import skill_group
 from uio.config import load_config
 from uio.examples import EXAMPLES
-from uio.schema.parser import check_identity_env, parse_definition_file, validate_definition
+from uio.schema.parser import (
+    check_heading_format,
+    check_identity_env,
+    check_minimal_body,
+    check_skill_interface_sections,
+    check_skill_references,
+    check_stopping_criteria,
+    check_thinking_complexity,
+    parse_definition_file,
+    validate_definition,
+)
 
 _EXAMPLE_AGENT = """\
 ---
@@ -146,20 +156,31 @@ def init_cmd(examples: bool) -> None:
 
 
 @main.command("validate")
-def validate_cmd() -> None:
+@click.option(
+    "--strict",
+    is_flag=True,
+    default=False,
+    help="Enable opt-in checks (e.g. stopping-criteria detection).",
+)
+def validate_cmd(strict: bool) -> None:
     """Parse all definition files and check required frontmatter fields.
 
     Exits non-zero if any errors are found.
+
+    Pass --strict to enable additional opt-in checks such as stopping-criteria
+    detection.
 
     Example:
 
     \b
       uio validate
+      uio validate --strict
     """
     cfg = load_config()
+    skills_dir = cfg["dirs"]["skills"]
     patterns = [
         (cfg["dirs"]["agents"], "*.agent.md"),
-        (cfg["dirs"]["skills"], "*.skill.md"),
+        (skills_dir, "*.skill.md"),
         (cfg["dirs"]["prompts"], "*.prompt.md"),
     ]
 
@@ -171,12 +192,19 @@ def validate_cmd() -> None:
         for path in sorted(glob(f"{directory}/{pattern}")):
             total += 1
             try:
-                fm, _ = parse_definition_file(path)
+                fm, body = parse_definition_file(path)
             except Exception as e:
                 errors.append(f"{path}: could not parse: {e}")
                 continue
             errors.extend(validate_definition(path, fm))
             warnings.extend(check_identity_env(path, fm))
+            warnings.extend(check_heading_format(path, fm, body))
+            warnings.extend(check_skill_references(path, body, skills_dir))
+            warnings.extend(check_thinking_complexity(path, fm))
+            warnings.extend(check_skill_interface_sections(path, body))
+            warnings.extend(check_minimal_body(path, body))
+            if strict:
+                warnings.extend(check_stopping_criteria(path, body))
 
     if total == 0:
         click.echo("  No definition files found.")

--- a/uio/core/clients.py
+++ b/uio/core/clients.py
@@ -118,7 +118,7 @@ class GeminiClient(LLMClient):
         )
         text_parts: list[str] = []
         calls: list[ToolCall] = []
-        for part in (resp.candidates[0].content.parts or []):
+        for part in resp.candidates[0].content.parts or []:
             if hasattr(part, "text") and part.text:
                 text_parts.append(part.text)
             if hasattr(part, "function_call") and part.function_call:

--- a/uio/schema/parser.py
+++ b/uio/schema/parser.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 
 import yaml
@@ -9,6 +10,15 @@ import yaml
 _FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n(.*)", re.DOTALL)
 
 REQUIRED_FIELDS = ("name", "description")
+
+# Matches "# <Type>: <name>" H1 headings
+_H1_RE = re.compile(r"^#\s+(\w+):\s+(.+)$", re.MULTILINE)
+
+# Stopping-criteria phrases expected somewhere in agent bodies
+_STOPPING_PHRASES = re.compile(
+    r"(stop\b|stopping criteria|do not proceed|halt|report and stop|print.*and stop)",
+    re.IGNORECASE,
+)
 
 
 def parse_definition_file(path: str) -> tuple[dict, str]:
@@ -93,5 +103,105 @@ def check_identity_env(path: str, frontmatter: dict) -> list[str]:
         field = "vcs-identity" if frontmatter.get("vcs-identity") else "github-identity"
         return [
             f"{path}: '{field}: {identity}' declared but env vars not set: " + ", ".join(missing)
+        ]
+    return []
+
+
+def check_heading_format(path: str, frontmatter: dict, body: str) -> list[str]:
+    """Warn when the first H1 heading does not match ``# {Type}: {name}``.
+
+    The ``name`` in the heading must match the ``name`` frontmatter field.
+    Non-fatal — different heading styles are allowed but flagged.
+    """
+    warnings: list[str] = []
+    name = frontmatter.get("name")
+    if not name:
+        return warnings  # already caught by validate_definition
+
+    m = _H1_RE.search(body)
+    if m is None:
+        warnings.append(f"{path}: no H1 heading found; expected '# <Type>: {name}'")
+        return warnings
+
+    heading_name = m.group(2).strip()
+    if heading_name != name:
+        warnings.append(
+            f"{path}: H1 heading name '{heading_name}' does not match"
+            f" frontmatter name '{name}'"
+        )
+    return warnings
+
+
+def check_skill_references(path: str, body: str, skills_dir: str) -> list[str]:
+    """Warn when the body references skills that do not exist on disk.
+
+    Detects invocation patterns like ``/skill-name`` or ``invoke.*skill-name``
+    and resolves them against ``*.skill.md`` files in *skills_dir*.
+    """
+    warnings: list[str] = []
+    # Collect known skill names from the skills directory
+    known: set[str] = set()
+    if os.path.isdir(skills_dir):
+        for fname in os.listdir(skills_dir):
+            if fname.endswith(".skill.md"):
+                known.add(fname[: -len(".skill.md")])
+
+    if not known:
+        return warnings  # no skills directory or no skills — nothing to validate against
+
+    # Match /skill-name invocations
+    invocations = re.findall(r"/([a-zA-Z0-9_-]+)", body)
+    for ref in invocations:
+        if ref and ref not in known:
+            warnings.append(
+                f"{path}: references skill '/{ref}' which does not exist in '{skills_dir}'"
+            )
+    return warnings
+
+
+def check_thinking_complexity(path: str, frontmatter: dict) -> list[str]:
+    """Warn when ``thinking`` capability is combined with ``complexity: small``.
+
+    This combination exhausts iteration budgets prematurely.
+    """
+    capabilities = frontmatter.get("capabilities") or []
+    if isinstance(capabilities, str):
+        capabilities = [capabilities]
+    if "thinking" in capabilities and frontmatter.get("complexity") == "small":
+        return [
+            f"{path}: 'thinking' capability combined with 'complexity: small'"
+            " — this may exhaust iteration budgets"
+        ]
+    return []
+
+
+def check_skill_interface_sections(path: str, body: str) -> list[str]:
+    """Warn when a ``.skill.md`` file is missing ``## Input`` or ``## Output`` sections."""
+    if not path.endswith(".skill.md"):
+        return []
+    warnings: list[str] = []
+    if not re.search(r"^##\s+Input\b", body, re.MULTILINE):
+        warnings.append(f"{path}: .skill.md is missing a '## Input' section")
+    if not re.search(r"^##\s+Output\b", body, re.MULTILINE):
+        warnings.append(f"{path}: .skill.md is missing a '## Output' section")
+    return warnings
+
+
+def check_stopping_criteria(path: str, body: str) -> list[str]:
+    """Warn when no explicit stopping language is found in the agent body.
+
+    This check is opt-in (only active when ``--strict`` is passed to the CLI).
+    """
+    if not _STOPPING_PHRASES.search(body):
+        return [f"{path}: no explicit stopping criteria found in agent body"]
+    return []
+
+
+def check_minimal_body(path: str, body: str) -> list[str]:
+    """Warn when the body (non-frontmatter content) is under 100 characters."""
+    if len(body) < 100:
+        return [
+            f"{path}: body is very short ({len(body)} chars);"
+            " consider adding more detail"
         ]
     return []

--- a/uio/schema/parser.py
+++ b/uio/schema/parser.py
@@ -126,8 +126,7 @@ def check_heading_format(path: str, frontmatter: dict, body: str) -> list[str]:
     heading_name = m.group(2).strip()
     if heading_name != name:
         warnings.append(
-            f"{path}: H1 heading name '{heading_name}' does not match"
-            f" frontmatter name '{name}'"
+            f"{path}: H1 heading name '{heading_name}' does not match frontmatter name '{name}'"
         )
     return warnings
 
@@ -200,8 +199,5 @@ def check_stopping_criteria(path: str, body: str) -> list[str]:
 def check_minimal_body(path: str, body: str) -> list[str]:
     """Warn when the body (non-frontmatter content) is under 100 characters."""
     if len(body) < 100:
-        return [
-            f"{path}: body is very short ({len(body)} chars);"
-            " consider adding more detail"
-        ]
+        return [f"{path}: body is very short ({len(body)} chars); consider adding more detail"]
     return []


### PR DESCRIPTION
## Summary

- Adds six new warning-level checks to `uio validate` in `uio/schema/parser.py`, all backward-compatible (warnings, not errors)
- Adds `--strict` flag to `uio validate` to opt into the stopping-criteria check
- Wires all new checks into the validate loop in `uio/cli/main.py`

### New checks

| Check | Function | Opt-in? |
|---|---|---|
| Heading Format Consistency — H1 must match `# {Type}: {name}` | `check_heading_format` | always |
| Skill Reference Validation — `/skill-name` refs against actual `.skill.md` files | `check_skill_references` | always |
| Thinking + Complexity Alignment — `thinking` capability + `complexity: small` | `check_thinking_complexity` | always |
| Skill Interface Sections — `## Input` / `## Output` required in `.skill.md` | `check_skill_interface_sections` | always |
| Stopping Criteria — detects missing explicit stop language | `check_stopping_criteria` | `--strict` only |
| Minimal Body Detection — warns when body < 100 characters | `check_minimal_body` | always |

## Test plan

- [ ] `uio validate` on a clean `.uio/` passes with new checks emitting warnings (not errors) for stub files
- [ ] A `.skill.md` without `## Input`/`## Output` produces the expected warnings
- [ ] An agent with `capabilities: [thinking]` and `complexity: small` produces the thinking+complexity warning
- [ ] `uio validate --strict` produces an additional stopping-criteria warning for agents that lack stop language
- [ ] `uio validate` (without `--strict`) does NOT emit stopping-criteria warnings
- [ ] H1 heading mismatch (name differs from frontmatter `name`) produces a heading-format warning
- [ ] Existing `tests/test_parser.py` suite passes unchanged

Closes #121

> 🤖 Generated by uio AI Coder