### PR TITLE
feat: add uio link subcommand for platform integration symlinks

### DIFF
--- a/docs/05-cli.md
+++ b/docs/05-cli.md
@@ -23,6 +23,7 @@ uio
 │   ├── show
 │   └── init
 ├── init
+├── link
 ├── validate
 ├── registry
 │   ├── list
@@ -247,6 +248,57 @@ uio init --examples
 | `--examples` | Also install the seven bundled real-world example definitions |
 
 Existing files are skipped (not overwritten).
+
+---
+
+## `uio link`
+
+Creates and maintains platform integration symlinks so that IDE and CI platforms can discover uio definitions.
+
+Reads source directories from `uio.toml` (`dirs.agents`, `dirs.skills`, `dirs.prompts`) and creates the correct symlinks for each platform.
+
+For `.claude/commands/` the command creates **per-file symlinks** that strip the `.prompt` infix so Claude Code discovers them as `/name` rather than `/name.prompt`.
+
+```bash
+uio link
+uio link --dry-run
+uio link --platforms claude
+uio link --force
+```
+
+| Flag | Description |
+|---|---|
+| `--platforms` | Comma-separated list of platforms to link: `github,claude`. Default: all. |
+| `--dry-run` | Print planned changes without modifying the filesystem. |
+| `--force` | Replace an existing `.claude/commands` directory symlink without prompting. |
+
+### What gets linked
+
+**`.github/`** (directory symlinks):
+
+```
+.github/agents  →  <agents_dir>
+.github/prompts →  <prompts_dir>
+.github/skills  →  <skills_dir>
+```
+
+**`.claude/`** (directory symlinks for agents and skills):
+
+```
+.claude/agents  →  <agents_dir>
+.claude/skills  →  <skills_dir>
+```
+
+**`.claude/commands/`** (real directory with per-file symlinks):
+
+```
+.claude/commands/take-issue.md         →  ../../.uio/prompts/take-issue.prompt.md
+.claude/commands/check-api-contract.md →  ../../.uio/prompts/check-api-contract.prompt.md
+```
+
+Running `uio link` a second time is a no-op. Adding or deleting a prompt file and re-running `uio link` adds or removes the corresponding symlink in `.claude/commands/`.
+
+If `.claude/commands` already exists as a directory symlink (legacy setup), `uio link` will prompt to replace it with a real directory. Pass `--force` to replace without prompting.
 
 ---
 

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -1,0 +1,245 @@
+"""Tests for uio link — platform integration symlink management."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from uio.cli.link import link_cmd
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _make_prompts(base: Path, names: list[str]) -> None:
+    prompts = base / ".uio" / "prompts"
+    prompts.mkdir(parents=True, exist_ok=True)
+    for name in names:
+        (prompts / f"{name}.prompt.md").write_text(f"# {name}\n")
+
+
+def _make_agents(base: Path) -> None:
+    (base / ".uio" / "agents").mkdir(parents=True, exist_ok=True)
+
+
+def _make_skills(base: Path) -> None:
+    (base / ".uio" / "skills").mkdir(parents=True, exist_ok=True)
+
+
+def _run(tmp_path: Path, args: list[str], input: str | None = None) -> tuple[int, str]:
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        # Create a minimal uio.toml using default .uio/ paths
+        Path("uio.toml").write_text(
+            "[dirs]\nagents = '.uio/agents'\nskills = '.uio/skills'\nprompts = '.uio/prompts'\n"
+        )
+        _make_agents(Path("."))
+        _make_skills(Path("."))
+        result = runner.invoke(link_cmd, args, input=input, catch_exceptions=False)
+        return result.exit_code, result.output
+
+
+# ── idempotency ───────────────────────────────────────────────────────────────
+
+
+def test_github_links_created(tmp_path):
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        Path("uio.toml").write_text(
+            "[dirs]\nagents = '.uio/agents'\nskills = '.uio/skills'\nprompts = '.uio/prompts'\n"
+        )
+        _make_agents(Path("."))
+        _make_skills(Path("."))
+        _make_prompts(Path("."), ["take-issue", "check-api"])
+
+        result = runner.invoke(link_cmd, ["--platforms", "github"], catch_exceptions=False)
+        assert result.exit_code == 0
+
+        assert Path(".github/agents").is_symlink()
+        assert Path(".github/prompts").is_symlink()
+        assert Path(".github/skills").is_symlink()
+
+        assert os.readlink(".github/agents") == "../.uio/agents"
+        assert os.readlink(".github/prompts") == "../.uio/prompts"
+        assert os.readlink(".github/skills") == "../.uio/skills"
+
+
+def test_github_links_idempotent(tmp_path):
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        Path("uio.toml").write_text(
+            "[dirs]\nagents = '.uio/agents'\nskills = '.uio/skills'\nprompts = '.uio/prompts'\n"
+        )
+        _make_agents(Path("."))
+        _make_skills(Path("."))
+        _make_prompts(Path("."), ["take-issue"])
+
+        runner.invoke(link_cmd, ["--platforms", "github"], catch_exceptions=False)
+        result = runner.invoke(link_cmd, ["--platforms", "github"], catch_exceptions=False)
+        assert result.exit_code == 0
+        # second run should produce no Create/Update/Remove lines
+        assert "Create" not in result.output
+        assert "Update" not in result.output
+        assert "Remove" not in result.output
+
+
+# ── .claude/commands/ per-file symlinks ──────────────────────────────────────
+
+
+def test_commands_dir_created_with_per_file_symlinks(tmp_path):
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        Path("uio.toml").write_text(
+            "[dirs]\nagents = '.uio/agents'\nskills = '.uio/skills'\nprompts = '.uio/prompts'\n"
+        )
+        _make_agents(Path("."))
+        _make_skills(Path("."))
+        _make_prompts(Path("."), ["take-issue", "check-api-contract"])
+
+        result = runner.invoke(link_cmd, ["--platforms", "claude"], catch_exceptions=False)
+        assert result.exit_code == 0
+
+        commands = Path(".claude/commands")
+        assert commands.is_dir() and not commands.is_symlink()
+        assert (commands / "take-issue.md").is_symlink()
+        assert (commands / "check-api-contract.md").is_symlink()
+        # .prompt should be stripped from the link name
+        assert not (commands / "take-issue.prompt.md").exists()
+
+
+def test_commands_link_target_is_relative(tmp_path):
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        Path("uio.toml").write_text(
+            "[dirs]\nagents = '.uio/agents'\nskills = '.uio/skills'\nprompts = '.uio/prompts'\n"
+        )
+        _make_agents(Path("."))
+        _make_skills(Path("."))
+        _make_prompts(Path("."), ["ask-docs"])
+
+        runner.invoke(link_cmd, ["--platforms", "claude"], catch_exceptions=False)
+
+        target = os.readlink(".claude/commands/ask-docs.md")
+        assert target == "../../.uio/prompts/ask-docs.prompt.md"
+
+
+def test_stale_command_link_removed(tmp_path):
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        Path("uio.toml").write_text(
+            "[dirs]\nagents = '.uio/agents'\nskills = '.uio/skills'\nprompts = '.uio/prompts'\n"
+        )
+        _make_agents(Path("."))
+        _make_skills(Path("."))
+        _make_prompts(Path("."), ["take-issue", "old-prompt"])
+
+        runner.invoke(link_cmd, ["--platforms", "claude"], catch_exceptions=False)
+        assert Path(".claude/commands/old-prompt.md").exists()
+
+        # Remove the prompt file
+        Path(".uio/prompts/old-prompt.prompt.md").unlink()
+
+        result = runner.invoke(link_cmd, ["--platforms", "claude"], catch_exceptions=False)
+        assert result.exit_code == 0
+        assert not Path(".claude/commands/old-prompt.md").exists()
+        assert Path(".claude/commands/take-issue.md").exists()
+
+
+def test_new_prompt_added_on_rerun(tmp_path):
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        Path("uio.toml").write_text(
+            "[dirs]\nagents = '.uio/agents'\nskills = '.uio/skills'\nprompts = '.uio/prompts'\n"
+        )
+        _make_agents(Path("."))
+        _make_skills(Path("."))
+        _make_prompts(Path("."), ["take-issue"])
+
+        runner.invoke(link_cmd, ["--platforms", "claude"], catch_exceptions=False)
+
+        # Add a new prompt
+        Path(".uio/prompts/new-feature.prompt.md").write_text("# new\n")
+
+        runner.invoke(link_cmd, ["--platforms", "claude"], catch_exceptions=False)
+        assert Path(".claude/commands/new-feature.md").is_symlink()
+
+
+# ── directory-symlink migration ──────────────────────────────────────────────
+
+
+def test_commands_dir_symlink_replaced_with_force(tmp_path):
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        Path("uio.toml").write_text(
+            "[dirs]\nagents = '.uio/agents'\nskills = '.uio/skills'\nprompts = '.uio/prompts'\n"
+        )
+        _make_agents(Path("."))
+        _make_skills(Path("."))
+        _make_prompts(Path("."), ["take-issue"])
+
+        # Simulate legacy setup: .claude/commands is a directory symlink
+        Path(".claude").mkdir()
+        Path(".claude/commands").symlink_to("../../.uio/prompts")
+
+        result = runner.invoke(
+            link_cmd, ["--platforms", "claude", "--force"], catch_exceptions=False
+        )
+        assert result.exit_code == 0
+
+        commands = Path(".claude/commands")
+        assert commands.is_dir() and not commands.is_symlink()
+        assert (commands / "take-issue.md").is_symlink()
+
+
+def test_commands_dir_symlink_kept_when_declined(tmp_path):
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        Path("uio.toml").write_text(
+            "[dirs]\nagents = '.uio/agents'\nskills = '.uio/skills'\nprompts = '.uio/prompts'\n"
+        )
+        _make_agents(Path("."))
+        _make_skills(Path("."))
+        _make_prompts(Path("."), ["take-issue"])
+
+        Path(".claude").mkdir()
+        Path(".claude/commands").symlink_to("../../.uio/prompts")
+
+        # User answers "n" to the replacement prompt
+        result = runner.invoke(
+            link_cmd, ["--platforms", "claude"], input="n\n", catch_exceptions=False
+        )
+        assert result.exit_code == 0
+        assert Path(".claude/commands").is_symlink()
+
+
+# ── dry-run ───────────────────────────────────────────────────────────────────
+
+
+def test_dry_run_makes_no_changes(tmp_path):
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        Path("uio.toml").write_text(
+            "[dirs]\nagents = '.uio/agents'\nskills = '.uio/skills'\nprompts = '.uio/prompts'\n"
+        )
+        _make_agents(Path("."))
+        _make_skills(Path("."))
+        _make_prompts(Path("."), ["take-issue"])
+
+        result = runner.invoke(link_cmd, ["--dry-run"], catch_exceptions=False)
+        assert result.exit_code == 0
+        assert "Dry run" in result.output
+
+        assert not Path(".github/agents").exists()
+        assert not Path(".claude/agents").exists()
+        assert not Path(".claude/commands").exists()
+
+
+# ── --platforms validation ────────────────────────────────────────────────────
+
+
+def test_unknown_platform_exits_nonzero(tmp_path):
+    exit_code, output = _run(tmp_path, ["--platforms", "bogus"])
+    assert exit_code != 0
+    assert "Unknown platform" in output

--- a/uio/cli/link.py
+++ b/uio/cli/link.py
@@ -1,0 +1,159 @@
+"""uio link — create and maintain platform integration symlinks."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import click
+
+from uio.config import load_config
+
+_PLATFORMS = ("github", "claude")
+
+
+@click.command("link")
+@click.option(
+    "--platforms",
+    default=None,
+    metavar="PLATFORMS",
+    help="Comma-separated platforms to link: github,claude. Default: all.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Print planned changes without modifying the filesystem.",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Replace a .claude/commands directory symlink without prompting.",
+)
+def link_cmd(platforms: str | None, dry_run: bool, force: bool) -> None:
+    """Create and maintain platform integration symlinks.
+
+    Reads source directories from uio.toml (dirs.agents, dirs.skills,
+    dirs.prompts) and creates the correct symlinks for each platform.
+
+    For .claude/commands/ the per-file symlinks strip the .prompt infix so
+    that Claude Code discovers them as /name rather than /name.prompt.
+
+    \b
+    Examples:
+      uio link
+      uio link --dry-run
+      uio link --platforms claude
+      uio link --force
+    """
+    cfg = load_config()
+    agents_dir = Path(cfg["dirs"]["agents"])
+    skills_dir = Path(cfg["dirs"]["skills"])
+    prompts_dir = Path(cfg["dirs"]["prompts"])
+
+    if platforms is not None:
+        selected = [p.strip() for p in platforms.split(",")]
+        for p in selected:
+            if p not in _PLATFORMS:
+                raise click.ClickException(
+                    f"Unknown platform: {p!r}. Choose from: {', '.join(_PLATFORMS)}"
+                )
+    else:
+        selected = list(_PLATFORMS)
+
+    if dry_run:
+        click.echo("Dry run — no changes will be made.\n")
+
+    if "github" in selected:
+        _link_github(agents_dir, skills_dir, prompts_dir, dry_run)
+
+    if "claude" in selected:
+        _link_claude(agents_dir, skills_dir, prompts_dir, dry_run, force)
+
+
+def _link_github(agents_dir: Path, skills_dir: Path, prompts_dir: Path, dry_run: bool) -> None:
+    github = Path(".github")
+    for link, target in [
+        (github / "agents", agents_dir),
+        (github / "prompts", prompts_dir),
+        (github / "skills", skills_dir),
+    ]:
+        _ensure_symlink(link, target, dry_run)
+
+
+def _link_claude(
+    agents_dir: Path, skills_dir: Path, prompts_dir: Path, dry_run: bool, force: bool
+) -> None:
+    claude = Path(".claude")
+    for link, target in [
+        (claude / "agents", agents_dir),
+        (claude / "skills", skills_dir),
+    ]:
+        _ensure_symlink(link, target, dry_run)
+
+    _link_commands(claude / "commands", prompts_dir, dry_run, force)
+
+
+def _link_commands(commands_dir: Path, prompts_dir: Path, dry_run: bool, force: bool) -> None:
+    """Manage per-file symlinks in .claude/commands/ for each *.prompt.md."""
+    if commands_dir.is_symlink():
+        existing_target = os.readlink(commands_dir)
+        click.echo(f"  Detected {commands_dir} is a directory symlink → {existing_target}")
+        replace = force or click.confirm(
+            "  Replace with a real directory containing per-file symlinks?",
+            default=False,
+        )
+        if not replace:
+            click.echo(f"  Skip    {commands_dir}  (kept as directory symlink)")
+            return
+        click.echo(f"  Remove  {commands_dir}  (directory symlink)")
+        if not dry_run:
+            commands_dir.unlink()
+    elif not commands_dir.exists():
+        click.echo(f"  Create  {commands_dir}/")
+        if not dry_run:
+            commands_dir.mkdir(parents=True, exist_ok=True)
+
+    # Build expected {link_name: prompt_file} from the prompts directory
+    expected: dict[str, Path] = {}
+    if prompts_dir.exists():
+        for prompt_file in sorted(prompts_dir.glob("*.prompt.md")):
+            stem = prompt_file.stem  # e.g. "foo.prompt"
+            name = stem.removesuffix(".prompt")
+            expected[name + ".md"] = prompt_file
+
+    # Remove stale symlinks
+    if commands_dir.exists():
+        for entry in sorted(commands_dir.iterdir()):
+            if entry.is_symlink() and entry.name not in expected:
+                click.echo(f"  Remove  {entry}  (stale)")
+                if not dry_run:
+                    entry.unlink()
+
+    # Create or update per-file symlinks
+    for link_name, prompt_file in sorted(expected.items()):
+        _ensure_symlink(commands_dir / link_name, prompt_file, dry_run)
+
+
+def _ensure_symlink(link: Path, target: Path, dry_run: bool) -> None:
+    """Create or verify a relative symlink from link to target."""
+    rel = Path(os.path.relpath(target, link.parent))
+
+    if link.is_symlink():
+        if os.readlink(link) == str(rel):
+            return  # already correct
+        click.echo(f"  Update  {link}  →  {rel}")
+        if not dry_run:
+            link.unlink()
+            link.symlink_to(rel)
+        return
+
+    if link.exists():
+        click.echo(f"  Skip    {link}  (exists but is not a symlink)")
+        return
+
+    click.echo(f"  Create  {link}  →  {rel}")
+    if not dry_run:
+        link.parent.mkdir(parents=True, exist_ok=True)
+        link.symlink_to(rel)

--- a/uio/cli/main.py
+++ b/uio/cli/main.py
@@ -13,6 +13,7 @@ from uio.cli.agent import agent_group
 from uio.cli.chat import chat_cmd
 from uio.cli.config import config_group
 from uio.cli.cost import cost_cmd
+from uio.cli.link import link_cmd
 from uio.cli.prompt import prompt_group
 from uio.cli.registry import registry_group
 from uio.cli.skill import skill_group
@@ -79,6 +80,7 @@ main.add_command(prompt_group, "prompt")
 main.add_command(chat_cmd, "chat")
 main.add_command(cost_cmd, "cost")
 main.add_command(config_group, "config")
+main.add_command(link_cmd, "link")
 main.add_command(registry_group, "registry")
 
 


### PR DESCRIPTION
## Summary

- Adds `uio link` CLI command that creates `.github/` and `.claude/` directory symlinks from the directories configured in `uio.toml`
- For `.claude/commands/` creates per-file symlinks that strip the `.prompt` infix, so Claude Code discovers prompts as `/name` instead of `/name.prompt`
- Detects and offers to replace legacy `.claude/commands` directory symlinks; `--force` skips the prompt
- Supports `--dry-run`, `--platforms github,claude`, and `--force` flags; idempotent on repeated runs

## Test plan

- [x] `test_github_links_created` — `.github/{agents,prompts,skills}` are relative symlinks
- [x] `test_github_links_idempotent` — second run produces no Create/Update/Remove output
- [x] `test_commands_dir_created_with_per_file_symlinks` — `.claude/commands/` is a real directory with `<name>.md` symlinks
- [x] `test_commands_link_target_is_relative` — symlink target is `../../.uio/prompts/<name>.prompt.md`
- [x] `test_stale_command_link_removed` — deleting a prompt and re-running removes the stale link
- [x] `test_new_prompt_added_on_rerun` — adding a prompt and re-running creates the new link
- [x] `test_commands_dir_symlink_replaced_with_force` — `--force` replaces legacy directory symlink
- [x] `test_commands_dir_symlink_kept_when_declined` — user declines and symlink is preserved
- [x] `test_dry_run_makes_no_changes` — no filesystem changes with `--dry-run`
- [x] `test_unknown_platform_exits_nonzero` — bad `--platforms` value exits 1

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)