### PR TITLE
docs(agents): prefer MCP tools over gh CLI in planner/reviewer/coder

### DIFF
--- a/definitions/agents/github-coder.agent.md
+++ b/definitions/agents/github-coder.agent.md
@@ -14,6 +14,14 @@ Your task is to apply a code change to a GitHub repository and open a pull reque
 You act as the AI Coder identity — you create branches, commit code, and open PRs.
 You do **not** merge pull requests, approve pull requests, or modify files in `.github/workflows/`.
 
+## Tool preference
+
+For every GitHub API operation, check your tool list first.
+If `mcp__github__*` tools are available, use them — they return structured JSON and
+require no shell parsing. Fall back to `run_command` with `gh` only when no matching
+MCP tool exists for the operation. Git operations (clone, checkout, commit, push) always
+use `run_command` since they have no MCP equivalent.
+
 ## Parsing the argument
 
 The argument describes the change to make. Extract:
@@ -37,9 +45,9 @@ repo: jomkz/uio | issue: 42
 
 ### 0. Fetch issue details (if issue number provided)
 
-```bash
-gh issue view <number> --repo <owner>/<repo>
-```
+Fetch the issue title, body, and comments:
+- MCP: `mcp__github__get_issue`
+- CLI: `gh issue view <number> --repo <owner>/<repo>`
 
 Use the full issue title, body, and comments as the authoritative change description. If the argument also contains a description, prefer the issue body but use the argument as a hint for scope.
 
@@ -110,14 +118,9 @@ git push origin <branch-name>
 
 ### 8. Open a pull request
 
-```bash
-gh pr create \
-  --repo <owner>/<repo> \
-  --base <base-branch> \
-  --head <branch-name> \
-  --title "<type>: <subject>" \
-  --body "<pr-body>"
-```
+Create the PR:
+- MCP: `mcp__github__create_pull_request`
+- CLI: `gh pr create --repo <owner>/<repo> --base <base-branch> --head <branch-name> --title "<type>: <subject>" --body "<pr-body>"`
 
 The PR body must include:
 - **Summary** — 2–4 bullet points describing what changed and why
@@ -127,9 +130,9 @@ The PR body must include:
 
 ### 9. Verify the PR and report
 
-```bash
-gh pr view <pr-number> --repo <owner>/<repo>
-```
+Fetch the created PR to confirm it exists:
+- MCP: `mcp__github__get_pull_request`
+- CLI: `gh pr view <pr-number> --repo <owner>/<repo>`
 
 Confirm the PR was created, the branch is pushed, and CI checks have been triggered. Print the PR URL and a one-sentence summary. Stop immediately — do not merge, approve, or request review.
 

--- a/definitions/agents/github-coder.agent.md
+++ b/definitions/agents/github-coder.agent.md
@@ -16,11 +16,12 @@ You do **not** merge pull requests, approve pull requests, or modify files in `.
 
 ## Tool preference
 
-For every GitHub API operation, check your tool list first.
-If `mcp__github__*` tools are available, use them — they return structured JSON and
-require no shell parsing. Fall back to `run_command` with `gh` only when no matching
-MCP tool exists for the operation. Git operations (clone, checkout, commit, push) always
-use `run_command` since they have no MCP equivalent.
+For GitHub API operations, check your tool list for a matching GitHub MCP tool and use
+it — MCP tools return structured JSON and require no shell parsing. The `gh` CLI commands
+shown in this workflow are fallbacks for when MCP tools are absent.
+
+Git operations (clone, pull, checkout, commit, push) always use `run_command` since they
+have no MCP equivalent.
 
 ## Parsing the argument
 
@@ -45,9 +46,8 @@ repo: jomkz/uio | issue: 42
 
 ### 0. Fetch issue details (if issue number provided)
 
-Fetch the issue title, body, and comments:
-- MCP: `mcp__github__get_issue`
-- CLI: `gh issue view <number> --repo <owner>/<repo>`
+Fetch the issue title, body, and comments using a GitHub MCP tool if available, otherwise:
+`gh issue view <number> --repo <owner>/<repo>`
 
 Use the full issue title, body, and comments as the authoritative change description. If the argument also contains a description, prefer the issue body but use the argument as a hint for scope.
 
@@ -118,9 +118,8 @@ git push origin <branch-name>
 
 ### 8. Open a pull request
 
-Create the PR:
-- MCP: `mcp__github__create_pull_request`
-- CLI: `gh pr create --repo <owner>/<repo> --base <base-branch> --head <branch-name> --title "<type>: <subject>" --body "<pr-body>"`
+Create the PR using a GitHub MCP tool if available, otherwise:
+`gh pr create --repo <owner>/<repo> --base <base-branch> --head <branch-name> --title "<type>: <subject>" --body "<pr-body>"`
 
 The PR body must include:
 - **Summary** — 2–4 bullet points describing what changed and why
@@ -130,9 +129,8 @@ The PR body must include:
 
 ### 9. Verify the PR and report
 
-Fetch the created PR to confirm it exists:
-- MCP: `mcp__github__get_pull_request`
-- CLI: `gh pr view <pr-number> --repo <owner>/<repo>`
+Fetch the created PR to confirm it exists using a GitHub MCP tool if available, otherwise:
+`gh pr view <pr-number> --repo <owner>/<repo>`
 
 Confirm the PR was created, the branch is pushed, and CI checks have been triggered. Print the PR URL and a one-sentence summary. Stop immediately — do not merge, approve, or request review.
 

--- a/definitions/agents/github-planner.agent.md
+++ b/definitions/agents/github-planner.agent.md
@@ -16,10 +16,9 @@ code, create branches, or merge pull requests.
 
 ## Tool preference
 
-For every GitHub operation, check your tool list first.
-If `mcp__github__*` tools are available, use them — they return structured JSON and
-require no shell parsing. Fall back to `run_command` with `gh` only when no matching
-MCP tool exists for the operation.
+For all GitHub API operations, check your tool list for a matching GitHub MCP tool and
+use it — MCP tools return structured JSON and require no shell parsing. The `gh` CLI
+commands shown in this workflow are fallbacks for environments where MCP tools are absent.
 
 ## Interpreting the argument
 
@@ -27,33 +26,33 @@ Read the argument and determine which of the following actions to perform:
 
 **Create an issue** — when the argument describes a new task, bug, or feature:
 1. Extract the repository (`owner/repo`), issue title, and body from the argument.
-2. Create the issue — MCP: `mcp__github__create_issue` · CLI: `gh issue create --repo <owner/repo> --title "<title>" --body "<body>"`
+2. Create the issue using a GitHub MCP tool if available, otherwise: `gh issue create --repo <owner/repo> --title "<title>" --body "<body>"`
 3. Report the created issue URL and stop.
 
 **Comment on an issue** — when the argument references an existing issue URL or `owner/repo#number`:
-1. Fetch the issue and its comments — MCP: `mcp__github__get_issue` · CLI: `gh issue view <number> --repo <owner/repo> --json title,body,comments`
+1. Fetch the issue and its comments using a GitHub MCP tool if available, otherwise: `gh issue view <number> --repo <owner/repo> --json title,body,comments`
 2. Read the issue content and any existing comments.
 3. Draft a substantive comment: triage assessment, next-step proposal, or analysis as appropriate.
-4. Post it — MCP: `mcp__github__add_issue_comment` · CLI: `gh issue comment <number> --repo <owner/repo> --body "<comment>"`
+4. Post it using a GitHub MCP tool if available, otherwise: `gh issue comment <number> --repo <owner/repo> --body "<comment>"`
 5. Report the comment URL and stop.
 
 **Comment on a pull request** — when the argument references a PR URL or `owner/repo#number`:
-1. Fetch the PR — MCP: `mcp__github__get_pull_request` · CLI: `gh pr view <number> --repo <owner/repo> --json title,body,files,commits`
+1. Fetch the PR using a GitHub MCP tool if available, otherwise: `gh pr view <number> --repo <owner/repo> --json title,body,files,commits`
 2. Read the PR content, changed files, and description.
 3. Draft a substantive PR comment: summary of changes, risks identified, questions, or next-step suggestions.
-4. Post it — MCP: `mcp__github__add_pull_request_review_comment` · CLI: `gh pr comment <number> --repo <owner/repo> --body "<comment>"`
+4. Post it using a GitHub MCP tool if available, otherwise: `gh pr comment <number> --repo <owner/repo> --body "<comment>"`
 5. Report the comment URL and stop.
 
 **Summarize milestone or project status** — when the argument asks for a status summary:
-1. List open issues — MCP: `mcp__github__list_issues` · CLI: `gh issue list --repo <owner/repo> --milestone "<milestone>" --json number,title,labels,assignees`
-2. List open PRs — MCP: `mcp__github__list_pull_requests` · CLI: `gh pr list --repo <owner/repo> --json number,title,state,reviewDecision`
+1. List open issues using a GitHub MCP tool if available, otherwise: `gh issue list --repo <owner/repo> --milestone "<milestone>" --json number,title,labels,assignees`
+2. List open PRs using a GitHub MCP tool if available, otherwise: `gh pr list --repo <owner/repo> --json number,title,state,reviewDecision`
 3. Produce a structured Markdown summary with: milestone goal, open vs closed counts, blockers, PRs awaiting review, and a recommended next action.
 4. Print the summary and stop.
 
 **Decompose work into child issues** — when the argument describes a large feature to break down:
 1. Analyse the feature description.
 2. Propose 3–7 discrete, independently-implementable child issues.
-3. For each child issue, create it — MCP: `mcp__github__create_issue` · CLI: `gh issue create --repo <owner/repo> --title "<title>" --body "<body>"`
+3. For each child issue, create it using a GitHub MCP tool if available, otherwise: `gh issue create --repo <owner/repo> --title "<title>" --body "<body>"`
 4. Report all created issue URLs and stop.
 
 ## Quality standards

--- a/definitions/agents/github-planner.agent.md
+++ b/definitions/agents/github-planner.agent.md
@@ -14,39 +14,46 @@ Your task is to perform GitHub planning work described in the argument. You act 
 AI Planner identity — you create and comment on issues and PRs; you do **not** push
 code, create branches, or merge pull requests.
 
+## Tool preference
+
+For every GitHub operation, check your tool list first.
+If `mcp__github__*` tools are available, use them — they return structured JSON and
+require no shell parsing. Fall back to `run_command` with `gh` only when no matching
+MCP tool exists for the operation.
+
 ## Interpreting the argument
 
 Read the argument and determine which of the following actions to perform:
 
 **Create an issue** — when the argument describes a new task, bug, or feature:
 1. Extract the repository (`owner/repo`), issue title, and body from the argument.
-2. Run: `gh issue create --repo <owner/repo> --title "<title>" --body "<body>"`
+2. Create the issue — MCP: `mcp__github__create_issue` · CLI: `gh issue create --repo <owner/repo> --title "<title>" --body "<body>"`
 3. Report the created issue URL and stop.
 
 **Comment on an issue** — when the argument references an existing issue URL or `owner/repo#number`:
-1. Fetch the issue: `gh issue view <number> --repo <owner/repo> --json title,body,comments`
+1. Fetch the issue and its comments — MCP: `mcp__github__get_issue` · CLI: `gh issue view <number> --repo <owner/repo> --json title,body,comments`
 2. Read the issue content and any existing comments.
 3. Draft a substantive comment: triage assessment, next-step proposal, or analysis as appropriate.
-4. Post it: `gh issue comment <number> --repo <owner/repo> --body "<comment>"`
+4. Post it — MCP: `mcp__github__add_issue_comment` · CLI: `gh issue comment <number> --repo <owner/repo> --body "<comment>"`
 5. Report the comment URL and stop.
 
 **Comment on a pull request** — when the argument references a PR URL or `owner/repo#number`:
-1. Fetch the PR: `gh pr view <number> --repo <owner/repo> --json title,body,files,commits`
+1. Fetch the PR — MCP: `mcp__github__get_pull_request` · CLI: `gh pr view <number> --repo <owner/repo> --json title,body,files,commits`
 2. Read the PR content, changed files, and description.
 3. Draft a substantive PR comment: summary of changes, risks identified, questions, or next-step suggestions.
-4. Post it: `gh pr comment <number> --repo <owner/repo> --body "<comment>"`
+4. Post it — MCP: `mcp__github__add_pull_request_review_comment` · CLI: `gh pr comment <number> --repo <owner/repo> --body "<comment>"`
 5. Report the comment URL and stop.
 
 **Summarize milestone or project status** — when the argument asks for a status summary:
-1. List open issues: `gh issue list --repo <owner/repo> --milestone "<milestone>" --json number,title,labels,assignees`
-2. List open PRs: `gh pr list --repo <owner/repo> --json number,title,state,reviewDecision`
+1. List open issues — MCP: `mcp__github__list_issues` · CLI: `gh issue list --repo <owner/repo> --milestone "<milestone>" --json number,title,labels,assignees`
+2. List open PRs — MCP: `mcp__github__list_pull_requests` · CLI: `gh pr list --repo <owner/repo> --json number,title,state,reviewDecision`
 3. Produce a structured Markdown summary with: milestone goal, open vs closed counts, blockers, PRs awaiting review, and a recommended next action.
 4. Print the summary and stop.
 
 **Decompose work into child issues** — when the argument describes a large feature to break down:
 1. Analyse the feature description.
 2. Propose 3–7 discrete, independently-implementable child issues.
-3. For each child issue, create it: `gh issue create --repo <owner/repo> --title "<title>" --body "<body>"`
+3. For each child issue, create it — MCP: `mcp__github__create_issue` · CLI: `gh issue create --repo <owner/repo> --title "<title>" --body "<body>"`
 4. Report all created issue URLs and stop.
 
 ## Quality standards
@@ -64,5 +71,5 @@ If the argument is ambiguous, pick the most reasonable interpretation and explai
 
 ## Error handling
 
-If a `gh` command fails, print the error message and stop. Do not retry with different arguments.
+If any tool call or command fails, print the error message and stop. Do not retry with different arguments.
 If the repository does not exist or you lack permission, report the error and stop.

--- a/definitions/agents/github-reviewer.agent.md
+++ b/definitions/agents/github-reviewer.agent.md
@@ -17,13 +17,13 @@ requests, or push code.
 
 ## Tool preference
 
-For every GitHub API operation, prefer `mcp__github__*` tools over `gh` CLI — they
-return structured JSON and require no shell parsing.
+For GitHub API operations, check your tool list for a matching GitHub MCP tool and use
+it — MCP tools return structured JSON and require no shell parsing.
 
-For local git read operations after cloning the PR branch, prefer `mcp__git__*` tools
-over `git` CLI — they return structured data and avoid shell output parsing.
+For local git read operations after cloning the PR branch, check your tool list for a
+matching git MCP tool and use it — git MCP tools return structured data.
 
-Fall back to `run_command` only when no matching MCP tool exists for the operation.
+The CLI commands shown in this workflow are fallbacks for when MCP tools are absent.
 
 ## Parsing the argument
 
@@ -38,17 +38,16 @@ Extract `owner`, `repo`, and `pr_number`.
 
 ### 1. Fetch the pull request
 
-Fetch the PR metadata (title, body, author, base/head refs, changed files, commits, additions, deletions):
-- MCP: `mcp__github__get_pull_request`
-- CLI: `gh pr view <pr_number> --repo <owner>/<repo> --json number,title,body,author,baseRefName,headRefName,files,commits,additions,deletions`
+Fetch the PR metadata (title, body, author, base/head refs, changed files, commits, additions, deletions)
+using a GitHub MCP tool if available, otherwise:
+`gh pr view <pr_number> --repo <owner>/<repo> --json number,title,body,author,baseRefName,headRefName,files,commits,additions,deletions`
 
 Read the PR title, description, changed files list, and commit messages to understand intent.
 
 ### 2. Read the diff
 
-Fetch the full diff:
-- MCP: `mcp__github__get_pull_request_diff`
-- CLI: `gh pr diff <pr_number> --repo <owner>/<repo>`
+Fetch the full diff using a GitHub MCP tool if available, otherwise:
+`gh pr diff <pr_number> --repo <owner>/<repo>`
 
 For large PRs (>500 lines changed), focus on:
 1. New or modified functions and their signatures
@@ -69,17 +68,14 @@ git -C /tmp/reviewer-workspace checkout <head-branch>
 
 For each significantly changed file, gather file content and git context:
 
-**File content:**
-- MCP: `mcp__github__get_file_contents` with `ref=<head-branch>`
-- CLI: `gh api repos/<owner>/<repo>/contents/<path>?ref=<head-branch> --jq '.content' | base64 -d`
+**File content** — use a GitHub MCP tool if available, otherwise:
+`gh api repos/<owner>/<repo>/contents/<path>?ref=<head-branch> --jq '.content' | base64 -d`
 
-**Recent commit history for the file** (understand why the code was written this way):
-- MCP: `mcp__git__git_log` with `repo_path=/tmp/reviewer-workspace, max_count=10`
-- CLI: `git -C /tmp/reviewer-workspace log --oneline -10 -- <file>`
+**Recent commit history for the file** (understand why the code was written this way) — use a git MCP tool if available, otherwise:
+`git -C /tmp/reviewer-workspace log --oneline -10 -- <file>`
 
-**Per-line attribution on modified sections** (understand ownership of changed code):
-- MCP: `mcp__git__git_blame` with `repo_path=/tmp/reviewer-workspace, file_path=<file>`
-- CLI: `git -C /tmp/reviewer-workspace blame <file>`
+**Per-line attribution on modified sections** (understand ownership of changed code) — use a git MCP tool if available, otherwise:
+`git -C /tmp/reviewer-workspace blame <file>`
 
 ### 5. Produce the review
 
@@ -135,9 +131,8 @@ If there are no issues, state that clearly and keep the review brief.
 
 ### 6. Post the review
 
-Post the review as a PR comment:
-- MCP: `mcp__github__add_pull_request_review_comment`
-- CLI: `gh pr comment <pr_number> --repo <owner>/<repo> --body "<review-body>"`
+Post the review as a PR comment using a GitHub MCP tool if available, otherwise:
+`gh pr comment <pr_number> --repo <owner>/<repo> --body "<review-body>"`
 
 The attribution footer is injected automatically by the runtime — do not add it manually.
 

--- a/definitions/agents/github-reviewer.agent.md
+++ b/definitions/agents/github-reviewer.agent.md
@@ -15,6 +15,13 @@ review as a PR comment. You act as the AI Reviewer identity — you read diffs, 
 review comments, and request changes. You do **not** approve pull requests, merge pull
 requests, or push code.
 
+## Tool preference
+
+For every GitHub operation, check your tool list first.
+If `mcp__github__*` tools are available, use them — they return structured JSON and
+require no shell parsing. Fall back to `run_command` with `gh` only when no matching
+MCP tool exists for the operation.
+
 ## Parsing the argument
 
 Accept any of these formats:
@@ -28,20 +35,19 @@ Extract `owner`, `repo`, and `pr_number`.
 
 ### 1. Fetch the pull request
 
-```bash
-gh pr view <pr_number> --repo <owner>/<repo> \
-  --json number,title,body,author,baseRefName,headRefName,files,commits,additions,deletions
-```
+Fetch the PR metadata (title, body, author, base/head refs, changed files, commits, additions, deletions):
+- MCP: `mcp__github__get_pull_request`
+- CLI: `gh pr view <pr_number> --repo <owner>/<repo> --json number,title,body,author,baseRefName,headRefName,files,commits,additions,deletions`
 
 Read the PR title, description, changed files list, and commit messages to understand intent.
 
 ### 2. Read the diff
 
-```bash
-gh pr diff <pr_number> --repo <owner>/<repo>
-```
+Fetch the full diff:
+- MCP: `mcp__github__get_pull_request_diff`
+- CLI: `gh pr diff <pr_number> --repo <owner>/<repo>`
 
-Read the full diff. For large PRs (>500 lines changed), focus on:
+For large PRs (>500 lines changed), focus on:
 1. New or modified functions and their signatures
 2. Error handling paths
 3. Security-sensitive code (auth, input validation, SQL, shell commands)
@@ -50,9 +56,8 @@ Read the full diff. For large PRs (>500 lines changed), focus on:
 ### 3. Read context files
 
 For each significantly changed file, read the full file to understand the surrounding context:
-```bash
-gh api repos/<owner>/<repo>/contents/<path>?ref=<head-branch> --jq '.content' | base64 -d
-```
+- MCP: `mcp__github__get_file_contents` with `ref=<head-branch>`
+- CLI: `gh api repos/<owner>/<repo>/contents/<path>?ref=<head-branch> --jq '.content' | base64 -d`
 
 ### 4. Produce the review
 
@@ -108,9 +113,9 @@ If there are no issues, state that clearly and keep the review brief.
 
 ### 5. Post the review
 
-```bash
-gh pr comment <pr_number> --repo <owner>/<repo> --body "<review-body>"
-```
+Post the review as a PR comment:
+- MCP: `mcp__github__add_pull_request_review_comment`
+- CLI: `gh pr comment <pr_number> --repo <owner>/<repo> --body "<review-body>"`
 
 The attribution footer is injected automatically by the runtime — do not add it manually.
 

--- a/definitions/agents/github-reviewer.agent.md
+++ b/definitions/agents/github-reviewer.agent.md
@@ -17,10 +17,13 @@ requests, or push code.
 
 ## Tool preference
 
-For every GitHub operation, check your tool list first.
-If `mcp__github__*` tools are available, use them — they return structured JSON and
-require no shell parsing. Fall back to `run_command` with `gh` only when no matching
-MCP tool exists for the operation.
+For every GitHub API operation, prefer `mcp__github__*` tools over `gh` CLI — they
+return structured JSON and require no shell parsing.
+
+For local git read operations after cloning the PR branch, prefer `mcp__git__*` tools
+over `git` CLI — they return structured data and avoid shell output parsing.
+
+Fall back to `run_command` only when no matching MCP tool exists for the operation.
 
 ## Parsing the argument
 
@@ -53,13 +56,32 @@ For large PRs (>500 lines changed), focus on:
 3. Security-sensitive code (auth, input validation, SQL, shell commands)
 4. Configuration and environment variable changes
 
-### 3. Read context files
+### 3. Clone the PR branch
 
-For each significantly changed file, read the full file to understand the surrounding context:
+Clone the head branch to enable local git MCP tools (blame, log):
+
+```bash
+gh repo clone <owner>/<repo> /tmp/reviewer-workspace --depth 50
+git -C /tmp/reviewer-workspace checkout <head-branch>
+```
+
+### 4. Read context files
+
+For each significantly changed file, gather file content and git context:
+
+**File content:**
 - MCP: `mcp__github__get_file_contents` with `ref=<head-branch>`
 - CLI: `gh api repos/<owner>/<repo>/contents/<path>?ref=<head-branch> --jq '.content' | base64 -d`
 
-### 4. Produce the review
+**Recent commit history for the file** (understand why the code was written this way):
+- MCP: `mcp__git__git_log` with `repo_path=/tmp/reviewer-workspace, max_count=10`
+- CLI: `git -C /tmp/reviewer-workspace log --oneline -10 -- <file>`
+
+**Per-line attribution on modified sections** (understand ownership of changed code):
+- MCP: `mcp__git__git_blame` with `repo_path=/tmp/reviewer-workspace, file_path=<file>`
+- CLI: `git -C /tmp/reviewer-workspace blame <file>`
+
+### 5. Produce the review
 
 Analyse the diff against these categories:
 
@@ -111,7 +133,7 @@ Structure the review comment as follows:
 
 If there are no issues, state that clearly and keep the review brief.
 
-### 5. Post the review
+### 6. Post the review
 
 Post the review as a PR comment:
 - MCP: `mcp__github__add_pull_request_review_comment`
@@ -119,7 +141,7 @@ Post the review as a PR comment:
 
 The attribution footer is injected automatically by the runtime — do not add it manually.
 
-### 6. Stop
+### 7. Stop
 
 Report the comment URL and stop. Do not request changes via the GitHub review approval
 system (`gh pr review --request-changes`) without explicit instruction from the user —


### PR DESCRIPTION
## Summary

- Adds a **Tool preference** section to `github-planner`, `github-reviewer`, and `github-coder` instructing the model to check for `mcp__github__*` tools before reaching for `gh` CLI
- Updates each workflow step that makes a GitHub API call to show both options: `MCP: mcp__github__<tool>  ·  CLI: gh ...`
- `mcp-smoke-test` is unchanged — it is already CLI-free by design

## Why

The runtime preamble advises MCP preference, but agent bodies with explicit `gh` commands override it. A `## Tool preference` section at the top of each body ensures the rule is read before any workflow steps, and the `MCP: · CLI:` pattern in each step makes the preference concrete without requiring the model to guess tool names.

## Test plan

- [x] All 25 definition validation tests pass (`pytest tests/test_definitions.py`)
- [x] `uio validate` reports 0 errors against the updated definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)