### PR TITLE
feat: add `uio mcp init` to scaffold Claude Code and VS Code MCP config

### DIFF
--- a/tests/test_mcp_init.py
+++ b/tests/test_mcp_init.py
@@ -1,0 +1,232 @@
+"""Tests for `uio mcp init`."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from uio.cli.main import main
+
+_TOML_GITHUB = """\
+[mcp.github]
+command  = "github-mcp-server stdio"
+env_keys = ["GITHUB_PERSONAL_ACCESS_TOKEN"]
+"""
+
+_TOML_TWO_SERVERS = """\
+[mcp.github]
+command  = "github-mcp-server stdio"
+env_keys = ["GITHUB_PERSONAL_ACCESS_TOKEN"]
+
+[mcp.git]
+command  = "uvx mcp-server-git --repository /workspace"
+"""
+
+_TOML_NO_ENV = """\
+[mcp.git]
+command = "uvx mcp-server-git --repository /workspace"
+"""
+
+
+def _run(args: list[str], toml: str | None = _TOML_GITHUB) -> object:
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        if toml is not None:
+            Path("uio.toml").write_text(toml)
+        result = runner.invoke(main, ["mcp"] + args, catch_exceptions=False)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Claude output format
+# ---------------------------------------------------------------------------
+
+
+def test_claude_writes_mcp_json():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path("uio.toml").write_text(_TOML_GITHUB)
+        result = runner.invoke(main, ["mcp", "init", "--for", "claude"], catch_exceptions=False)
+        assert result.exit_code == 0
+        data = json.loads(Path(".mcp.json").read_text())
+
+    assert "mcpServers" in data
+    gh = data["mcpServers"]["github"]
+    assert gh["command"] == "github-mcp-server"
+    assert gh["args"] == ["stdio"]
+    assert gh["env"]["GITHUB_PERSONAL_ACCESS_TOKEN"] == "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+
+
+def test_claude_no_env_keys_omits_env_block():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path("uio.toml").write_text(_TOML_NO_ENV)
+        runner.invoke(main, ["mcp", "init", "--for", "claude"], catch_exceptions=False)
+        data = json.loads(Path(".mcp.json").read_text())
+
+    assert "env" not in data["mcpServers"]["git"]
+
+
+# ---------------------------------------------------------------------------
+# VS Code output format
+# ---------------------------------------------------------------------------
+
+
+def test_vscode_writes_vscode_mcp_json():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path("uio.toml").write_text(_TOML_GITHUB)
+        result = runner.invoke(main, ["mcp", "init", "--for", "vscode"], catch_exceptions=False)
+        assert result.exit_code == 0
+        data = json.loads(Path(".vscode/mcp.json").read_text())
+
+    assert "servers" in data
+    gh = data["servers"]["github"]
+    assert gh["command"] == "github-mcp-server"
+    assert gh["args"] == ["stdio"]
+    assert gh["env"]["GITHUB_PERSONAL_ACCESS_TOKEN"] == "${input:github-personal-access-token}"
+
+    assert data["inputs"][0]["id"] == "github-personal-access-token"
+    assert data["inputs"][0]["password"] is True
+
+
+def test_vscode_creates_directory():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path("uio.toml").write_text(_TOML_GITHUB)
+        runner.invoke(main, ["mcp", "init", "--for", "vscode"], catch_exceptions=False)
+        assert Path(".vscode/mcp.json").exists()
+
+
+def test_vscode_no_env_keys_omits_inputs():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path("uio.toml").write_text(_TOML_NO_ENV)
+        runner.invoke(main, ["mcp", "init", "--for", "vscode"], catch_exceptions=False)
+        data = json.loads(Path(".vscode/mcp.json").read_text())
+
+    assert "inputs" not in data
+
+
+# ---------------------------------------------------------------------------
+# Skip-if-exists / --force
+# ---------------------------------------------------------------------------
+
+
+def test_skip_if_exists():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path("uio.toml").write_text(_TOML_GITHUB)
+        Path(".mcp.json").write_text('{"original": true}')
+        result = runner.invoke(main, ["mcp", "init", "--for", "claude"], catch_exceptions=False)
+        assert result.exit_code == 0
+        assert "Skipped" in result.output
+        assert json.loads(Path(".mcp.json").read_text()) == {"original": True}
+
+
+def test_force_overwrites():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path("uio.toml").write_text(_TOML_GITHUB)
+        Path(".mcp.json").write_text('{"original": true}')
+        result = runner.invoke(
+            main, ["mcp", "init", "--for", "claude", "--force"], catch_exceptions=False
+        )
+        assert result.exit_code == 0
+        data = json.loads(Path(".mcp.json").read_text())
+        assert "mcpServers" in data
+
+
+# ---------------------------------------------------------------------------
+# --dry-run
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_makes_no_changes():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path("uio.toml").write_text(_TOML_GITHUB)
+        result = runner.invoke(
+            main, ["mcp", "init", "--for", "claude", "--dry-run"], catch_exceptions=False
+        )
+        assert result.exit_code == 0
+        assert "Would write" in result.output
+        assert not Path(".mcp.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# No MCP config
+# ---------------------------------------------------------------------------
+
+
+def test_no_mcp_config_exits_nonzero():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(main, ["mcp", "init", "--for", "claude"])
+        assert result.exit_code != 0
+        assert "No MCP servers configured" in result.output
+
+
+# ---------------------------------------------------------------------------
+# --global flag
+# ---------------------------------------------------------------------------
+
+
+def test_global_writes_claude_settings(tmp_path):
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path("uio.toml").write_text(_TOML_GITHUB)
+        with patch("uio.cli.mcp.Path.home", return_value=fake_home):
+            result = runner.invoke(
+                main, ["mcp", "init", "--for", "claude", "--global"], catch_exceptions=False
+            )
+    assert result.exit_code == 0
+    settings = json.loads((fake_home / ".claude" / "settings.json").read_text())
+    assert "mcpServers" in settings
+    assert "github" in settings["mcpServers"]
+
+
+def test_global_merges_existing_claude_settings(tmp_path):
+    fake_home = tmp_path / "home"
+    (fake_home / ".claude").mkdir(parents=True)
+    existing = {"theme": "dark", "mcpServers": {"other": {"command": "other-server"}}}
+    (fake_home / ".claude" / "settings.json").write_text(json.dumps(existing))
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path("uio.toml").write_text(_TOML_GITHUB)
+        with patch("uio.cli.mcp.Path.home", return_value=fake_home):
+            runner.invoke(
+                main, ["mcp", "init", "--for", "claude", "--global"], catch_exceptions=False
+            )
+
+    settings = json.loads((fake_home / ".claude" / "settings.json").read_text())
+    assert settings["theme"] == "dark"
+    assert "other" in settings["mcpServers"]
+    assert "github" in settings["mcpServers"]
+
+
+def test_global_with_vscode_exits_nonzero():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path("uio.toml").write_text(_TOML_GITHUB)
+        result = runner.invoke(main, ["mcp", "init", "--for", "vscode", "--global"])
+        assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# --for is required
+# ---------------------------------------------------------------------------
+
+
+def test_for_required():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path("uio.toml").write_text(_TOML_GITHUB)
+        result = runner.invoke(main, ["mcp", "init"])
+        assert result.exit_code != 0

--- a/uio/cli/main.py
+++ b/uio/cli/main.py
@@ -14,6 +14,7 @@ from uio.cli.chat import chat_cmd
 from uio.cli.config import config_group
 from uio.cli.cost import cost_cmd
 from uio.cli.link import link_cmd
+from uio.cli.mcp import mcp_group
 from uio.cli.prompt import prompt_group
 from uio.cli.registry import registry_group
 from uio.cli.skill import skill_group
@@ -82,6 +83,7 @@ main.add_command(cost_cmd, "cost")
 main.add_command(config_group, "config")
 main.add_command(link_cmd, "link")
 main.add_command(registry_group, "registry")
+main.add_command(mcp_group, "mcp")
 
 
 @main.command("init")
@@ -144,15 +146,18 @@ def init_cmd(examples: bool) -> None:
                 else:
                     click.echo(f"  Skipped (exists): {dest}")
 
-    # Add cost ledger to .gitignore if one exists
+    # Add generated files to .gitignore if one exists
     ledger = cfg["runtime"]["cost_ledger"]
     gitignore = Path(".gitignore")
     if gitignore.exists():
         contents = gitignore.read_text()
-        if ledger not in contents:
-            with gitignore.open("a") as f:
+        with gitignore.open("a") as f:
+            if ledger not in contents:
                 f.write(f"\n# uio cost ledger\n{ledger}\n")
-            click.echo(f"  Added '{ledger}' to .gitignore")
+                click.echo(f"  Added '{ledger}' to .gitignore")
+            if ".mcp.json" not in contents:
+                f.write("\n# uio mcp init output (env var refs vary per developer)\n.mcp.json\n")
+                click.echo("  Added '.mcp.json' to .gitignore")
 
     click.echo("\nDone. Run 'uio agent list' to see available agents.")
 

--- a/uio/cli/mcp.py
+++ b/uio/cli/mcp.py
@@ -1,0 +1,188 @@
+"""uio mcp — generate platform MCP configuration files."""
+
+from __future__ import annotations
+
+import json
+import shlex
+from pathlib import Path
+
+import click
+
+from uio.config import load_config
+
+
+def _cmd_parts(raw: str) -> tuple[str, list[str]]:
+    parts = shlex.split(raw) if raw else []
+    return (parts[0] if parts else ""), (parts[1:] if len(parts) > 1 else [])
+
+
+def _claude_entry(server_cfg: dict) -> dict:
+    command, args = _cmd_parts(server_cfg.get("command", ""))
+    entry: dict = {"command": command}
+    if args:
+        entry["args"] = args
+    env_keys = server_cfg.get("env_keys", [])
+    if env_keys:
+        entry["env"] = {k: f"${{{k}}}" for k in env_keys}
+    return entry
+
+
+def _vscode_entry(server_cfg: dict) -> tuple[dict, list[dict]]:
+    command, args = _cmd_parts(server_cfg.get("command", ""))
+    entry: dict = {"command": command}
+    if args:
+        entry["args"] = args
+    inputs: list[dict] = []
+    env_keys = server_cfg.get("env_keys", [])
+    if env_keys:
+        env_block: dict = {}
+        for k in env_keys:
+            input_id = k.lower().replace("_", "-")
+            env_block[k] = f"${{input:{input_id}}}"
+            inputs.append(
+                {
+                    "type": "promptString",
+                    "id": input_id,
+                    "description": k.replace("_", " ").title(),
+                    "password": True,
+                }
+            )
+        entry["env"] = env_block
+    return entry, inputs
+
+
+def _write_json(dest: Path, data: dict, force: bool, dry_run: bool) -> None:
+    if dest.exists() and not force:
+        click.echo(f"  Skipped (exists): {dest}  (use --force to overwrite)")
+        return
+    content = json.dumps(data, indent=2) + "\n"
+    if dry_run:
+        click.echo(f"  Would write: {dest}")
+    else:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(content)
+        click.echo(f"  Wrote: {dest}")
+
+
+def _write_claude(mcp_cfg: dict, dest: Path, force: bool, dry_run: bool) -> None:
+    output = {"mcpServers": {name: _claude_entry(cfg) for name, cfg in mcp_cfg.items()}}
+    _write_json(dest, output, force, dry_run)
+
+
+def _merge_claude_global(mcp_cfg: dict, settings_path: Path, force: bool, dry_run: bool) -> None:
+    existing: dict = {}
+    if settings_path.exists():
+        try:
+            existing = json.loads(settings_path.read_text())
+        except Exception:
+            pass
+
+    servers: dict = existing.get("mcpServers", {})
+    changed = False
+    for name, server_cfg in mcp_cfg.items():
+        if name in servers and not force:
+            click.echo(f"  Skipped (exists): mcpServers.{name} in {settings_path}")
+            continue
+        servers[name] = _claude_entry(server_cfg)
+        changed = True
+        click.echo(
+            f"  {'Would write' if dry_run else 'Wrote'}: mcpServers.{name} → {settings_path}"
+        )
+
+    if changed and not dry_run:
+        existing["mcpServers"] = servers
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        settings_path.write_text(json.dumps(existing, indent=2) + "\n")
+
+
+def _write_vscode(mcp_cfg: dict, dest: Path, force: bool, dry_run: bool) -> None:
+    all_inputs: list[dict] = []
+    all_servers: dict = {}
+    for name, server_cfg in mcp_cfg.items():
+        entry, inputs = _vscode_entry(server_cfg)
+        all_servers[name] = entry
+        all_inputs.extend(inputs)
+
+    output: dict = {}
+    if all_inputs:
+        output["inputs"] = all_inputs
+    output["servers"] = all_servers
+    _write_json(dest, output, force, dry_run)
+
+
+@click.group("mcp")
+def mcp_group() -> None:
+    """Manage MCP server configuration for external tools."""
+
+
+@mcp_group.command("init")
+@click.option(
+    "--for",
+    "platform",
+    type=click.Choice(["claude", "vscode"]),
+    required=True,
+    help="Target platform: 'claude' writes .mcp.json; 'vscode' writes .vscode/mcp.json.",
+)
+@click.option(
+    "--global",
+    "global_",
+    is_flag=True,
+    default=False,
+    help="(claude only) Merge into ~/.claude/settings.json instead of writing .mcp.json.",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Overwrite the target file if it already exists.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Print planned output without writing any files.",
+)
+def mcp_init_cmd(platform: str, global_: bool, force: bool, dry_run: bool) -> None:
+    """Scaffold an MCP config file for Claude Code or VS Code.
+
+    Reads [mcp.<name>] server definitions from uio.toml and writes the
+    appropriate config file for the target platform. Secret values are
+    never written to disk — env var references are emitted instead.
+
+    Declare env vars required by each server in uio.toml:
+
+    \b
+      [mcp.github]
+      command  = "github-mcp-server stdio"
+      env_keys = ["GITHUB_PERSONAL_ACCESS_TOKEN"]
+
+    \b
+    Examples:
+      uio mcp init --for claude
+      uio mcp init --for vscode
+      uio mcp init --for claude --global
+      uio mcp init --for claude --force
+    """
+    if global_ and platform != "claude":
+        raise click.UsageError("--global is only supported with --for claude")
+
+    cfg = load_config()
+    mcp_cfg = cfg.get("mcp", {})
+
+    if not mcp_cfg:
+        raise click.ClickException(
+            "No MCP servers configured in uio.toml.\n"
+            "Add one or more [mcp.<name>] sections first, for example:\n\n"
+            "  [mcp.github]\n"
+            '  command  = "github-mcp-server stdio"\n'
+            '  env_keys = ["GITHUB_PERSONAL_ACCESS_TOKEN"]'
+        )
+
+    if platform == "claude":
+        if global_:
+            settings_path = Path.home() / ".claude" / "settings.json"
+            _merge_claude_global(mcp_cfg, settings_path, force, dry_run)
+        else:
+            _write_claude(mcp_cfg, Path(".mcp.json"), force, dry_run)
+    else:
+        _write_vscode(mcp_cfg, Path(".vscode") / "mcp.json", force, dry_run)


### PR DESCRIPTION
## Summary

- Adds `uio mcp` subcommand group with `uio mcp init` as its first command
- `--for claude` writes `.mcp.json`; `--for vscode` writes `.vscode/mcp.json`; `--for claude --global` merges into `~/.claude/settings.json`
- Secret values are never written to disk — Claude Code gets `${VAR}` env references, VS Code gets `${input:<id>}` references backed by a generated `inputs` block
- `uio init` now also adds `.mcp.json` to `.gitignore` alongside `uio_cost.jsonl`

## Test plan

- [ ] `uio mcp init --for claude` writes `.mcp.json` with correct `mcpServers` structure
- [ ] `uio mcp init --for vscode` writes `.vscode/mcp.json` with `servers` + `inputs`
- [ ] `uio mcp init --for claude --global` merges into `~/.claude/settings.json` without clobbering unrelated keys
- [ ] Re-running without `--force` prints "Skipped" and leaves file unchanged
- [ ] `--force` overwrites existing file
- [ ] `--dry-run` prints intent but makes no filesystem changes
- [ ] Running with no `[mcp.*]` in `uio.toml` exits non-zero with a helpful message
- [ ] `uio init` on a project with `.gitignore` adds `.mcp.json` entry

Closes #128