### PR TITLE
chore: change default routing chain order to ollama → openai → gemini → anthropic

### DIFF
--- a/docs/07-providers.md
+++ b/docs/07-providers.md
@@ -9,10 +9,10 @@ uio supports three built-in providers and any OpenAI-compatible endpoint. This p
 When no `--provider` flag is given, uio tries providers in this order:
 
 ```
-Gemini  →  Anthropic  →  OpenAI  →  Ollama
+Ollama  →  OpenAI  →  Gemini  →  Anthropic
 ```
 
-A provider is included in the chain if its required API key is present in the environment. Ollama has no key requirement and is always the final fallback (as long as the Ollama process is running).
+A provider is included in the chain if its required API key is present in the environment. Ollama has no key requirement and is always tried first (as long as the Ollama process is running). Paid providers follow in ascending cost order.
 
 The first provider in the chain that initialises successfully is used. To see which provider would be selected for the current environment:
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -129,9 +129,10 @@ def test_provider_chain_explicit_override_even_without_key(monkeypatch):
 def test_provider_chain_auto_includes_gemini_when_key_present(monkeypatch):
     monkeypatch.setenv("GEMINI_API_KEY", "fake-key")
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     chain = select_provider_chain(None)
     assert "gemini" in chain
-    assert chain.index("gemini") == 0
+    assert chain.index("ollama") < chain.index("gemini")
 
 
 def test_provider_chain_auto_skips_gemini_when_key_missing(monkeypatch):
@@ -182,10 +183,10 @@ def test_provider_chain_respects_routing_order(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "o-key")
     chain = select_provider_chain(None)
     assert (
-        chain.index("gemini")
-        < chain.index("anthropic")
+        chain.index("ollama")
         < chain.index("openai")
-        < chain.index("ollama")
+        < chain.index("gemini")
+        < chain.index("anthropic")
     )
 
 
@@ -210,7 +211,8 @@ def test_provider_chain_anthropic_only_when_only_anthropic_key(monkeypatch):
     monkeypatch.setenv("ANTHROPIC_API_KEY", "a-key")
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     chain = select_provider_chain(None)
-    assert chain[0] == "anthropic"
+    assert "anthropic" in chain
+    assert chain.index("ollama") < chain.index("anthropic")
 
 
 # ── estimate_cost_usd ──────────────────────────────────────────────────────────

--- a/uio/core/routing.py
+++ b/uio/core/routing.py
@@ -6,7 +6,7 @@ import os
 
 from uio.core.clients import PROVIDER_DEFAULTS, PROVIDER_SMALL_MODELS
 
-ROUTING_CHAIN = ["gemini", "anthropic", "openai", "ollama"]
+ROUTING_CHAIN = ["ollama", "openai", "gemini", "anthropic"]
 
 PROVIDER_KEY_ENV: dict[str, str | None] = {
     "gemini": "GEMINI_API_KEY",
@@ -69,5 +69,5 @@ def select_provider_chain(provider_override: str | None, complexity: str = "smal
     # For small complexity, always fall back to Ollama if nothing else is available.
     # For large complexity, Ollama is excluded — an empty list tells the runner to exit cleanly.
     if not available and complexity != "large":
-        return [ROUTING_CHAIN[-1]]
+        return ["ollama"]
     return available


### PR DESCRIPTION
## Summary

- Changes `ROUTING_CHAIN` in `uio/core/routing.py` from `["gemini", "anthropic", "openai", "ollama"]` to `["ollama", "openai", "gemini", "anthropic"]` — cost-first ordering: local/free before paid, paid providers ascending by per-token cost.
- Updates `docs/07-providers.md` auto-routing section to reflect the new chain order and clarify that Ollama is now the first provider tried (not the last fallback).
- Updates three tests in `tests/test_routing.py` that asserted the old chain positions.
- Corrects the unreachable small-complexity fallback in `select_provider_chain` from `ROUTING_CHAIN[-1]` (which would have returned `"anthropic"` with the new order) to hardcoded `"ollama"`.

## Test plan

- [ ] `pytest -m "not integration"` passes (all 46 routing tests green locally)
- [ ] `ruff format --check .` and `ruff check .` pass with no issues
- [ ] `uio config show` with no API keys set shows `ollama` as the selected provider
- [ ] `uio config show` with `GEMINI_API_KEY` set and no other keys shows `ollama` first, `gemini` second
- [ ] `uio config show` with all keys set shows chain order `ollama → openai → gemini → anthropic`

Closes #133

---
> 🤖 Generated by [uio AI Coder](https://github.com/jomkz/uio) — review before merging.