### PR TITLE
feat: make routing chain configurable in uio.toml

### DIFF
--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -215,6 +215,51 @@ def test_provider_chain_anthropic_only_when_only_anthropic_key(monkeypatch):
     assert chain.index("ollama") < chain.index("anthropic")
 
 
+def test_provider_chain_custom_routing_chain_respected(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "g-key")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "a-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "o-key")
+    chain = select_provider_chain(None, routing_chain=["anthropic", "openai"])
+    assert chain == ["anthropic", "openai"]
+
+
+def test_provider_chain_custom_chain_filters_missing_keys(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "a-key")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    chain = select_provider_chain(None, routing_chain=["anthropic", "openai"])
+    assert chain == ["anthropic"]
+    assert "openai" not in chain
+
+
+def test_provider_chain_custom_chain_unknown_provider_skipped(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "a-key")
+    chain = select_provider_chain(None, routing_chain=["anthropic", "unknown-provider"])
+    assert chain == ["anthropic"]
+    assert "unknown-provider" not in chain
+
+
+def test_provider_chain_none_routing_chain_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "g-key")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "a-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "o-key")
+    chain_default = select_provider_chain(None, routing_chain=None)
+    chain_explicit = select_provider_chain(None)
+    assert chain_default == chain_explicit == ROUTING_CHAIN
+
+
+def test_provider_chain_custom_chain_ollama_included_for_large(monkeypatch):
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    chain = select_provider_chain(None, complexity="large", routing_chain=["ollama", "gemini"])
+    assert "ollama" not in chain
+
+
+def test_provider_chain_custom_chain_preserves_order(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "g-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "o-key")
+    chain = select_provider_chain(None, routing_chain=["gemini", "openai", "ollama"])
+    assert chain.index("gemini") < chain.index("openai") < chain.index("ollama")
+
+
 # ── estimate_cost_usd ──────────────────────────────────────────────────────────
 
 

--- a/uio/cli/agent.py
+++ b/uio/cli/agent.py
@@ -109,6 +109,7 @@ def agent_run_cmd(
         max_iterations=cfg["runtime"]["max_iterations"],
         max_iterations_large=cfg["runtime"]["max_iterations_large"],
         anthropic_max_tokens=cfg["runtime"]["anthropic_max_tokens"],
+        routing_chain=cfg["runtime"].get("routing_chain"),
     )
 
 

--- a/uio/cli/config.py
+++ b/uio/cli/config.py
@@ -27,7 +27,10 @@ def config_show_cmd() -> None:
       uio config show
     """
     cfg = load_config()
-    chain = select_provider_chain(cfg["runtime"].get("default_provider"))
+    chain = select_provider_chain(
+        cfg["runtime"].get("default_provider"),
+        routing_chain=cfg["runtime"].get("routing_chain"),
+    )
 
     click.echo("Provider routing chain:\n")
     all_providers = ["gemini", "anthropic", "openai", "ollama"]

--- a/uio/cli/prompt.py
+++ b/uio/cli/prompt.py
@@ -81,6 +81,7 @@ def prompt_run_cmd(
         ledger_path=cfg["runtime"]["cost_ledger"],
         large_agent_names=cfg["large_agents"]["names"],
         shell_override=shell,
+        routing_chain=cfg["runtime"].get("routing_chain"),
     )
 
 

--- a/uio/cli/skill.py
+++ b/uio/cli/skill.py
@@ -89,6 +89,7 @@ def skill_run_cmd(
         ledger_path=cfg["runtime"]["cost_ledger"],
         large_agent_names=cfg["large_agents"]["names"],
         shell_override=shell,
+        routing_chain=cfg["runtime"].get("routing_chain"),
     )
 
 

--- a/uio/config.py
+++ b/uio/config.py
@@ -20,6 +20,7 @@ _DEFAULTS: dict = {
     },
     "runtime": {
         "default_provider": None,
+        "routing_chain": None,
         "cost_ledger": "uio_cost.jsonl",
         "timeout": 300,
         "max_iterations": 10,
@@ -41,6 +42,7 @@ prompts = ".uio/prompts"
 
 [runtime]
 # default_provider = "gemini"
+# routing_chain = ["ollama", "openai", "gemini", "anthropic"]
 cost_ledger          = "uio_cost.jsonl"
 timeout              = 300
 max_iterations       = 10   # small agents (summarise, comment, query)

--- a/uio/core/routing.py
+++ b/uio/core/routing.py
@@ -47,11 +47,16 @@ def select_model(provider: str, complexity: str, model_override: str | None) -> 
     return PROVIDER_DEFAULTS.get(provider, "")
 
 
-def select_provider_chain(provider_override: str | None, complexity: str = "small") -> list[str]:
+def select_provider_chain(
+    provider_override: str | None,
+    complexity: str = "small",
+    routing_chain: list[str] | None = None,
+) -> list[str]:
     """Return ordered providers to try.
 
     If --provider is set, returns that single provider. Otherwise returns all
-    providers in ROUTING_CHAIN that have their required API key available.
+    providers in the active chain that have their required API key available.
+    The active chain is ``routing_chain`` when provided, else ``ROUTING_CHAIN``.
 
     Ollama is excluded from auto-routing for large-complexity runs because
     local models are unlikely to reliably execute multi-step tool-call chains.
@@ -59,11 +64,14 @@ def select_provider_chain(provider_override: str | None, complexity: str = "smal
     """
     if provider_override:
         return [provider_override]
+    chain = routing_chain if routing_chain is not None else ROUTING_CHAIN
     available = []
-    for p in ROUTING_CHAIN:
+    for p in chain:
         if p == "ollama" and complexity == "large":
             continue
-        key_env = PROVIDER_KEY_ENV.get(p)
+        if p not in PROVIDER_KEY_ENV:
+            continue
+        key_env = PROVIDER_KEY_ENV[p]
         if key_env is None or os.environ.get(key_env):
             available.append(p)
     # For small complexity, always fall back to Ollama if nothing else is available.

--- a/uio/core/runner.py
+++ b/uio/core/runner.py
@@ -164,6 +164,7 @@ def run_agent(
     max_iterations: int = _DEFAULT_MAX_ITERATIONS,
     max_iterations_large: int = _DEFAULT_MAX_ITERATIONS_LARGE,
     anthropic_max_tokens: int | None = None,
+    routing_chain: list[str] | None = None,
 ) -> None:
     if definition_path is None:
         raise ValueError("definition_path must be provided")
@@ -216,7 +217,7 @@ def run_agent(
         user_message = f"Begin your workflow now. Argument: {arg}"
 
     resolved_complexity = infer_complexity(agent_name, frontmatter, complexity, large_agent_names)
-    provider_chain = select_provider_chain(provider, resolved_complexity)
+    provider_chain = select_provider_chain(provider, resolved_complexity, routing_chain)
     # Frontmatter max_tokens overrides the project-level anthropic_max_tokens setting.
     resolved_max_tokens: int | None = frontmatter.get("max_tokens") or anthropic_max_tokens
     cap = max_iterations_large if resolved_complexity == "large" else max_iterations


### PR DESCRIPTION
## Summary

- Adds an optional `routing_chain` key under `[runtime]` in `uio.toml` that overrides the hardcoded `ROUTING_CHAIN` default in `uio/core/routing.py`
- When `routing_chain` is absent the existing default order is used unchanged — no behaviour change for current users
- Unknown providers in a custom chain are skipped gracefully (not in `PROVIDER_KEY_ENV`); providers with missing API keys are filtered as usual
- `uio config show` now reflects the resolved chain order when a custom chain is configured
- Documents the option as a commented-out example in the starter `uio.toml` template

## Test plan

- [ ] Add `routing_chain = ["anthropic", "openai"]` to `[runtime]` in `uio.toml` and run `uio config show` — confirm only those providers appear in the chain (filtered by key availability)
- [ ] Remove `routing_chain` from `uio.toml` and confirm `uio config show` shows the default order
- [ ] Run `pytest -m "not integration"` — all 342 tests pass
- [ ] Include an unknown provider name in `routing_chain`; confirm it is silently skipped and the run proceeds with valid providers

Closes #132

---
> 🤖 Generated by [uio](https://github.com/jomkz/uio) AI Coder · `uio-coder[bot]`