### PR TITLE
feat: add setup-python-env skill for reliable Python environment bootstrapping

### DIFF
--- a/definitions/agents/github-coder.agent.md
+++ b/definitions/agents/github-coder.agent.md
@@ -110,11 +110,17 @@ Make the minimal set of code edits required to implement the described change.
 - Do not reformat unrelated code or fix unrelated issues.
 - Do not modify any file under `.github/workflows/` — stop with an error if the change requires it.
 
-### 5. Run code quality checks
+### 5. Set up the Python environment
+
+If the repository contains a Python project, run `/setup-python-env` with `project-path: <work-dir>`. This ensures `/quality-checks` runs against an environment that matches CI.
+
+Skip this step for non-Python repositories.
+
+### 6. Run code quality checks
 
 Before committing, run `/quality-checks` with `project-path: <work-dir>`. Stop if it reports any unfixable errors.
 
-### 6. Commit with the AI Coder author identity
+### 7. Commit with the AI Coder author identity
 
 The runtime will instruct you to use the correct author flags. Use them on every commit:
 
@@ -127,15 +133,15 @@ git -C <work-dir> \
 Commit message format: `<type>: <short imperative subject>` (conventional commits).
 Types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`.
 
-If there were formatting-only changes from step 5, include them in the same commit.
+If there were formatting-only changes from step 6, include them in the same commit.
 
-### 7. Push the branch
+### 8. Push the branch
 
 ```bash
 git -C <work-dir> push origin <branch-name>
 ```
 
-### 8. Open a pull request
+### 9. Open a pull request
 
 Create the PR using a GitHub MCP tool if available, otherwise:
 `gh pr create --repo <owner>/<repo> --base <base-branch> --head <branch-name> --title "<type>: <subject>" --body "<pr-body>"`
@@ -146,7 +152,7 @@ The PR body must include:
 - `Closes #<issue>` if an issue number was provided
 - The AI disclosure footer (injected automatically by the runtime)
 
-### 9. Verify the PR and report
+### 10. Verify the PR and report
 
 Fetch the created PR to confirm it exists using a GitHub MCP tool if available, otherwise:
 `gh pr view <pr-number> --repo <owner>/<repo>`

--- a/definitions/skills/setup-python-env.skill.md
+++ b/definitions/skills/setup-python-env.skill.md
@@ -1,0 +1,63 @@
+---
+name: setup-python-env
+description: Detect the project's Python package manager and bootstrap a virtual environment with all dependencies installed.
+---
+
+# Skill: setup-python-env
+
+## Input
+
+- `project-path` — root directory of the Python project (required)
+- `python-version` — preferred Python version (e.g. `3.12`); defaults to the version declared in `pyproject.toml`, `.python-version`, or `runtime.txt`, falling back to the system default (optional)
+
+## Output
+
+A virtual environment exists at `<project-path>/.venv`, is activated for the remainder of the workflow, and all project dependencies (including dev extras) are installed.
+
+## Steps
+
+### 1. Detect the package manager
+
+Inspect the files at `project-path` and use the **first** match in this priority order:
+
+| Condition | Tool | Bootstrap commands |
+|---|---|---|
+| `uv.lock` present **or** `[tool.uv]` in `pyproject.toml` | `uv` | `uv venv .venv && uv pip install -e ".[dev]"` |
+| `poetry.lock` present | `poetry` | `poetry install` |
+| `Pipfile.lock` present | `pipenv` | `pipenv install --dev` |
+| `requirements-dev.txt` present | `pip` | `python -m pip install -r requirements-dev.txt` |
+| `requirements.txt` present | `pip` | `python -m pip install -r requirements.txt` |
+| `pyproject.toml` present (no lock file) | `pip` | `python -m pip install -e ".[dev]"` |
+| None of the above | — | Warn and skip; do not abort the parent workflow |
+
+> **`pip` invocation**: always use `python -m pip` rather than bare `pip` to avoid `PATH` issues.
+
+### 2. Bootstrap the environment
+
+Run the detected bootstrap commands from `project-path`:
+
+```bash
+cd <project-path>
+# example for pip + pyproject.toml:
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -e ".[dev]"
+```
+
+For `uv`: if `.venv` already exists, skip `uv venv` and proceed directly to `uv pip install`.
+
+For `poetry` and `pipenv`: these tools manage their own virtual environments; do not create `.venv` manually.
+
+If the selected tool is not installed, try the next tool in the priority list rather than failing immediately.
+
+If no tool succeeds, report a clear error listing what was tried and stop.
+
+### 3. Verify the environment
+
+Confirm the environment is active and dependencies are installed:
+
+```bash
+python -c "import sys; print(sys.executable)"
+```
+
+If this fails, report the error and stop.

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1,0 +1,70 @@
+"""Structural validation tests for skill definitions in definitions/skills/."""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+import yaml
+
+from uio.schema.parser import parse_definition_file, validate_definition
+
+_SKILLS_DIR = pathlib.Path(__file__).parent.parent / "definitions" / "skills"
+_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n(.*)", re.DOTALL)
+
+
+def _all_skill_files() -> list[pathlib.Path]:
+    return sorted(_SKILLS_DIR.glob("**/*.skill.md"))
+
+
+def _parse_frontmatter(path: pathlib.Path) -> tuple[dict, str]:
+    content = path.read_text()
+    m = _FRONTMATTER_RE.match(content)
+    if not m:
+        return {}, content.strip()
+    return yaml.safe_load(m.group(1)) or {}, m.group(2).strip()
+
+
+def test_skills_dir_has_definitions():
+    files = _all_skill_files()
+    assert files, f"No .skill.md files found under {_SKILLS_DIR}"
+
+
+@pytest.mark.parametrize("path", _all_skill_files(), ids=lambda p: p.name)
+def test_skill_has_frontmatter(path):
+    fm, _ = _parse_frontmatter(path)
+    assert fm, f"{path.name}: no frontmatter found"
+
+
+@pytest.mark.parametrize("path", _all_skill_files(), ids=lambda p: p.name)
+def test_skill_has_name(path):
+    fm, _ = _parse_frontmatter(path)
+    assert fm.get("name"), f"{path.name}: missing 'name' field"
+
+
+@pytest.mark.parametrize("path", _all_skill_files(), ids=lambda p: p.name)
+def test_skill_has_description(path):
+    fm, _ = _parse_frontmatter(path)
+    assert fm.get("description"), f"{path.name}: missing 'description' field"
+
+
+@pytest.mark.parametrize("path", _all_skill_files(), ids=lambda p: p.name)
+def test_skill_has_nonempty_body(path):
+    _, body = _parse_frontmatter(path)
+    assert body.strip(), f"{path.name}: body is empty"
+
+
+@pytest.mark.parametrize("path", _all_skill_files(), ids=lambda p: p.name)
+def test_skill_passes_validation(path, tmp_path):
+    dest = tmp_path / path.name
+    dest.write_text(path.read_text())
+    fm, _ = parse_definition_file(str(dest))
+    errors = validate_definition(str(dest), fm)
+    assert errors == [], f"{path.name}: validation errors: {errors}"
+
+
+@pytest.mark.parametrize("path", _all_skill_files(), ids=lambda p: p.name)
+def test_skill_has_steps_section(path):
+    _, body = _parse_frontmatter(path)
+    assert "## Steps" in body, f"{path.name}: missing '## Steps' section"


### PR DESCRIPTION
## Summary

- Adds `definitions/skills/setup-python-env.skill.md`: a reusable skill that detects the project's Python package manager (`uv`, `poetry`, `pipenv`, or `pip` via `python -m pip`) and bootstraps a `.venv` with all dependencies installed
- Updates `definitions/agents/github-coder.agent.md` to invoke `/setup-python-env` as a new step 5, between "Apply the change" and "Run code quality checks", so quality checks always run in a properly installed environment
- Adds `tests/test_skills.py` which parametrically validates every `.skill.md` file under `definitions/skills/` for frontmatter, required fields, non-empty body, and a `## Steps` section — mirrors the existing `test_definitions.py` approach for agents

## Test plan

- [ ] `pytest tests/test_skills.py -v` passes for all three existing skill files
- [ ] `ruff format --check . && ruff check .` reports no issues
- [ ] Manually verify `setup-python-env.skill.md` has `## Input`, `## Output`, and `## Steps` sections
- [ ] Confirm `github-coder.agent.md` step 5 reads "Set up the Python environment" and references `/setup-python-env`

Closes #139

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) (AI Coder identity)