### PR TITLE
feat: clone agent workspaces into .tmp/ so MCP tools can access them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,3 +223,6 @@ __marimo__/
 .claude/agents
 .claude/skills
 .claude/commands
+
+# Agent clone workspaces (created by github-coder and similar agents)
+.agents/

--- a/.gitignore
+++ b/.gitignore
@@ -225,4 +225,4 @@ __marimo__/
 .claude/commands
 
 # Agent clone workspaces (created by github-coder and similar agents)
-.agents/
+.tmp/

--- a/definitions/agents/github-coder.agent.md
+++ b/definitions/agents/github-coder.agent.md
@@ -43,7 +43,7 @@ The argument describes the change to make. Extract:
 - **Issue number** — optional; if provided, fetch the full issue body to derive or refine the change description
 - **Branch name** — optional; default to `ai-coder/<slugified-description>`
 - **Base branch** — optional; default to `main`
-- **Work dir** — optional; default to `<workspace-root>/.agents/<repo>-<branch-slug>` where `<workspace-root>` is the root of the current project (run `git rev-parse --show-toplevel` to detect it), `<repo>` is the repository name without the owner prefix, and `<branch-slug>` is the branch name with `/` replaced by `-` (e.g. branch `ai-coder/my-fix` → slug `ai-coder-my-fix`). Placing workspaces under `.agents/` keeps them inside the MCP server allowlist so `mcp__mcp-git__*` and `mcp__mcp-filesystem__*` tools work without fallback. Each branch gets its own subdirectory so concurrent or sequential runs do not share state. Derive this once and use it as `<work-dir>` in every subsequent step.
+- **Work dir** — optional; default to `<workspace-root>/.tmp/<repo>-<branch-slug>` where `<workspace-root>` is the root of the current project (run `git rev-parse --show-toplevel` to detect it), `<repo>` is the repository name without the owner prefix, and `<branch-slug>` is the branch name with `/` replaced by `-` (e.g. branch `ai-coder/my-fix` → slug `ai-coder-my-fix`). Placing workspaces under `.tmp/` keeps them inside the MCP server allowlist so `mcp__mcp-git__*` and `mcp__mcp-filesystem__*` tools work without fallback. Each branch gets its own subdirectory so concurrent or sequential runs do not share state. Derive this once and use it as `<work-dir>` in every subsequent step.
 
 Example argument:
 ```

--- a/definitions/agents/github-coder.agent.md
+++ b/definitions/agents/github-coder.agent.md
@@ -43,7 +43,7 @@ The argument describes the change to make. Extract:
 - **Issue number** — optional; if provided, fetch the full issue body to derive or refine the change description
 - **Branch name** — optional; default to `ai-coder/<slugified-description>`
 - **Base branch** — optional; default to `main`
-- **Work dir** — optional; default to `/tmp/<repo>-<branch-slug>` where `<repo>` is the repository name without the owner prefix and `<branch-slug>` is the branch name with `/` replaced by `-` (e.g. branch `ai-coder/my-fix` → slug `ai-coder-my-fix`). This gives each branch its own isolated workspace so concurrent or sequential runs on the same repo do not interfere. Derive this once and use it as `<work-dir>` in every subsequent step.
+- **Work dir** — optional; default to `<workspace-root>/.agents/<repo>-<branch-slug>` where `<workspace-root>` is the root of the current project (run `git rev-parse --show-toplevel` to detect it), `<repo>` is the repository name without the owner prefix, and `<branch-slug>` is the branch name with `/` replaced by `-` (e.g. branch `ai-coder/my-fix` → slug `ai-coder-my-fix`). Placing workspaces under `.agents/` keeps them inside the MCP server allowlist so `mcp__mcp-git__*` and `mcp__mcp-filesystem__*` tools work without fallback. Each branch gets its own subdirectory so concurrent or sequential runs do not share state. Derive this once and use it as `<work-dir>` in every subsequent step.
 
 Example argument:
 ```

--- a/definitions/skills/github-clone-repo.skill.md
+++ b/definitions/skills/github-clone-repo.skill.md
@@ -9,9 +9,10 @@ description: Clone a GitHub repository to a local path and check out a branch.
 
 - `owner/repo` — repository to clone (required)
 - `target-path` — local filesystem path to clone into (required). Callers should use an
-  isolated path derived from both the repo and the branch (e.g. `/tmp/<repo>-<branch-slug>`,
-  where `<branch-slug>` is the branch name with `/` replaced by `-`) so that concurrent or
-  sequential runs on the same repo do not share state.
+  isolated path derived from both the repo and the branch (e.g. `<workspace-root>/.agents/<repo>-<branch-slug>`,
+  where `<workspace-root>` is the current project root and `<branch-slug>` is the branch name
+  with `/` replaced by `-`) so that concurrent or sequential runs on the same repo do not share
+  state. Placing the path under `.agents/` keeps it within the MCP server allowlist.
 - `branch` — branch to check out after cloning (optional; defaults to the repository's default branch)
 
 ## Output

--- a/definitions/skills/github-clone-repo.skill.md
+++ b/definitions/skills/github-clone-repo.skill.md
@@ -9,10 +9,10 @@ description: Clone a GitHub repository to a local path and check out a branch.
 
 - `owner/repo` — repository to clone (required)
 - `target-path` — local filesystem path to clone into (required). Callers should use an
-  isolated path derived from both the repo and the branch (e.g. `<workspace-root>/.agents/<repo>-<branch-slug>`,
+  isolated path derived from both the repo and the branch (e.g. `<workspace-root>/.tmp/<repo>-<branch-slug>`,
   where `<workspace-root>` is the current project root and `<branch-slug>` is the branch name
   with `/` replaced by `-`) so that concurrent or sequential runs on the same repo do not share
-  state. Placing the path under `.agents/` keeps it within the MCP server allowlist.
+  state. Placing the path under `.tmp/` keeps it within the MCP server allowlist.
 - `branch` — branch to check out after cloning (optional; defaults to the repository's default branch)
 
 ## Output


### PR DESCRIPTION
## Summary

- Changes the default \`github-coder\` work dir from \`/tmp/<repo>-<branch-slug>\` to \`<workspace-root>/.tmp/<repo>-<branch-slug>\`, keeping cloned repos inside the MCP server's allowed-paths allowlist
- MCP tools (\`mcp__mcp-git__*\`, \`mcp__mcp-filesystem__*\`) now work against cloned repos without falling back to bare Bash — the preferred tool path in the agent definition is actually exercised
- Adds \`.tmp/\` to \`.gitignore\` so clone workspaces are never accidentally staged or committed
- Updates \`github-clone-repo.skill.md\` \`target-path\` docs to reflect the new convention and explain why \`.tmp/\` is used

## Test plan

- [ ] Run \`/github-coder\` on any issue in this repo and confirm \`mcp__mcp-git__git_create_branch\` and \`mcp__mcp-filesystem__list_directory\` succeed without the "outside allowed repository" error
- [ ] Confirm the \`.tmp/\` directory is created under the workspace root and its contents do not appear in \`git status\`
- [ ] \`ruff format --check . && ruff check .\` reports no issues

Closes #145

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) (AI Coder identity)