### PR TITLE
docs: document MCP path restriction, .tmp/ convention, and git_create_branch gotcha

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,3 +37,15 @@ equivalent and must always run via shell commands (`run_command` in uio, `Bash`
 in Claude Code). Commit operations that require a custom author identity
 (`-c user.name=... -c user.email=...`) also require the shell; no git MCP tool
 supports custom author flags.
+
+## `git_create_branch` does not switch HEAD
+
+`mcp__mcp-git__git_create_branch` (and its environment-specific equivalents)
+creates the branch but leaves HEAD on the current branch. Always follow it with
+an explicit checkout via shell:
+
+```bash
+git -C <work-dir> checkout <branch-name>
+```
+
+Skipping this step causes subsequent commits to land on the wrong branch.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,34 @@ Code, create `.mcp.json` at the repo root:
 Until that file exists, `ToolSearch` will not find any GitHub MCP tools and the
 `gh` CLI fallback is the correct path.
 
+## MCP tool path restrictions
+
+The MCP git and filesystem servers in this environment enforce an allowed-paths
+allowlist restricted to the workspace root (e.g. `/home/john/src/uio`). Any
+operation on a path outside the workspace — including `/tmp` — will fail with
+"Access denied / outside allowed repository".
+
+Agent clone workspaces must therefore be placed under `<workspace-root>/.tmp/`
+rather than `/tmp/`. The `.tmp/` directory is git-ignored. Use this pattern for
+the work dir:
+
+```
+<workspace-root>/.tmp/<repo>-<branch-slug>
+```
+
+## GitHub MCP write operations (temporary limitation)
+
+`mcp__mcp-github__create_pull_request` and `mcp__mcp-github__issue_write`
+currently return 403 in this environment due to token scope. This is temporary.
+Until resolved, fall back to the `gh` CLI for PR creation and issue creation:
+
+```bash
+gh pr create --repo <owner>/<repo> ...
+gh issue create --repo <owner>/<repo> ...
+```
+
+Read operations (`issue_read`, `pull_request_read`, etc.) work correctly.
+
 ## Running agent definitions directly
 
 When a user asks to execute a workflow described in `definitions/agents/*.agent.md`,


### PR DESCRIPTION
## Summary

- **AGENTS.md**: documents that `mcp__mcp-git__git_create_branch` creates a branch but does not switch HEAD — an explicit `git checkout` must always follow it. Skipping this causes commits to land on the wrong branch (hit twice in this session).
- **CLAUDE.md**: documents the MCP allowed-paths restriction in this environment (workspace root only; `/tmp` is out of bounds) and the resulting `.tmp/` clone workspace convention. Also notes that GitHub MCP write operations (`create_pull_request`, `issue_write`) currently return 403 and require `gh` CLI fallback — flagged as temporary.

## Test plan

- [ ] Review both files for accuracy against observed behaviour in PRs #144–#148
- [ ] Confirm the 403 note is removed from `CLAUDE.md` once the token scope issue is resolved

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) (AI Coder identity)