### PR TITLE
fix: replace non-existent npm package with github-mcp-server binary download

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,11 +200,23 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Pre-bundle npm MCP packages
+      - name: Pre-bundle npm MCP packages and github-mcp-server binary
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npm install --prefix mcp-vendor \
             @modelcontextprotocol/server-filesystem \
             @modelcontextprotocol/server-sequential-thinking
+          mkdir -p mcp-vendor/bin
+          for arch_pair in "amd64:x86_64" "arm64:arm64"; do
+            DOCKER_ARCH="${arch_pair%%:*}"
+            GH_ARCH="${arch_pair##*:}"
+            URL=$(gh api repos/github/github-mcp-server/releases/latest \
+              --jq ".assets[].browser_download_url" \
+              | grep "Linux_${GH_ARCH}\.tar\.gz$")
+            curl -fsSL "$URL" | tar -xz -C mcp-vendor/bin github-mcp-server
+            mv mcp-vendor/bin/github-mcp-server "mcp-vendor/bin/github-mcp-server-${DOCKER_ARCH}"
+          done
 
       - name: Wait for uio-ai to appear on PyPI
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -227,6 +227,10 @@ __marimo__/
 # Agent clone workspaces (created by github-coder and similar agents)
 .tmp/
 
+# github-mcp-server binaries downloaded by the release workflow
+mcp-vendor/bin/*
+!mcp-vendor/bin/.gitkeep
+
 # npm packages pre-bundled for the Docker build by the release workflow.
 # Only the .gitkeep placeholder is committed; package contents are generated.
 mcp-vendor/node_modules/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,16 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     && apt-get install -y --no-install-recommends gh \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# @github/github-mcp-server wraps a platform-specific Go binary and must be
-# installed inside the container (npm postinstall fetches the arch-correct
-# binary). Placed before ARG UIO_VERSION so this layer is cached between releases.
-RUN npm install -g @github/github-mcp-server
+# github-mcp-server native Go binary — downloaded from GitHub Releases by the
+# release workflow for both amd64 (Linux_x86_64) and arm64. Falls back
+# gracefully for local builds where mcp-vendor/bin/ contains only .gitkeep.
+COPY mcp-vendor/bin/ /tmp/mcp-bin/
+RUN arch=$(uname -m | sed 's/aarch64/arm64/') && \
+    if [ -f "/tmp/mcp-bin/github-mcp-server-${arch}" ]; then \
+        cp "/tmp/mcp-bin/github-mcp-server-${arch}" /usr/local/bin/github-mcp-server && \
+        chmod +x /usr/local/bin/github-mcp-server; \
+    fi && \
+    rm -rf /tmp/mcp-bin
 
 # Pure-JS MCP packages are pre-bundled by the release workflow on the native
 # runner (see the "Pre-bundle npm MCP packages" step in release.yml) and


### PR DESCRIPTION
## Summary

- **Root cause**: \`@github/github-mcp-server\` does not exist on npmjs.com. The original pre-warm loop hid this with \`|| true\`; after #156 changed it to \`npm install -g\`, the build hard-fails with a 404.
- **Fix**: download the official Go binary from GitHub Releases in the pre-bundle workflow step — \`gh api\` resolves the latest release URL and fetches \`Linux_x86_64\` and \`Linux_arm64\` tarballs on the native runner.
- **Dockerfile**: \`COPY mcp-vendor/bin/\` + \`uname -m\` selects the arch-correct binary and installs it to \`/usr/local/bin/github-mcp-server\`. Falls back gracefully for local builds where only \`.gitkeep\` is present.

## Test plan

- [ ] Docker image build completes without 404 errors
- [ ] \`docker run --rm ghcr.io/jomkz/uio:latest which github-mcp-server\` returns \`/usr/local/bin/github-mcp-server\`
- [ ] \`docker run --rm ghcr.io/jomkz/uio:latest github-mcp-server --version\` prints the version

Closes #157

---
> 🤖 Generated with [uio AI Coder](https://github.com/jomkz/uio)