### PR TITLE
docs: add Agentic Stack glossary and adopt unified terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # uio
 
-`uio` is a lightweight, provider-agnostic framework for defining and running AI agents, skills, and prompts. Definitions live as markdown files with YAML frontmatter. The `uio` CLI discovers and executes them against any supported LLM provider. The [origin story](docs/16-about.md) covers how and why.
+`uio` is a lightweight, provider-agnostic framework for building the **Agentic Stack** — agents, skills, prompts, and tools — as plain markdown files with YAML frontmatter. The `uio` CLI discovers and executes them against any supported LLM provider. The [origin story](docs/16-about.md) covers how and why.
 
 ## Concepts
 
 | Concept | What it is |
 |---|---|
-| **Agent** | A multi-turn agentic loop that can execute shell commands and call MCP tools |
-| **Skill** | A reusable module invoked by agents to perform a focused, composable task |
-| **Prompt** | A single-shot LLM instruction for one well-defined workflow |
+| **Agent** | A multi-turn tool-use loop that can execute shell commands and call MCP tools; defined in `*.agent.md` |
+| **Skill** | A focused, composable subtask — same loop as an agent, but user-directed via `uio skill run`; defined in `*.skill.md` |
+| **Prompt** | A single-shot LLM instruction with no tool loop; defined in `*.prompt.md` |
+| **Tool** | An external capability the model invokes mid-loop (MCP tools, `run_command`) — agent-directed, not user-directed |
+
+See the [Glossary](docs/02-concepts.md#glossary) for precise definitions of all terms, including the skill vs tool distinction.
 
 ## Documentation
 

--- a/docs/02-concepts.md
+++ b/docs/02-concepts.md
@@ -54,6 +54,8 @@ Example: `ask-docs.prompt.md` answers a focused question about a codebase by app
 | `invokable` frontmatter | No | No | Optional |
 | Typical use | Multi-step workflow | Focused subtask | One-shot query |
 
+Tools (`run_command`, MCP tools) are not definition types — they are capabilities the model invokes at runtime. See the [Glossary](#glossary) for the Tool definition and the skill vs tool distinction.
+
 ---
 
 ## The `.uio/` directory
@@ -104,7 +106,7 @@ The definition file is the single source of truth for behaviour. Moving, editing
 | **Prompts** | `.prompt.md` — single-shot instructions |
 | **Tools** | MCP tools + `run_command` — agent-directed capabilities |
 
-This vocabulary is intentional. "Agentic Stack" is the umbrella term for the agents + skills + prompts + tools model that `uio` provides.
+This vocabulary is intentional. **"Agentic Stack"** is the umbrella term for the agents + skills + prompts + tools model that `uio` provides. See the [Glossary](#glossary) below for precise term definitions.
 
 ---
 
@@ -113,8 +115,8 @@ This vocabulary is intentional. "Agentic Stack" is the umbrella term for the age
 | Term | Definition |
 |---|---|
 | **Agent** | An autonomous decision-maker that runs a multi-turn tool-use loop. Defined in `*.agent.md`. Agents decide when to call tools and how to interpret results. |
-| **Skill** | A focused, composable subtask. Runs the same tool-use loop as an agent internally, but is **user-directed**: you invoke it explicitly with `uio skill run <name>`. Skills are small, reusable building blocks; agents are higher-level workflows that may reference skills by name. |
+| **Skill** | A focused, composable subtask. Runs the same tool-use loop as an agent internally, but is **user-directed**: you invoke it explicitly with `uio skill run <name>`. Skills may also be referenced by name inside agent definition bodies. Skills are small, reusable building blocks; agents are higher-level workflows. |
 | **Prompt** | A single-shot LLM instruction. The definition body is sent once and the response is printed — no tool-use loop. Defined in `*.prompt.md`. |
 | **Tool** | An external capability the **model** invokes mid-loop. Tools are agent-directed: the agent decides when and how to call them. Examples: `run_command` (built-in), MCP tools such as GitHub or filesystem access. This is the key distinction from skills — a tool is called by the model; a skill is called by you. |
-| **Memory** | Persistent context injected into agent runs across sessions. Not yet implemented; tracked in [#161](https://github.com/jomkz/uio/issues/161). |
-| **Guardrails** | Per-definition constraints on cost, tool access, and iteration count. Not yet implemented; tracked in [#160](https://github.com/jomkz/uio/issues/160). |
+| **Memory** | Persistent context injected into agent runs across sessions. Not yet implemented (planned). |
+| **Guardrails** | Per-definition constraints on cost, tool access, and iteration count. Not yet implemented (planned). |

--- a/docs/02-concepts.md
+++ b/docs/02-concepts.md
@@ -90,3 +90,31 @@ Every `uio agent run` / `uio skill run` / `uio prompt run` invocation:
 8. Appends a cost entry to `uio_cost.jsonl`
 
 The definition file is the single source of truth for behaviour. Moving, editing, or deleting it immediately affects the next run.
+
+---
+
+## The Agentic Stack
+
+`uio` implements the **Agentic Stack** pattern — a layered model for composable AI automation:
+
+| Layer | uio primitive |
+|---|---|
+| **Agents** | `.agent.md` — autonomous decision-makers |
+| **Skills** | `.skill.md` — composable, user-directed subtasks |
+| **Prompts** | `.prompt.md` — single-shot instructions |
+| **Tools** | MCP tools + `run_command` — agent-directed capabilities |
+
+This vocabulary is intentional. "Agentic Stack" is the umbrella term for the agents + skills + prompts + tools model that `uio` provides.
+
+---
+
+## Glossary
+
+| Term | Definition |
+|---|---|
+| **Agent** | An autonomous decision-maker that runs a multi-turn tool-use loop. Defined in `*.agent.md`. Agents decide when to call tools and how to interpret results. |
+| **Skill** | A focused, composable subtask. Runs the same tool-use loop as an agent internally, but is **user-directed**: you invoke it explicitly with `uio skill run <name>`. Skills are small, reusable building blocks; agents are higher-level workflows that may reference skills by name. |
+| **Prompt** | A single-shot LLM instruction. The definition body is sent once and the response is printed — no tool-use loop. Defined in `*.prompt.md`. |
+| **Tool** | An external capability the **model** invokes mid-loop. Tools are agent-directed: the agent decides when and how to call them. Examples: `run_command` (built-in), MCP tools such as GitHub or filesystem access. This is the key distinction from skills — a tool is called by the model; a skill is called by you. |
+| **Memory** | Persistent context injected into agent runs across sessions. Not yet implemented; tracked in [#161](https://github.com/jomkz/uio/issues/161). |
+| **Guardrails** | Per-definition constraints on cost, tool access, and iteration count. Not yet implemented; tracked in [#160](https://github.com/jomkz/uio/issues/160). |


### PR DESCRIPTION
## Summary

- Introduces **"Agentic Stack"** as the umbrella term for uio's agents + skills + prompts + tools model in the README intro and in a new `docs/02-concepts.md` section
- Adds a **Glossary** table to `docs/02-concepts.md` with canonical definitions for: agent, skill, prompt, tool, memory, and guardrails
- Expands the README Concepts table to include **Tool** and sharpens the Skill vs Tool distinction: tools are agent-directed (model calls them mid-loop); skills are user-directed (`uio skill run`)
- No code changes — docs only

## Test plan

- [ ] Read `docs/02-concepts.md` — verify the Agentic Stack section and Glossary table render correctly in GitHub markdown
- [ ] Read `README.md` — verify the intro uses "Agentic Stack" and the Concepts table includes Tool
- [ ] Confirm all acceptance criteria from #159 are met: glossary present, README updated, skill vs tool distinction documented

Closes #159

---
> 🤖 Generated by [uio AI Coder](https://github.com/jomkz/uio) · identity: `uio-coder[bot]`