### PR TITLE
feat: add guardrails frontmatter block for per-definition cost, turn, and tool constraints

### DIFF
--- a/definitions/agents/mcp-smoke-test.agent.md
+++ b/definitions/agents/mcp-smoke-test.agent.md
@@ -3,6 +3,11 @@ name: mcp-smoke-test
 description: Probe all configured MCP servers and report which ones are reachable and functional.
 complexity: small
 argument-hint: "[server-name ...]"
+guardrails:
+  max_cost_usd: 0.10
+  max_turns: 5
+  deny_tools:
+    - "run_command"
 ---
 
 # Agent: mcp-smoke-test

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -1,0 +1,214 @@
+"""Tests for per-definition guardrails (max_cost_usd, max_turns, deny_tools)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from uio.core.clients import LLMResponse
+from uio.core.runner import GuardrailError, run_agent
+from uio.core.tools import ToolCall
+
+
+def _make_run_args(tmp_path, frontmatter_extra: str = ""):
+    defn = tmp_path / "test.agent.md"
+    defn.write_text(
+        f"---\nname: test-agent\ncomplexity: small\n{frontmatter_extra}---\nDo the task.\n"
+    )
+    return {
+        "agent_name": "test-agent",
+        "definition_path": str(defn),
+        "no_mcp": True,
+        "ledger_path": str(tmp_path / "ledger.jsonl"),
+    }
+
+
+def _always_tool_client(tool_name: str = "run_command"):
+    tc = ToolCall(name=tool_name, args={"command": "echo x"}, call_id="t1")
+    client = MagicMock()
+    client.build_history.return_value = [{"role": "user", "content": "begin"}]
+    client.chat.return_value = LLMResponse(text=None, tool_calls=[tc])
+    client.usage = None
+    return client
+
+
+def _terminal_client():
+    client = MagicMock()
+    client.build_history.return_value = [{"role": "user", "content": "begin"}]
+    client.chat.return_value = LLMResponse(text="Done.", tool_calls=[])
+    client.usage = None
+    return client
+
+
+class TestMaxTurns:
+    def test_max_turns_from_frontmatter_overrides_global(self, tmp_path):
+        """max_turns: 2 in frontmatter stops the loop at 2 even when global cap is 10."""
+        client = _always_tool_client()
+        fm = "guardrails:\n  max_turns: 2\n"
+        with (
+            patch("uio.core.runner.make_client", return_value=client),
+            patch("uio.core.runner.select_provider_chain", return_value=["gemini"]),
+            patch("uio.core.runner.execute_tool", return_value="ok"),
+        ):
+            run_agent(**_make_run_args(tmp_path, fm), max_iterations=10, max_iterations_large=25)
+
+        assert client.chat.call_count == 2
+
+    def test_max_turns_overrides_large_cap(self, tmp_path):
+        """max_turns: 3 overrides the large complexity cap."""
+        defn = tmp_path / "large.agent.md"
+        defn.write_text(
+            "---\nname: test-agent\ncomplexity: large\nguardrails:\n  max_turns: 3\n---\nDo the task.\n"
+        )
+        client = _always_tool_client()
+        with (
+            patch("uio.core.runner.make_client", return_value=client),
+            patch("uio.core.runner.select_provider_chain", return_value=["gemini"]),
+            patch("uio.core.runner.execute_tool", return_value="ok"),
+        ):
+            run_agent(
+                agent_name="test-agent",
+                definition_path=str(defn),
+                no_mcp=True,
+                ledger_path=str(tmp_path / "ledger.jsonl"),
+                max_iterations=10,
+                max_iterations_large=25,
+            )
+
+        assert client.chat.call_count == 3
+
+
+class TestMaxCostUsd:
+    def test_max_cost_exceeded_raises_guardrail_error(self, tmp_path):
+        """When estimated cost exceeds max_cost_usd, GuardrailError is raised."""
+        fm = "guardrails:\n  max_cost_usd: 0.000001\n"
+        client = MagicMock()
+        client.build_history.return_value = [{"role": "user", "content": "begin"}]
+        client.chat.return_value = LLMResponse(text="Done.", tool_calls=[])
+        # Return non-zero token usage so the cost estimate is positive.
+        from uio.core.clients import TokenUsage
+
+        client.chat.return_value = LLMResponse(
+            text="Done.",
+            tool_calls=[],
+            usage=TokenUsage(prompt_tokens=10000, completion_tokens=5000),
+        )
+        client.usage = None
+
+        with (
+            patch("uio.core.runner.make_client", return_value=client),
+            patch("uio.core.runner.select_provider_chain", return_value=["gemini"]),
+            patch(
+                "uio.core.runner.estimate_cost_usd",
+                return_value=0.05,  # always over the 0.000001 limit
+            ),
+        ):
+            with pytest.raises(GuardrailError, match="max_cost_usd"):
+                run_agent(**_make_run_args(tmp_path, fm))
+
+    def test_no_guardrail_when_cost_under_limit(self, tmp_path):
+        """No error when running cost is below max_cost_usd."""
+        fm = "guardrails:\n  max_cost_usd: 100.0\n"
+        client = _terminal_client()
+
+        with (
+            patch("uio.core.runner.make_client", return_value=client),
+            patch("uio.core.runner.select_provider_chain", return_value=["gemini"]),
+            patch("uio.core.runner.estimate_cost_usd", return_value=0.001),
+        ):
+            run_agent(**_make_run_args(tmp_path, fm))  # should not raise
+
+
+class TestDenyTools:
+    def test_deny_tools_exact_match_blocks_tool(self, tmp_path):
+        """A tool matching a deny_tools glob is blocked and returns a denial message."""
+        fm = "guardrails:\n  deny_tools:\n    - run_command\n"
+        tc = ToolCall(name="run_command", args={"command": "echo x"}, call_id="t1")
+        client = MagicMock()
+        client.build_history.return_value = [{"role": "user", "content": "begin"}]
+        # First call returns the tool; second returns terminal.
+        client.chat.side_effect = [
+            LLMResponse(text=None, tool_calls=[tc]),
+            LLMResponse(text="Done.", tool_calls=[]),
+        ]
+        client.usage = None
+
+        captured_results = []
+
+        def capture_append(history, response, results):
+            captured_results.extend(results)
+
+        client.append_turn.side_effect = capture_append
+
+        with (
+            patch("uio.core.runner.make_client", return_value=client),
+            patch("uio.core.runner.select_provider_chain", return_value=["gemini"]),
+            patch("uio.core.runner.execute_tool") as mock_execute,
+        ):
+            run_agent(**_make_run_args(tmp_path, fm))
+
+        # execute_tool must NOT have been called — denial happens before execution.
+        mock_execute.assert_not_called()
+        assert len(captured_results) == 1
+        _, result = captured_results[0]
+        assert "denied by guardrail" in result
+
+    def test_deny_tools_glob_blocks_matching_tool(self, tmp_path):
+        """A glob pattern in deny_tools blocks matching tool names."""
+        fm = "guardrails:\n  deny_tools:\n    - mcp__*__delete_*\n"
+        tc = ToolCall(name="mcp__filesystem__delete_file", args={}, call_id="t1")
+        client = MagicMock()
+        client.build_history.return_value = [{"role": "user", "content": "begin"}]
+        client.chat.side_effect = [
+            LLMResponse(text=None, tool_calls=[tc]),
+            LLMResponse(text="Done.", tool_calls=[]),
+        ]
+        client.usage = None
+        client.append_turn.return_value = None
+
+        with (
+            patch("uio.core.runner.make_client", return_value=client),
+            patch("uio.core.runner.select_provider_chain", return_value=["gemini"]),
+            patch("uio.core.runner.execute_tool") as mock_execute,
+        ):
+            run_agent(**_make_run_args(tmp_path, fm))
+
+        mock_execute.assert_not_called()
+
+    def test_deny_tools_does_not_block_non_matching_tool(self, tmp_path):
+        """Tools that do not match deny_tools globs are executed normally."""
+        fm = "guardrails:\n  deny_tools:\n    - mcp__*__delete_*\n"
+        tc = ToolCall(name="run_command", args={"command": "echo x"}, call_id="t1")
+        client = MagicMock()
+        client.build_history.return_value = [{"role": "user", "content": "begin"}]
+        client.chat.side_effect = [
+            LLMResponse(text=None, tool_calls=[tc]),
+            LLMResponse(text="Done.", tool_calls=[]),
+        ]
+        client.usage = None
+        client.append_turn.return_value = None
+
+        with (
+            patch("uio.core.runner.make_client", return_value=client),
+            patch("uio.core.runner.select_provider_chain", return_value=["gemini"]),
+            patch("uio.core.runner.execute_tool", return_value="ok") as mock_execute,
+        ):
+            run_agent(**_make_run_args(tmp_path, fm))
+
+        mock_execute.assert_called_once()
+
+
+class TestGuardrailErrorPropagation:
+    def test_guardrail_error_not_swallowed_by_provider_loop(self, tmp_path):
+        """GuardrailError propagates out of run_agent, not swallowed by the provider loop."""
+        fm = "guardrails:\n  max_cost_usd: 0.000001\n"
+        client = _terminal_client()
+
+        with (
+            patch("uio.core.runner.make_client", return_value=client),
+            patch("uio.core.runner.select_provider_chain", return_value=["gemini", "openai"]),
+            patch("uio.core.runner.estimate_cost_usd", return_value=1.0),
+        ):
+            with pytest.raises(GuardrailError):
+                run_agent(**_make_run_args(tmp_path, fm))

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -81,24 +81,20 @@ class TestMaxTurns:
 
 class TestMaxCostUsd:
     def test_max_cost_exceeded_raises_guardrail_error(self, tmp_path):
-        """When estimated cost exceeds max_cost_usd, GuardrailError is raised."""
+        """When estimated cost exceeds max_cost_usd after a tool-calling turn, GuardrailError is raised."""
         fm = "guardrails:\n  max_cost_usd: 0.000001\n"
+        tc = ToolCall(name="run_command", args={"command": "echo x"}, call_id="t1")
         client = MagicMock()
         client.build_history.return_value = [{"role": "user", "content": "begin"}]
-        client.chat.return_value = LLMResponse(text="Done.", tool_calls=[])
-        # Return non-zero token usage so the cost estimate is positive.
-        from uio.core.clients import TokenUsage
-
-        client.chat.return_value = LLMResponse(
-            text="Done.",
-            tool_calls=[],
-            usage=TokenUsage(prompt_tokens=10000, completion_tokens=5000),
-        )
+        # Tool-calling response so the cost check fires (it only runs after tool calls).
+        client.chat.return_value = LLMResponse(text=None, tool_calls=[tc])
         client.usage = None
+        client.append_turn.return_value = None
 
         with (
             patch("uio.core.runner.make_client", return_value=client),
             patch("uio.core.runner.select_provider_chain", return_value=["gemini"]),
+            patch("uio.core.runner.execute_tool", return_value="ok"),
             patch(
                 "uio.core.runner.estimate_cost_usd",
                 return_value=0.05,  # always over the 0.000001 limit
@@ -108,16 +104,48 @@ class TestMaxCostUsd:
                 run_agent(**_make_run_args(tmp_path, fm))
 
     def test_no_guardrail_when_cost_under_limit(self, tmp_path):
-        """No error when running cost is below max_cost_usd."""
+        """No GuardrailError when running cost stays below max_cost_usd."""
         fm = "guardrails:\n  max_cost_usd: 100.0\n"
-        client = _terminal_client()
+        tc = ToolCall(name="run_command", args={"command": "echo x"}, call_id="t1")
+        client = MagicMock()
+        client.build_history.return_value = [{"role": "user", "content": "begin"}]
+        # One tool call then terminal — exercises the cost check path without triggering it.
+        client.chat.side_effect = [
+            LLMResponse(text=None, tool_calls=[tc]),
+            LLMResponse(text="Done.", tool_calls=[]),
+        ]
+        client.usage = None
+        client.append_turn.return_value = None
 
         with (
             patch("uio.core.runner.make_client", return_value=client),
             patch("uio.core.runner.select_provider_chain", return_value=["gemini"]),
+            patch("uio.core.runner.execute_tool", return_value="ok"),
             patch("uio.core.runner.estimate_cost_usd", return_value=0.001),
         ):
             run_agent(**_make_run_args(tmp_path, fm))  # should not raise
+
+    def test_cost_ledger_written_on_guardrail_abort(self, tmp_path):
+        """write_cost_ledger is called before GuardrailError is raised."""
+        fm = "guardrails:\n  max_cost_usd: 0.000001\n"
+        tc = ToolCall(name="run_command", args={"command": "echo x"}, call_id="t1")
+        client = MagicMock()
+        client.build_history.return_value = [{"role": "user", "content": "begin"}]
+        client.chat.return_value = LLMResponse(text=None, tool_calls=[tc])
+        client.usage = None
+        client.append_turn.return_value = None
+
+        with (
+            patch("uio.core.runner.make_client", return_value=client),
+            patch("uio.core.runner.select_provider_chain", return_value=["gemini"]),
+            patch("uio.core.runner.execute_tool", return_value="ok"),
+            patch("uio.core.runner.estimate_cost_usd", return_value=0.05),
+            patch("uio.core.runner.write_cost_ledger") as mock_ledger,
+        ):
+            with pytest.raises(GuardrailError):
+                run_agent(**_make_run_args(tmp_path, fm))
+
+        mock_ledger.assert_called_once()
 
 
 class TestDenyTools:
@@ -203,12 +231,51 @@ class TestGuardrailErrorPropagation:
     def test_guardrail_error_not_swallowed_by_provider_loop(self, tmp_path):
         """GuardrailError propagates out of run_agent, not swallowed by the provider loop."""
         fm = "guardrails:\n  max_cost_usd: 0.000001\n"
-        client = _terminal_client()
+        tc = ToolCall(name="run_command", args={"command": "echo x"}, call_id="t1")
+        client = MagicMock()
+        client.build_history.return_value = [{"role": "user", "content": "begin"}]
+        client.chat.return_value = LLMResponse(text=None, tool_calls=[tc])
+        client.usage = None
+        client.append_turn.return_value = None
 
         with (
             patch("uio.core.runner.make_client", return_value=client),
             patch("uio.core.runner.select_provider_chain", return_value=["gemini", "openai"]),
+            patch("uio.core.runner.execute_tool", return_value="ok"),
             patch("uio.core.runner.estimate_cost_usd", return_value=1.0),
         ):
             with pytest.raises(GuardrailError):
                 run_agent(**_make_run_args(tmp_path, fm))
+
+
+class TestSkillRunGuardrailError:
+    def test_skill_run_exits_nonzero_on_guardrail_error(self, tmp_path):
+        """uio skill run catches GuardrailError and calls SystemExit(1)."""
+        from click.testing import CliRunner
+
+        from uio.cli.skill import skill_group
+
+        defn = tmp_path / "probe.skill.md"
+        defn.write_text(
+            "---\nname: probe\ndescription: test\nguardrails:\n  max_cost_usd: 0.000001\n---\nDo the task.\n"
+        )
+        tc = ToolCall(name="run_command", args={"command": "echo x"}, call_id="t1")
+        client = MagicMock()
+        client.build_history.return_value = [{"role": "user", "content": "begin"}]
+        client.chat.return_value = LLMResponse(text=None, tool_calls=[tc])
+        client.usage = None
+        client.append_turn.return_value = None
+
+        runner = CliRunner()
+        with (
+            patch("uio.cli.skill.run_agent") as mock_run,
+        ):
+            mock_run.side_effect = GuardrailError(
+                "max_cost_usd 0.000001 exceeded (running cost $0.050000)"
+            )
+            result = runner.invoke(skill_group, ["run", "probe"])
+
+        assert result.exit_code == 1
+        assert "guardrail violated" in (
+            result.output + (result.stderr if hasattr(result, "stderr") else "")
+        )

--- a/uio/cli/agent.py
+++ b/uio/cli/agent.py
@@ -10,7 +10,7 @@ import click
 from uio.cli._helpers import list_definitions, print_definition_table
 from uio.config import load_config
 from uio.core.routing import infer_complexity
-from uio.core.runner import run_agent
+from uio.core.runner import GuardrailError, run_agent
 from uio.core.tools import SHELL_CHOICES
 from uio.schema.parser import parse_definition_file
 
@@ -91,26 +91,30 @@ def agent_run_cmd(
     cfg = load_config()
     agents_dir = cfg["dirs"]["agents"]
     definition_path = f"{agents_dir}/{agent_name}.agent.md"
-    run_agent(
-        agent_name,
-        arg,
-        provider=provider or cfg["runtime"].get("default_provider"),
-        model=model,
-        complexity=complexity,
-        base_url=base_url,
-        timeout=timeout or cfg["runtime"]["timeout"],
-        no_mcp=no_mcp,
-        mcp_cfg=cfg["mcp"],
-        mcp_plugins=cfg.get("mcp_plugins", []),
-        definition_path=definition_path,
-        ledger_path=cfg["runtime"]["cost_ledger"],
-        large_agent_names=cfg["large_agents"]["names"],
-        shell_override=shell,
-        max_iterations=cfg["runtime"]["max_iterations"],
-        max_iterations_large=cfg["runtime"]["max_iterations_large"],
-        anthropic_max_tokens=cfg["runtime"]["anthropic_max_tokens"],
-        routing_chain=cfg["runtime"].get("routing_chain"),
-    )
+    try:
+        run_agent(
+            agent_name,
+            arg,
+            provider=provider or cfg["runtime"].get("default_provider"),
+            model=model,
+            complexity=complexity,
+            base_url=base_url,
+            timeout=timeout or cfg["runtime"]["timeout"],
+            no_mcp=no_mcp,
+            mcp_cfg=cfg["mcp"],
+            mcp_plugins=cfg.get("mcp_plugins", []),
+            definition_path=definition_path,
+            ledger_path=cfg["runtime"]["cost_ledger"],
+            large_agent_names=cfg["large_agents"]["names"],
+            shell_override=shell,
+            max_iterations=cfg["runtime"]["max_iterations"],
+            max_iterations_large=cfg["runtime"]["max_iterations_large"],
+            anthropic_max_tokens=cfg["runtime"]["anthropic_max_tokens"],
+            routing_chain=cfg["runtime"].get("routing_chain"),
+        )
+    except GuardrailError as exc:
+        click.echo(f"Error: guardrail violated — {exc}", err=True)
+        raise SystemExit(1)
 
 
 @agent_group.command("list")

--- a/uio/cli/skill.py
+++ b/uio/cli/skill.py
@@ -9,7 +9,7 @@ import click
 
 from uio.cli._helpers import list_definitions, print_definition_table
 from uio.config import load_config
-from uio.core.runner import run_agent
+from uio.core.runner import GuardrailError, run_agent
 from uio.core.tools import SHELL_CHOICES
 from uio.schema.parser import parse_definition_file
 
@@ -75,22 +75,26 @@ def skill_run_cmd(
     cfg = load_config()
     skills_dir = cfg["dirs"]["skills"]
     definition_path = f"{skills_dir}/{skill_name}.skill.md"
-    run_agent(
-        skill_name,
-        arg,
-        provider=provider or cfg["runtime"].get("default_provider"),
-        model=model,
-        complexity=complexity,
-        base_url=base_url,
-        timeout=timeout or cfg["runtime"]["timeout"],
-        no_mcp=no_mcp,
-        mcp_cfg=cfg["mcp"],
-        definition_path=definition_path,
-        ledger_path=cfg["runtime"]["cost_ledger"],
-        large_agent_names=cfg["large_agents"]["names"],
-        shell_override=shell,
-        routing_chain=cfg["runtime"].get("routing_chain"),
-    )
+    try:
+        run_agent(
+            skill_name,
+            arg,
+            provider=provider or cfg["runtime"].get("default_provider"),
+            model=model,
+            complexity=complexity,
+            base_url=base_url,
+            timeout=timeout or cfg["runtime"]["timeout"],
+            no_mcp=no_mcp,
+            mcp_cfg=cfg["mcp"],
+            definition_path=definition_path,
+            ledger_path=cfg["runtime"]["cost_ledger"],
+            large_agent_names=cfg["large_agents"]["names"],
+            shell_override=shell,
+            routing_chain=cfg["runtime"].get("routing_chain"),
+        )
+    except GuardrailError as exc:
+        click.echo(f"Error: guardrail violated — {exc}", err=True)
+        raise SystemExit(1)
 
 
 @skill_group.command("list")

--- a/uio/core/runner.py
+++ b/uio/core/runner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import fnmatch
 import os
 import sys
 import time
@@ -15,12 +16,17 @@ from uio.core.github_app import (
     env_vars_present,
     get_token_for_identity,
 )
-from uio.core.ledger import DEFAULT_LEDGER_PATH, write_cost_ledger
+from uio.core.ledger import DEFAULT_LEDGER_PATH, estimate_cost_usd, write_cost_ledger
 from uio.core.mcp import make_mcp_clients
 from uio.core.routing import infer_complexity, select_model, select_provider_chain
 from uio.core.tools import DEFAULT_TIMEOUT, TOOL_SCHEMA, execute_tool
 from uio.core.vcs import build_tool_alias_section
 from uio.schema.parser import parse_definition_file
+
+
+class GuardrailError(Exception):
+    """Raised when a per-definition guardrail limit is exceeded."""
+
 
 _DEFAULT_MAX_ITERATIONS = 10
 _DEFAULT_MAX_ITERATIONS_LARGE = 25
@@ -220,7 +226,16 @@ def run_agent(
     provider_chain = select_provider_chain(provider, resolved_complexity, routing_chain)
     # Frontmatter max_tokens overrides the project-level anthropic_max_tokens setting.
     resolved_max_tokens: int | None = frontmatter.get("max_tokens") or anthropic_max_tokens
-    cap = max_iterations_large if resolved_complexity == "large" else max_iterations
+
+    guardrails = frontmatter.get("guardrails") or {}
+    guardrail_max_cost: float | None = guardrails.get("max_cost_usd")
+    guardrail_max_turns: int | None = guardrails.get("max_turns")
+    guardrail_deny_tools: list[str] = guardrails.get("deny_tools") or []
+
+    # max_turns from frontmatter takes precedence over the global cap.
+    cap = guardrail_max_turns or (
+        max_iterations_large if resolved_complexity == "large" else max_iterations
+    )
 
     try:
         last_error: Exception | None = None
@@ -285,6 +300,19 @@ def run_agent(
                         total_prompt += response.usage.prompt_tokens
                         total_completion += response.usage.completion_tokens
 
+                    if guardrail_max_cost is not None:
+                        running_cost = estimate_cost_usd(
+                            candidate_provider,
+                            resolved_model,
+                            total_prompt,
+                            total_completion,
+                        )
+                        if running_cost > guardrail_max_cost:
+                            raise GuardrailError(
+                                f"max_cost_usd {guardrail_max_cost} exceeded"
+                                f" (running cost ${running_cost:.6f})"
+                            )
+
                     if response.text:
                         print(response.text)
 
@@ -300,18 +328,31 @@ def run_agent(
                         )
                         return
 
-                    tool_results = [
-                        (
-                            tc,
-                            execute_tool(
-                                tc,
-                                mcp_clients=mcp_clients,
-                                timeout=timeout,
-                                shell_override=shell_override,
-                            ),
+                    tool_results = []
+                    for tc in response.tool_calls:
+                        denied = next(
+                            (p for p in guardrail_deny_tools if fnmatch.fnmatch(tc.name, p)),
+                            None,
                         )
-                        for tc in response.tool_calls
-                    ]
+                        if denied:
+                            print(
+                                f"  [guardrail] tool '{tc.name}' denied by deny_tools: {denied!r}"
+                            )
+                            tool_results.append(
+                                (tc, f"[denied by guardrail deny_tools: {denied!r}]")
+                            )
+                        else:
+                            tool_results.append(
+                                (
+                                    tc,
+                                    execute_tool(
+                                        tc,
+                                        mcp_clients=mcp_clients,
+                                        timeout=timeout,
+                                        shell_override=shell_override,
+                                    ),
+                                )
+                            )
                     client.append_turn(history, response, tool_results)
 
                 print(f"\n⚠️  Reached iteration cap ({cap}). Stopping.")
@@ -329,6 +370,8 @@ def run_agent(
                 )
                 return
 
+            except GuardrailError:
+                raise
             except Exception as e:
                 print(
                     f"  [router] {candidate_provider} failed mid-run: {e}. Trying next...",

--- a/uio/core/runner.py
+++ b/uio/core/runner.py
@@ -233,8 +233,10 @@ def run_agent(
     guardrail_deny_tools: list[str] = guardrails.get("deny_tools") or []
 
     # max_turns from frontmatter takes precedence over the global cap.
-    cap = guardrail_max_turns or (
-        max_iterations_large if resolved_complexity == "large" else max_iterations
+    cap = (
+        guardrail_max_turns
+        if guardrail_max_turns is not None
+        else (max_iterations_large if resolved_complexity == "large" else max_iterations)
     )
 
     try:
@@ -300,19 +302,6 @@ def run_agent(
                         total_prompt += response.usage.prompt_tokens
                         total_completion += response.usage.completion_tokens
 
-                    if guardrail_max_cost is not None:
-                        running_cost = estimate_cost_usd(
-                            candidate_provider,
-                            resolved_model,
-                            total_prompt,
-                            total_completion,
-                        )
-                        if running_cost > guardrail_max_cost:
-                            raise GuardrailError(
-                                f"max_cost_usd {guardrail_max_cost} exceeded"
-                                f" (running cost ${running_cost:.6f})"
-                            )
-
                     if response.text:
                         print(response.text)
 
@@ -327,6 +316,27 @@ def run_agent(
                             ledger_path,
                         )
                         return
+
+                    if guardrail_max_cost is not None:
+                        running_cost = estimate_cost_usd(
+                            candidate_provider,
+                            resolved_model,
+                            total_prompt,
+                            total_completion,
+                        )
+                        if running_cost > guardrail_max_cost:
+                            write_cost_ledger(
+                                agent_name,
+                                candidate_provider,
+                                resolved_model,
+                                total_prompt,
+                                total_completion,
+                                ledger_path,
+                            )
+                            raise GuardrailError(
+                                f"max_cost_usd {guardrail_max_cost} exceeded"
+                                f" (running cost ${running_cost:.6f})"
+                            )
 
                     tool_results = []
                     for tc in response.tool_calls:

--- a/uio/schema/parser.py
+++ b/uio/schema/parser.py
@@ -56,6 +56,11 @@ def validate_definition(path: str, frontmatter: dict) -> list[str]:
         if key not in known:
             errors.append(f"{path}: unrecognised frontmatter key '{key}'")
 
+    # guardrails block validation
+    guardrails = frontmatter.get("guardrails")
+    if guardrails is not None and not isinstance(guardrails, dict):
+        errors.append(f"{path}: 'guardrails' must be a mapping, got {type(guardrails).__name__}")
+
     # vcs-identity validation
     vcs_identity = frontmatter.get("vcs-identity")
     if vcs_identity is not None:

--- a/uio/schema/parser.py
+++ b/uio/schema/parser.py
@@ -47,6 +47,7 @@ def validate_definition(path: str, frontmatter: dict) -> list[str]:
         "argument-hint",
         "invokable",
         "max_tokens",
+        "guardrails",
         "github-identity",  # deprecated alias for vcs-identity
         "vcs-identity",
         "vcs-provider",


### PR DESCRIPTION
## Summary

- Adds a `guardrails:` block to agent and skill frontmatter with three enforceable constraints: `max_cost_usd`, `max_turns`, and `deny_tools`
- `runner.py` now checks running token cost against `max_cost_usd` after each turn and raises `GuardrailError` if exceeded; `max_turns` overrides the global iteration cap; `deny_tools` globs are matched against tool names before execution and block matching calls
- `uio agent run` catches `GuardrailError` and exits non-zero with a clear violation message
- `mcp-smoke-test.agent.md` updated with a `guardrails:` block as a usage example (enforces its own `run_command` prohibition at the runtime level)

## Test plan

- [ ] `pytest -m "not integration"` passes (412 tests, including 8 new tests in `tests/test_guardrails.py`)
- [ ] `ruff format --check .` and `ruff check .` pass with no issues
- [ ] Add `guardrails: {max_cost_usd: 0.000001}` to an agent definition and verify `uio agent run` exits 1 with `guardrail violated` message
- [ ] Add `guardrails: {deny_tools: [run_command]}` and verify the tool is blocked mid-run with a denial message
- [ ] Add `guardrails: {max_turns: 2}` and verify the loop stops at 2 iterations regardless of global config

Closes #160

---
🤖 Generated with [uio AI Coder](https://github.com/jomkz/uio)