### PR TITLE
feat: add *.memory.md definition type for persistent context injection

### DIFF
--- a/.uio/memory/project-context.memory.md
+++ b/.uio/memory/project-context.memory.md
@@ -1,0 +1,13 @@
+---
+name: project-context
+description: High-level context about this project injected into every agent run.
+scope: project
+---
+
+This repository is **uio** — a provider-agnostic AI agent/skill/prompt runner.
+
+Key facts agents should know:
+- Definition files live under `.uio/agents/`, `.uio/skills/`, `.uio/prompts/`, and `.uio/memory/`.
+- The primary CLI entry point is `uio`. Run `uio --help` to see all subcommands.
+- CI runs `ruff format --check .` and `ruff check .` for linting, and `pytest -m "not integration"` for tests.
+- GitHub operations use the `gh` CLI or MCP GitHub tools; prefer MCP when available.

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,235 @@
+"""Tests for the *.memory.md definition type and uio memory CLI."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from uio.cli.main import main
+from uio.core.memory import (
+    build_memory_section,
+    clear_session_memory,
+    estimate_tokens,
+    load_memory_files,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_memory(directory: Path, filename: str, name: str, scope: str, body: str) -> Path:
+    path = directory / filename
+    content = f"---\nname: {name}\ndescription: test\nscope: {scope}\n---\n{body}\n"
+    path.write_text(content)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# load_memory_files
+# ---------------------------------------------------------------------------
+
+
+def test_load_memory_files_empty_dir(tmp_path):
+    entries = load_memory_files(str(tmp_path))
+    assert entries == []
+
+
+def test_load_memory_files_nonexistent_dir(tmp_path):
+    entries = load_memory_files(str(tmp_path / "nonexistent"))
+    assert entries == []
+
+
+def test_load_memory_files_reads_frontmatter_and_body(tmp_path):
+    _write_memory(tmp_path, "ctx.memory.md", "ctx", "project", "Some context.")
+    entries = load_memory_files(str(tmp_path))
+    assert len(entries) == 1
+    path, fm, body = entries[0]
+    assert fm["name"] == "ctx"
+    assert fm["scope"] == "project"
+    assert body == "Some context."
+
+
+def test_load_memory_files_ignores_non_memory_files(tmp_path):
+    (tmp_path / "agent.agent.md").write_text("---\nname: A\ndescription: D.\n---\nBody.")
+    entries = load_memory_files(str(tmp_path))
+    assert entries == []
+
+
+def test_load_memory_files_sorted_alphabetically(tmp_path):
+    _write_memory(tmp_path, "z.memory.md", "z", "project", "Z body.")
+    _write_memory(tmp_path, "a.memory.md", "a", "project", "A body.")
+    entries = load_memory_files(str(tmp_path))
+    names = [fm["name"] for _, fm, _ in entries]
+    assert names == ["a", "z"]
+
+
+# ---------------------------------------------------------------------------
+# build_memory_section
+# ---------------------------------------------------------------------------
+
+
+def test_build_memory_section_empty_dir(tmp_path):
+    assert build_memory_section(str(tmp_path)) == ""
+
+
+def test_build_memory_section_single_entry(tmp_path):
+    _write_memory(tmp_path, "ctx.memory.md", "ctx", "project", "Key fact.")
+    section = build_memory_section(str(tmp_path))
+    assert "## Persistent Memory" in section
+    assert "### ctx" in section
+    assert "Key fact." in section
+
+
+def test_build_memory_section_skips_empty_bodies(tmp_path):
+    _write_memory(tmp_path, "empty.memory.md", "empty", "project", "")
+    assert build_memory_section(str(tmp_path)) == ""
+
+
+def test_build_memory_section_multiple_entries_separated(tmp_path):
+    _write_memory(tmp_path, "a.memory.md", "a", "project", "Body A.")
+    _write_memory(tmp_path, "b.memory.md", "b", "session", "Body B.")
+    section = build_memory_section(str(tmp_path))
+    assert "### a" in section
+    assert "### b" in section
+    assert "---" in section
+
+
+# ---------------------------------------------------------------------------
+# clear_session_memory
+# ---------------------------------------------------------------------------
+
+
+def test_clear_session_memory_clears_session_scope(tmp_path):
+    _write_memory(tmp_path, "sess.memory.md", "sess", "session", "Temporary data.")
+    clear_session_memory(str(tmp_path))
+    entries = load_memory_files(str(tmp_path))
+    assert len(entries) == 1
+    _, _, body = entries[0]
+    assert body == ""
+
+
+def test_clear_session_memory_preserves_project_scope(tmp_path):
+    _write_memory(tmp_path, "proj.memory.md", "proj", "project", "Permanent data.")
+    clear_session_memory(str(tmp_path))
+    entries = load_memory_files(str(tmp_path))
+    _, _, body = entries[0]
+    assert body == "Permanent data."
+
+
+def test_clear_session_memory_mixed_scopes(tmp_path):
+    _write_memory(tmp_path, "a.memory.md", "a", "project", "Keep me.")
+    _write_memory(tmp_path, "b.memory.md", "b", "session", "Erase me.")
+    clear_session_memory(str(tmp_path))
+    entries = {fm["name"]: body for _, fm, body in load_memory_files(str(tmp_path))}
+    assert entries["a"] == "Keep me."
+    assert entries["b"] == ""
+
+
+# ---------------------------------------------------------------------------
+# estimate_tokens
+# ---------------------------------------------------------------------------
+
+
+def test_estimate_tokens_basic():
+    assert estimate_tokens("a" * 400) == 100
+
+
+def test_estimate_tokens_minimum():
+    assert estimate_tokens("") >= 1
+
+
+# ---------------------------------------------------------------------------
+# CLI: uio memory list
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def memory_dir(tmp_path, monkeypatch):
+    mem = tmp_path / "memory"
+    mem.mkdir()
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "uio.toml").write_text(
+        textwrap.dedent(f"""\
+        [dirs]
+        memory = "{mem}"
+        agents = "{tmp_path / "agents"}"
+        skills = "{tmp_path / "skills"}"
+        prompts = "{tmp_path / "prompts"}"
+        """)
+    )
+    return mem
+
+
+def test_memory_list_empty(memory_dir):
+    runner = CliRunner()
+    result = runner.invoke(main, ["memory", "list"])
+    assert result.exit_code == 0
+    assert "No memory files found" in result.output
+
+
+def test_memory_list_shows_entries(memory_dir):
+    _write_memory(memory_dir, "ctx.memory.md", "ctx", "project", "Some data here.")
+    runner = CliRunner()
+    result = runner.invoke(main, ["memory", "list"])
+    assert result.exit_code == 0
+    assert "ctx" in result.output
+    assert "project" in result.output
+
+
+# ---------------------------------------------------------------------------
+# CLI: uio memory view
+# ---------------------------------------------------------------------------
+
+
+def test_memory_view_existing(memory_dir):
+    _write_memory(memory_dir, "ctx.memory.md", "ctx", "project", "Detailed context.")
+    runner = CliRunner()
+    result = runner.invoke(main, ["memory", "view", "ctx"])
+    assert result.exit_code == 0
+    assert "Detailed context." in result.output
+
+
+def test_memory_view_missing(memory_dir):
+    runner = CliRunner()
+    result = runner.invoke(main, ["memory", "view", "nonexistent"])
+    assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# CLI: uio memory clear
+# ---------------------------------------------------------------------------
+
+
+def test_memory_clear_all(memory_dir):
+    _write_memory(memory_dir, "a.memory.md", "a", "project", "Data A.")
+    _write_memory(memory_dir, "b.memory.md", "b", "session", "Data B.")
+    runner = CliRunner()
+    result = runner.invoke(main, ["memory", "clear"])
+    assert result.exit_code == 0
+    entries = {fm["name"]: body for _, fm, body in load_memory_files(str(memory_dir))}
+    assert entries["a"] == ""
+    assert entries["b"] == ""
+
+
+def test_memory_clear_session_only(memory_dir):
+    _write_memory(memory_dir, "a.memory.md", "a", "project", "Keep me.")
+    _write_memory(memory_dir, "b.memory.md", "b", "session", "Erase me.")
+    runner = CliRunner()
+    result = runner.invoke(main, ["memory", "clear", "--session"])
+    assert result.exit_code == 0
+    entries = {fm["name"]: body for _, fm, body in load_memory_files(str(memory_dir))}
+    assert entries["a"] == "Keep me."
+    assert entries["b"] == ""
+
+
+def test_memory_clear_nothing_to_clear(memory_dir):
+    _write_memory(memory_dir, "empty.memory.md", "empty", "project", "")
+    runner = CliRunner()
+    result = runner.invoke(main, ["memory", "clear"])
+    assert result.exit_code == 0
+    assert "Nothing to clear" in result.output

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -11,9 +11,11 @@ from click.testing import CliRunner
 from uio.cli.main import main
 from uio.core.memory import (
     build_memory_section,
+    clear_all_memory,
     clear_session_memory,
     estimate_tokens,
     load_memory_files,
+    write_memory_body,
 )
 
 
@@ -131,6 +133,68 @@ def test_clear_session_memory_mixed_scopes(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# write_memory_body (YAML safety)
+# ---------------------------------------------------------------------------
+
+
+def test_write_memory_body_roundtrips_special_chars(tmp_path):
+    """Frontmatter with colon-containing description must roundtrip safely."""
+    path = str(tmp_path / "tricky.memory.md")
+    fm = {"name": "tricky", "description": "Tracks goals: Q3", "scope": "project"}
+    write_memory_body(path, fm, "Body text.")
+    fm2, body2 = load_memory_files(str(tmp_path))[0][1:3]
+    assert fm2["description"] == "Tracks goals: Q3"
+    assert body2 == "Body text."
+
+
+def test_write_memory_body_clears_body(tmp_path):
+    path = str(tmp_path / "s.memory.md")
+    fm = {"name": "s", "description": "d", "scope": "session"}
+    write_memory_body(path, fm, "Initial body.")
+    write_memory_body(path, fm, "")
+    _, _, body = load_memory_files(str(tmp_path))[0]
+    assert body == ""
+
+
+# ---------------------------------------------------------------------------
+# clear_all_memory
+# ---------------------------------------------------------------------------
+
+
+def test_clear_all_memory_clears_all_scopes(tmp_path):
+    _write_memory(tmp_path, "a.memory.md", "a", "project", "Data A.")
+    _write_memory(tmp_path, "b.memory.md", "b", "session", "Data B.")
+    cleared = clear_all_memory(str(tmp_path))
+    assert len(cleared) == 2
+    entries = {fm["name"]: body for _, fm, body in load_memory_files(str(tmp_path))}
+    assert entries["a"] == ""
+    assert entries["b"] == ""
+
+
+def test_clear_all_memory_skips_already_empty(tmp_path):
+    _write_memory(tmp_path, "empty.memory.md", "empty", "project", "")
+    cleared = clear_all_memory(str(tmp_path))
+    assert cleared == []
+
+
+# ---------------------------------------------------------------------------
+# clear_session_memory (return value)
+# ---------------------------------------------------------------------------
+
+
+def test_clear_session_memory_returns_cleared(tmp_path):
+    _write_memory(tmp_path, "s.memory.md", "s", "session", "Data.")
+    cleared = clear_session_memory(str(tmp_path))
+    assert cleared == [("s", "session")]
+
+
+def test_clear_session_memory_returns_empty_when_nothing_to_clear(tmp_path):
+    _write_memory(tmp_path, "p.memory.md", "p", "project", "Data.")
+    cleared = clear_session_memory(str(tmp_path))
+    assert cleared == []
+
+
+# ---------------------------------------------------------------------------
 # estimate_tokens
 # ---------------------------------------------------------------------------
 
@@ -139,8 +203,8 @@ def test_estimate_tokens_basic():
     assert estimate_tokens("a" * 400) == 100
 
 
-def test_estimate_tokens_minimum():
-    assert estimate_tokens("") >= 1
+def test_estimate_tokens_empty():
+    assert estimate_tokens("") == 0
 
 
 # ---------------------------------------------------------------------------

--- a/uio/cli/agent.py
+++ b/uio/cli/agent.py
@@ -111,6 +111,7 @@ def agent_run_cmd(
             max_iterations_large=cfg["runtime"]["max_iterations_large"],
             anthropic_max_tokens=cfg["runtime"]["anthropic_max_tokens"],
             routing_chain=cfg["runtime"].get("routing_chain"),
+            memory_dir=cfg["dirs"]["memory"],
         )
     except GuardrailError as exc:
         click.echo(f"Error: guardrail violated — {exc}", err=True)

--- a/uio/cli/main.py
+++ b/uio/cli/main.py
@@ -15,6 +15,7 @@ from uio.cli.config import config_group
 from uio.cli.cost import cost_cmd
 from uio.cli.link import link_cmd
 from uio.cli.mcp import mcp_group
+from uio.cli.memory import memory_group
 from uio.cli.prompt import prompt_group
 from uio.cli.registry import registry_group
 from uio.cli.skill import skill_group
@@ -82,6 +83,7 @@ main.add_command(chat_cmd, "chat")
 main.add_command(cost_cmd, "cost")
 main.add_command(config_group, "config")
 main.add_command(link_cmd, "link")
+main.add_command(memory_group, "memory")
 main.add_command(registry_group, "registry")
 main.add_command(mcp_group, "mcp")
 

--- a/uio/cli/main.py
+++ b/uio/cli/main.py
@@ -112,8 +112,9 @@ def init_cmd(examples: bool) -> None:
     agents_dir = Path(cfg["dirs"]["agents"])
     skills_dir = Path(cfg["dirs"]["skills"])
     prompts_dir = Path(cfg["dirs"]["prompts"])
+    memory_dir = Path(cfg["dirs"]["memory"])
 
-    for d in (agents_dir, skills_dir, prompts_dir):
+    for d in (agents_dir, skills_dir, prompts_dir, memory_dir):
         d.mkdir(parents=True, exist_ok=True)
         click.echo(f"  Created directory: {d}/")
 

--- a/uio/cli/memory.py
+++ b/uio/cli/memory.py
@@ -1,0 +1,107 @@
+"""uio memory subcommands: list, view, clear."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import click
+
+from uio.config import load_config
+from uio.core.memory import estimate_tokens, load_memory_files
+
+
+@click.group("memory", no_args_is_help=True)
+def memory_group() -> None:
+    """Manage persistent memory files.
+
+    Memory files live in .uio/memory/*.memory.md and are injected into
+    the system prompt at agent/skill startup.
+    """
+
+
+@memory_group.command("list")
+def memory_list_cmd() -> None:
+    """List all memory files with name, scope, and body size in tokens."""
+    cfg = load_config()
+    memory_dir = cfg["dirs"]["memory"]
+    entries = load_memory_files(memory_dir)
+    if not entries:
+        click.echo(f"  No memory files found (expected {memory_dir}/*.memory.md).")
+        return
+    rows = []
+    for path, fm, body in entries:
+        name = fm.get("name", Path(path).stem)
+        scope = fm.get("scope", "project")
+        tokens = estimate_tokens(body) if body else 0
+        rows.append([name, scope, str(tokens)])
+    headers = ["NAME", "SCOPE", "TOKENS"]
+    widths = [max(len(h), max(len(r[i]) for r in rows)) for i, h in enumerate(headers)]
+    click.echo("  ".join(h.ljust(w) for h, w in zip(headers, widths)))
+    click.echo("  ".join("-" * w for w in widths))
+    for row in rows:
+        click.echo("  ".join(cell.ljust(w) for cell, w in zip(row, widths)))
+
+
+@memory_group.command("view")
+@click.argument("name", metavar="NAME")
+def memory_view_cmd(name: str) -> None:
+    """Print the body of the named memory file.
+
+    NAME is the value of the 'name' frontmatter field.
+    """
+    cfg = load_config()
+    memory_dir = cfg["dirs"]["memory"]
+    entries = load_memory_files(memory_dir)
+    for path, fm, body in entries:
+        if fm.get("name") == name or Path(path).stem == name:
+            if not body:
+                click.echo(f"  (memory '{name}' is empty)")
+                return
+            click.echo(body)
+            return
+    click.echo(f"  Memory '{name}' not found in {memory_dir}.", err=True)
+    sys.exit(1)
+
+
+@memory_group.command("clear")
+@click.option(
+    "--session",
+    is_flag=True,
+    default=False,
+    help="Clear only session-scoped memory files (default: clear all).",
+)
+def memory_clear_cmd(session: bool) -> None:
+    """Truncate memory file bodies.
+
+    Without --session, clears ALL memory files (project and session).
+    With --session, clears only session-scoped memory files.
+
+    \b
+    Examples:
+      uio memory clear
+      uio memory clear --session
+    """
+    cfg = load_config()
+    memory_dir = cfg["dirs"]["memory"]
+    entries = load_memory_files(memory_dir)
+    if not entries:
+        click.echo(f"  No memory files found in {memory_dir}.")
+        return
+
+    from uio.core.memory import _write_memory_body
+
+    cleared = 0
+    for path, fm, body in entries:
+        scope = fm.get("scope", "project")
+        if session and scope != "session":
+            continue
+        if body:
+            _write_memory_body(path, fm, "")
+            name = fm.get("name", Path(path).stem)
+            click.echo(f"  Cleared: {name} ({scope})")
+            cleared += 1
+    if cleared == 0:
+        click.echo("  Nothing to clear.")
+    else:
+        click.echo(f"\n  {cleared} memory file(s) cleared.")

--- a/uio/cli/memory.py
+++ b/uio/cli/memory.py
@@ -8,7 +8,12 @@ from pathlib import Path
 import click
 
 from uio.config import load_config
-from uio.core.memory import estimate_tokens, load_memory_files
+from uio.core.memory import (
+    clear_all_memory,
+    clear_session_memory,
+    estimate_tokens,
+    load_memory_files,
+)
 
 
 @click.group("memory", no_args_is_help=True)
@@ -84,24 +89,10 @@ def memory_clear_cmd(session: bool) -> None:
     """
     cfg = load_config()
     memory_dir = cfg["dirs"]["memory"]
-    entries = load_memory_files(memory_dir)
-    if not entries:
-        click.echo(f"  No memory files found in {memory_dir}.")
-        return
-
-    from uio.core.memory import _write_memory_body
-
-    cleared = 0
-    for path, fm, body in entries:
-        scope = fm.get("scope", "project")
-        if session and scope != "session":
-            continue
-        if body:
-            _write_memory_body(path, fm, "")
-            name = fm.get("name", Path(path).stem)
-            click.echo(f"  Cleared: {name} ({scope})")
-            cleared += 1
-    if cleared == 0:
+    cleared = clear_session_memory(memory_dir) if session else clear_all_memory(memory_dir)
+    if not cleared:
         click.echo("  Nothing to clear.")
     else:
-        click.echo(f"\n  {cleared} memory file(s) cleared.")
+        for name, scope in cleared:
+            click.echo(f"  Cleared: {name} ({scope})")
+        click.echo(f"\n  {len(cleared)} memory file(s) cleared.")

--- a/uio/cli/prompt.py
+++ b/uio/cli/prompt.py
@@ -82,6 +82,7 @@ def prompt_run_cmd(
         large_agent_names=cfg["large_agents"]["names"],
         shell_override=shell,
         routing_chain=cfg["runtime"].get("routing_chain"),
+        memory_dir=cfg["dirs"]["memory"],
     )
 
 

--- a/uio/cli/skill.py
+++ b/uio/cli/skill.py
@@ -91,6 +91,7 @@ def skill_run_cmd(
             large_agent_names=cfg["large_agents"]["names"],
             shell_override=shell,
             routing_chain=cfg["runtime"].get("routing_chain"),
+            memory_dir=cfg["dirs"]["memory"],
         )
     except GuardrailError as exc:
         click.echo(f"Error: guardrail violated — {exc}", err=True)

--- a/uio/config.py
+++ b/uio/config.py
@@ -17,6 +17,7 @@ _DEFAULTS: dict = {
         "agents": ".uio/agents",
         "skills": ".uio/skills",
         "prompts": ".uio/prompts",
+        "memory": ".uio/memory",
     },
     "runtime": {
         "default_provider": None,
@@ -39,6 +40,7 @@ _STARTER_TOML = """\
 agents  = ".uio/agents"
 skills  = ".uio/skills"
 prompts = ".uio/prompts"
+memory  = ".uio/memory"
 
 [runtime]
 # default_provider = "gemini"

--- a/uio/core/memory.py
+++ b/uio/core/memory.py
@@ -1,0 +1,79 @@
+"""Memory file loading, injection, and session cleanup for *.memory.md files."""
+
+from __future__ import annotations
+
+import re
+from glob import glob
+from pathlib import Path
+
+import yaml
+
+_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n(.*)", re.DOTALL)
+
+VALID_SCOPES = ("project", "session")
+
+
+def _parse_memory_file(path: str) -> tuple[dict, str]:
+    """Return (frontmatter_dict, body_text) for a memory file."""
+    with open(path) as f:
+        raw = f.read()
+    m = _FRONTMATTER_RE.match(raw)
+    if not m:
+        return {}, raw.strip()
+    return yaml.safe_load(m.group(1)) or {}, m.group(2).strip()
+
+
+def _write_memory_body(path: str, frontmatter: dict, body: str) -> None:
+    """Rewrite a memory file with the given body (preserves frontmatter)."""
+    lines = ["---"]
+    for key, value in frontmatter.items():
+        if isinstance(value, str):
+            lines.append(f"{key}: {value!r}" if "\n" in value else f"{key}: {value}")
+        else:
+            lines.append(f"{key}: {value}")
+    lines.append("---")
+    if body:
+        lines.append(body)
+    Path(path).write_text("\n".join(lines) + "\n")
+
+
+def load_memory_files(memory_dir: str) -> list[tuple[str, dict, str]]:
+    """Return (path, frontmatter, body) for all *.memory.md files in memory_dir."""
+    pattern = f"{memory_dir}/*.memory.md"
+    results = []
+    for path in sorted(glob(pattern)):
+        try:
+            fm, body = _parse_memory_file(path)
+        except Exception:
+            continue
+        results.append((path, fm, body))
+    return results
+
+
+def build_memory_section(memory_dir: str) -> str:
+    """Return a ``## Persistent Memory`` block for injection into the system prompt.
+
+    Returns an empty string when no memory files exist or all are empty.
+    """
+    entries = load_memory_files(memory_dir)
+    parts = []
+    for _path, fm, body in entries:
+        if not body:
+            continue
+        name = fm.get("name", Path(_path).stem)
+        parts.append(f"### {name}\n\n{body}")
+    if not parts:
+        return ""
+    return "## Persistent Memory\n\n" + "\n\n---\n\n".join(parts) + "\n\n"
+
+
+def clear_session_memory(memory_dir: str) -> None:
+    """Truncate the body of all session-scoped memory files to empty."""
+    for path, fm, _body in load_memory_files(memory_dir):
+        if fm.get("scope") == "session":
+            _write_memory_body(path, fm, "")
+
+
+def estimate_tokens(text: str) -> int:
+    """Rough token estimate: 4 characters per token."""
+    return max(1, len(text) // 4)

--- a/uio/core/memory.py
+++ b/uio/core/memory.py
@@ -10,8 +10,6 @@ import yaml
 
 _FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n(.*)", re.DOTALL)
 
-VALID_SCOPES = ("project", "session")
-
 
 def _parse_memory_file(path: str) -> tuple[dict, str]:
     """Return (frontmatter_dict, body_text) for a memory file."""
@@ -23,18 +21,13 @@ def _parse_memory_file(path: str) -> tuple[dict, str]:
     return yaml.safe_load(m.group(1)) or {}, m.group(2).strip()
 
 
-def _write_memory_body(path: str, frontmatter: dict, body: str) -> None:
+def write_memory_body(path: str, frontmatter: dict, body: str) -> None:
     """Rewrite a memory file with the given body (preserves frontmatter)."""
-    lines = ["---"]
-    for key, value in frontmatter.items():
-        if isinstance(value, str):
-            lines.append(f"{key}: {value!r}" if "\n" in value else f"{key}: {value}")
-        else:
-            lines.append(f"{key}: {value}")
-    lines.append("---")
+    fm_text = yaml.dump(frontmatter, default_flow_style=False, allow_unicode=True).rstrip()
+    content = f"---\n{fm_text}\n---\n"
     if body:
-        lines.append(body)
-    Path(path).write_text("\n".join(lines) + "\n")
+        content += body + "\n"
+    Path(path).write_text(content)
 
 
 def load_memory_files(memory_dir: str) -> list[tuple[str, dict, str]]:
@@ -67,13 +60,29 @@ def build_memory_section(memory_dir: str) -> str:
     return "## Persistent Memory\n\n" + "\n\n---\n\n".join(parts) + "\n\n"
 
 
-def clear_session_memory(memory_dir: str) -> None:
-    """Truncate the body of all session-scoped memory files to empty."""
+def clear_session_memory(memory_dir: str) -> list[tuple[str, str]]:
+    """Truncate the body of all session-scoped memory files to empty.
+
+    Returns list of (name, scope) for entries that were cleared.
+    """
+    cleared = []
     for path, fm, _body in load_memory_files(memory_dir):
         if fm.get("scope") == "session":
-            _write_memory_body(path, fm, "")
+            write_memory_body(path, fm, "")
+            cleared.append((fm.get("name", Path(path).stem), "session"))
+    return cleared
+
+
+def clear_all_memory(memory_dir: str) -> list[tuple[str, str]]:
+    """Truncate the body of all memory files. Returns list of (name, scope) cleared."""
+    cleared = []
+    for path, fm, body in load_memory_files(memory_dir):
+        if body:
+            write_memory_body(path, fm, "")
+            cleared.append((fm.get("name", Path(path).stem), fm.get("scope", "project")))
+    return cleared
 
 
 def estimate_tokens(text: str) -> int:
     """Rough token estimate: 4 characters per token."""
-    return max(1, len(text) // 4)
+    return len(text) // 4

--- a/uio/core/runner.py
+++ b/uio/core/runner.py
@@ -18,6 +18,7 @@ from uio.core.github_app import (
 )
 from uio.core.ledger import DEFAULT_LEDGER_PATH, estimate_cost_usd, write_cost_ledger
 from uio.core.mcp import make_mcp_clients
+from uio.core.memory import build_memory_section, clear_session_memory
 from uio.core.routing import infer_complexity, select_model, select_provider_chain
 from uio.core.tools import DEFAULT_TIMEOUT, TOOL_SCHEMA, execute_tool
 from uio.core.vcs import build_tool_alias_section
@@ -171,6 +172,7 @@ def run_agent(
     max_iterations_large: int = _DEFAULT_MAX_ITERATIONS_LARGE,
     anthropic_max_tokens: int | None = None,
     routing_chain: list[str] | None = None,
+    memory_dir: str | None = None,
 ) -> None:
     if definition_path is None:
         raise ValueError("definition_path must be provided")
@@ -214,8 +216,12 @@ def run_agent(
         else ""
     )
 
+    memory_block = build_memory_section(memory_dir) if memory_dir else ""
+    memory_suffix = ("\n\n" + memory_block.rstrip()) if memory_block else ""
     system_prompt = (
-        f"{preamble}{attribution_block}# Agent: {frontmatter.get('name', agent_name)}\n\n{body}"
+        f"{preamble}{attribution_block}"
+        f"# Agent: {frontmatter.get('name', agent_name)}\n\n{body}"
+        f"{memory_suffix}"
     )
 
     user_message = "Begin your workflow now."
@@ -394,3 +400,5 @@ def run_agent(
     finally:
         for client in mcp_clients.values():
             client.close()
+        if memory_dir:
+            clear_session_memory(memory_dir)


### PR DESCRIPTION
## Summary

- Adds `.uio/memory/*.memory.md` definition files with `name`, `description`, and `scope` (`project` | `session`) frontmatter fields
- At agent/skill startup, `runner.py` reads all in-scope memory files and appends their bodies to the system prompt under a `## Persistent Memory` heading
- `scope: session` memory files are truncated to empty after each run; `scope: project` files persist across runs
- New `uio memory` CLI group with `list`, `view <name>`, and `clear [--session]` subcommands
- Adds `.uio/memory/project-context.memory.md` as a working example and 21 new unit tests

## Test plan

- [ ] `uio memory list` — shows name, scope, and token count for each memory file
- [ ] `uio memory view project-context` — prints the body of the example file
- [ ] `uio memory clear --session` — truncates only session-scoped files, leaves project files untouched
- [ ] `uio memory clear` — truncates all memory file bodies
- [ ] Run `uio agent run <any-agent>` and confirm `## Persistent Memory` appears in the resolved system prompt (add a `print(system_prompt)` temporarily or check via test)
- [ ] Confirm `scope: session` file is empty after the agent completes
- [ ] `pytest -m "not integration"` — all 435 tests pass (including 21 new memory tests)
- [ ] `ruff format --check . && ruff check .` — no errors

Closes #161

---
🤖 Generated with [uio AI Coder](https://github.com/jomkz/uio)