### PR TITLE
feat: add context: frontmatter for file-glob knowledge injection

### DIFF
--- a/definitions/agents/coder.agent.md
+++ b/definitions/agents/coder.agent.md
@@ -6,6 +6,9 @@ capabilities:
   - vcs
 vcs-identity: coder
 argument-hint: "<change-description> | repo: <owner>/<repo> [| issue: <number>] [| branch: <name>] [| base: <branch>] [| workdir: <path>]"
+context:
+  - CONTRIBUTING.md
+  - AGENTS.md
 ---
 
 # Agent: coder

--- a/tests/test_context_injection.py
+++ b/tests/test_context_injection.py
@@ -9,7 +9,7 @@ from uio.core.runner import _build_context_section, _count_tokens
 
 class TestCountTokens:
     def test_empty_string(self):
-        assert _count_tokens("") == 1  # clamped to minimum 1
+        assert _count_tokens("") == 0
 
     def test_four_chars_is_one_token(self):
         assert _count_tokens("abcd") == 1
@@ -91,6 +91,23 @@ class TestBuildContextSection:
         (sub / "guide.md").write_text("guide content")
         result = _build_context_section(["docs/guide.md"], str(tmp_path), 8000)
         assert os.path.join("docs", "guide.md") in result
+
+    def test_exact_budget_no_spurious_section(self, tmp_path):
+        # First file exactly fills the budget; second file should produce no section at all.
+        # 40 chars = 10 tokens; max_tokens=10 means first file exactly fills budget.
+        (tmp_path / "a.txt").write_text("a" * 40)
+        (tmp_path / "b.txt").write_text("should not appear")
+        result = _build_context_section(["a.txt", "b.txt"], str(tmp_path), max_tokens=10)
+        assert "a" * 40 in result
+        assert "should not appear" not in result
+        assert "[truncated" not in result
+
+    def test_single_pattern_multi_file_cap(self, tmp_path):
+        # Both files match a single glob pattern; cap is hit on the first file.
+        (tmp_path / "a.txt").write_text("z" * 40000)  # ~10000 tokens
+        (tmp_path / "b.txt").write_text("should not appear")
+        result = _build_context_section(["*.txt"], str(tmp_path), max_tokens=100)
+        assert "should not appear" not in result
 
 
 class TestParserAcceptsContextKey:

--- a/tests/test_context_injection.py
+++ b/tests/test_context_injection.py
@@ -1,0 +1,108 @@
+"""Tests for context: frontmatter glob injection."""
+
+from __future__ import annotations
+
+import os
+
+from uio.core.runner import _build_context_section, _count_tokens
+
+
+class TestCountTokens:
+    def test_empty_string(self):
+        assert _count_tokens("") == 1  # clamped to minimum 1
+
+    def test_four_chars_is_one_token(self):
+        assert _count_tokens("abcd") == 1
+
+    def test_longer_text(self):
+        assert _count_tokens("a" * 400) == 100
+
+
+class TestBuildContextSection:
+    def test_empty_globs_returns_empty(self, tmp_path):
+        result = _build_context_section([], str(tmp_path), 8000)
+        assert result == ""
+
+    def test_nonmatching_glob_silently_skipped(self, tmp_path):
+        result = _build_context_section(["does_not_exist.md"], str(tmp_path), 8000)
+        assert result == ""
+
+    def test_single_file_included(self, tmp_path):
+        f = tmp_path / "README.md"
+        f.write_text("Hello world")
+        result = _build_context_section(["README.md"], str(tmp_path), 8000)
+        assert "## Context" in result
+        assert "README.md" in result
+        assert "Hello world" in result
+
+    def test_multiple_files_included(self, tmp_path):
+        (tmp_path / "a.md").write_text("File A")
+        (tmp_path / "b.md").write_text("File B")
+        result = _build_context_section(["*.md"], str(tmp_path), 8000)
+        assert "File A" in result
+        assert "File B" in result
+
+    def test_directory_entries_skipped(self, tmp_path):
+        subdir = tmp_path / "subdir"
+        subdir.mkdir()
+        result = _build_context_section(["subdir"], str(tmp_path), 8000)
+        assert result == ""
+
+    def test_recursive_glob(self, tmp_path):
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (sub / "nested.md").write_text("Nested content")
+        result = _build_context_section(["**/*.md"], str(tmp_path), 8000)
+        assert "Nested content" in result
+
+    def test_truncation_with_marker(self, tmp_path):
+        # File has 400 tokens worth of content (~1600 chars), cap is 10 tokens
+        content = "x" * 1600
+        (tmp_path / "big.txt").write_text(content)
+        result = _build_context_section(["big.txt"], str(tmp_path), max_tokens=10)
+        assert "[truncated —" in result
+        assert "tokens omitted]" in result
+        # Should only include first 10*4=40 chars of content
+        assert "x" * 40 in result
+        assert "x" * 41 not in result
+
+    def test_second_file_skipped_after_cap(self, tmp_path):
+        big = "y" * 40000  # ~10000 tokens
+        (tmp_path / "big.txt").write_text(big)
+        (tmp_path / "small.txt").write_text("Should not appear")
+        result = _build_context_section(["big.txt", "small.txt"], str(tmp_path), max_tokens=100)
+        assert "Should not appear" not in result
+
+    def test_string_glob_normalised_to_list(self, tmp_path):
+        # runner.py normalises str -> [str] before calling _build_context_section,
+        # but the function itself also accepts a list; test that directly.
+        (tmp_path / "file.md").write_text("content here")
+        result = _build_context_section(["file.md"], str(tmp_path), 8000)
+        assert "content here" in result
+
+    def test_context_heading_present(self, tmp_path):
+        (tmp_path / "notes.md").write_text("some notes")
+        result = _build_context_section(["notes.md"], str(tmp_path), 8000)
+        assert result.startswith("## Context\n\n")
+
+    def test_relative_path_in_heading(self, tmp_path):
+        sub = tmp_path / "docs"
+        sub.mkdir()
+        (sub / "guide.md").write_text("guide content")
+        result = _build_context_section(["docs/guide.md"], str(tmp_path), 8000)
+        assert os.path.join("docs", "guide.md") in result
+
+
+class TestParserAcceptsContextKey:
+    """Ensure validate_definition does not flag 'context' as unknown."""
+
+    def test_context_key_is_known(self, tmp_path):
+        from uio.schema.parser import validate_definition
+
+        fm = {
+            "name": "test-agent",
+            "description": "A test.",
+            "context": ["README.md"],
+        }
+        errors = validate_definition(str(tmp_path / "test.agent.md"), fm)
+        assert not any("unrecognised" in e and "context" in e for e in errors)

--- a/uio/cli/agent.py
+++ b/uio/cli/agent.py
@@ -112,6 +112,7 @@ def agent_run_cmd(
             anthropic_max_tokens=cfg["runtime"]["anthropic_max_tokens"],
             routing_chain=cfg["runtime"].get("routing_chain"),
             memory_dir=cfg["dirs"]["memory"],
+            context_max_tokens=cfg["runtime"]["context_max_tokens"],
         )
     except GuardrailError as exc:
         click.echo(f"Error: guardrail violated — {exc}", err=True)

--- a/uio/cli/prompt.py
+++ b/uio/cli/prompt.py
@@ -83,6 +83,7 @@ def prompt_run_cmd(
         shell_override=shell,
         routing_chain=cfg["runtime"].get("routing_chain"),
         memory_dir=cfg["dirs"]["memory"],
+        context_max_tokens=cfg["runtime"]["context_max_tokens"],
     )
 
 

--- a/uio/cli/skill.py
+++ b/uio/cli/skill.py
@@ -92,6 +92,7 @@ def skill_run_cmd(
             shell_override=shell,
             routing_chain=cfg["runtime"].get("routing_chain"),
             memory_dir=cfg["dirs"]["memory"],
+            context_max_tokens=cfg["runtime"]["context_max_tokens"],
         )
     except GuardrailError as exc:
         click.echo(f"Error: guardrail violated — {exc}", err=True)

--- a/uio/config.py
+++ b/uio/config.py
@@ -27,6 +27,7 @@ _DEFAULTS: dict = {
         "max_iterations": 10,
         "max_iterations_large": 25,
         "anthropic_max_tokens": 16000,
+        "context_max_tokens": 8000,
     },
     "large_agents": {
         "names": [],
@@ -50,6 +51,7 @@ timeout              = 300
 max_iterations       = 10   # small agents (summarise, comment, query)
 max_iterations_large = 25   # large agents (github-coder, multi-step workflows)
 # anthropic_max_tokens = 16000  # Anthropic only; also overridable per-agent via frontmatter
+# context_max_tokens   = 8000   # token cap for context: glob injection (default 8000)
 
 [large_agents]
 # Agent names that always use the large model tier (in addition to

--- a/uio/core/runner.py
+++ b/uio/core/runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import fnmatch
+import glob as _glob
 import os
 import sys
 import time
@@ -47,6 +48,61 @@ _RETRY_BACKOFF = [5, 15, 30]  # seconds — enough for Gemini high-demand 503s t
 def _is_retryable(exc: Exception) -> bool:
     msg = str(exc)
     return any(s in msg for s in _RETRYABLE_SUBSTRINGS)
+
+
+def _count_tokens(text: str) -> int:
+    """Rough token estimate: 4 characters per token (matches common LLM rule of thumb)."""
+    return max(1, len(text) // 4)
+
+
+def _build_context_section(globs: list[str], project_root: str, max_tokens: int) -> str:
+    """Resolve file globs and return a ## Context block for the system prompt.
+
+    Files that match no globs are silently skipped.  Once the running token total
+    reaches *max_tokens* the current file is truncated with a marker and no further
+    files are read.  Returns an empty string when nothing matches.
+    """
+    if not globs:
+        return ""
+
+    sections: list[str] = []
+    total_tokens = 0
+    cap_reached = False
+
+    for pattern in globs:
+        if cap_reached:
+            break
+        matched = sorted(_glob.glob(os.path.join(project_root, pattern), recursive=True))
+        for fpath in matched:
+            if cap_reached:
+                break
+            if not os.path.isfile(fpath):
+                continue
+            try:
+                content = open(fpath, encoding="utf-8", errors="replace").read()
+            except OSError:
+                continue
+
+            file_tokens = _count_tokens(content)
+            rel_path = os.path.relpath(fpath, project_root)
+            remaining = max_tokens - total_tokens
+
+            if file_tokens <= remaining:
+                sections.append(f"### {rel_path}\n\n{content}")
+                total_tokens += file_tokens
+            else:
+                cutoff = remaining * 4
+                omitted = file_tokens - remaining
+                sections.append(
+                    f"### {rel_path}\n\n{content[:cutoff]}\n[truncated — {omitted} tokens omitted]"
+                )
+                cap_reached = True
+
+    if not sections:
+        return ""
+
+    body = "\n\n---\n\n".join(sections)
+    return f"## Context\n\n{body}\n\n"
 
 
 def _inject_vcs_identity(frontmatter: dict) -> str | None:
@@ -173,6 +229,7 @@ def run_agent(
     anthropic_max_tokens: int | None = None,
     routing_chain: list[str] | None = None,
     memory_dir: str | None = None,
+    context_max_tokens: int = 8000,
 ) -> None:
     if definition_path is None:
         raise ValueError("definition_path must be provided")
@@ -218,8 +275,15 @@ def run_agent(
 
     memory_block = build_memory_section(memory_dir) if memory_dir else ""
     memory_suffix = ("\n\n" + memory_block.rstrip()) if memory_block else ""
+
+    context_globs = frontmatter.get("context") or []
+    if isinstance(context_globs, str):
+        context_globs = [context_globs]
+    context_block = _build_context_section(context_globs, os.getcwd(), context_max_tokens)
+
     system_prompt = (
         f"{preamble}{attribution_block}"
+        f"{context_block}"
         f"# Agent: {frontmatter.get('name', agent_name)}\n\n{body}"
         f"{memory_suffix}"
     )

--- a/uio/core/runner.py
+++ b/uio/core/runner.py
@@ -52,7 +52,7 @@ def _is_retryable(exc: Exception) -> bool:
 
 def _count_tokens(text: str) -> int:
     """Rough token estimate: 4 characters per token (matches common LLM rule of thumb)."""
-    return max(1, len(text) // 4)
+    return len(text) // 4
 
 
 def _build_context_section(globs: list[str], project_root: str, max_tokens: int) -> str:
@@ -79,7 +79,8 @@ def _build_context_section(globs: list[str], project_root: str, max_tokens: int)
             if not os.path.isfile(fpath):
                 continue
             try:
-                content = open(fpath, encoding="utf-8", errors="replace").read()
+                with open(fpath, encoding="utf-8", errors="replace") as fh:
+                    content = fh.read()
             except OSError:
                 continue
 
@@ -90,6 +91,8 @@ def _build_context_section(globs: list[str], project_root: str, max_tokens: int)
             if file_tokens <= remaining:
                 sections.append(f"### {rel_path}\n\n{content}")
                 total_tokens += file_tokens
+                if total_tokens >= max_tokens:
+                    cap_reached = True
             else:
                 cutoff = remaining * 4
                 omitted = file_tokens - remaining

--- a/uio/schema/parser.py
+++ b/uio/schema/parser.py
@@ -48,6 +48,7 @@ def validate_definition(path: str, frontmatter: dict) -> list[str]:
         "invokable",
         "max_tokens",
         "guardrails",
+        "context",
         "github-identity",  # deprecated alias for vcs-identity
         "vcs-identity",
         "vcs-provider",


### PR DESCRIPTION
## Summary

- Adds a `context:` frontmatter field to agent and skill definitions, accepting a list of file-glob patterns
- At run time `runner.py` resolves each glob relative to `os.getcwd()`, reads matching files, and prepends their content as a `## Context` block in the system prompt (before the definition body)
- A `context_max_tokens` key in `uio.toml` (default `8000`) caps total injection size; files that exceed the cap are truncated with a `[truncated — N tokens omitted]` marker; globs that match nothing are silently skipped
- `coder.agent.md` is updated with a `context: [CONTRIBUTING.md, AGENTS.md]` example to demonstrate the feature

## Test plan

- [ ] `pytest tests/test_context_injection.py` — 15 new unit tests covering token counting, single/multi-file inclusion, recursive globs, directory-entry skipping, truncation, and the parser accepting the new key
- [ ] `pytest -m "not integration"` — full suite (456 tests) passes with no regressions
- [ ] `ruff format --check . && ruff check .` — no lint or formatting errors

Closes #162

---
*🤖 Generated with [uio AI Coder](https://github.com/jomkz/uio)*