### PR TITLE
feat: add *.workflow.md definition type for chaining agents and skills

### DIFF
--- a/definitions/workflows/review-and-fix.workflow.md
+++ b/definitions/workflows/review-and-fix.workflow.md
@@ -1,0 +1,32 @@
+---
+name: review-and-fix
+description: Review a pull request and open a fix branch if blockers are found.
+steps:
+  - name: review
+    agent: reviewer
+    arg: "{{ input }}"
+    output: review_result
+
+  - name: fix
+    agent: coder
+    arg: "{{ input }}"
+    when: "review_result contains BLOCKER"
+---
+
+# Workflow: review-and-fix
+
+This workflow demonstrates agent chaining with a conditional step.
+
+**Step 1 — review:** Runs the `reviewer` agent against the pull request reference
+passed as `{{ input }}` (e.g. `owner/repo#42`). The reviewer's final response is
+stored in `review_result`.
+
+**Step 2 — fix (conditional):** Runs the `coder` agent with the same PR reference,
+but only when `review_result` contains the word `BLOCKER`. If the review is clean
+the step is skipped and the workflow exits cleanly.
+
+Run this workflow with:
+
+```
+uio workflow run review-and-fix "owner/repo#42"
+```

--- a/docs/02-concepts.md
+++ b/docs/02-concepts.md
@@ -8,7 +8,7 @@ The name `uio` comes from Linux's **Userspace I/O** framework. In Linux, UIO let
 
 ---
 
-## The three definition types
+## The four definition types
 
 Every `uio` definition is a markdown file. The file type is encoded in the filename extension, and the YAML frontmatter at the top controls how the runtime handles it.
 
@@ -40,19 +40,76 @@ Use a prompt for well-defined, one-shot queries where you want the model to resp
 
 Example: `ask-docs.prompt.md` answers a focused question about a codebase by appending the question as a final line.
 
+### Workflows (`.workflow.md`)
+
+A workflow is a **deterministic pipeline** that chains agents and skills into an ordered sequence of steps. Unlike an agent (which makes its own decisions about what to do next), a workflow's structure is fixed in the definition file — the runtime executes steps one at a time, in order, with no LLM orchestrating the sequence.
+
+Each step specifies which agent or skill to invoke, an optional argument template (with `{{ variable }}` interpolation), an optional output variable to capture the step's final response, and an optional `when:` condition that controls whether the step runs.
+
+**Frontmatter fields:**
+
+- `name` (required) — workflow display name
+- `description` (required) — one-line summary
+- `steps` (required) — ordered list of step definitions
+
+**Step fields:**
+
+| Field | Required | Description |
+|---|---|---|
+| `name` | Yes | Step label shown in output |
+| `agent` | One of these | Agent stem to invoke (e.g. `reviewer`) |
+| `skill` | One of these | Skill stem to invoke (e.g. `summarise`) |
+| `arg` | No | Argument string; supports `{{ variable }}` interpolation |
+| `output` | No | Variable name to capture the step's final response |
+| `when` | No | Skip condition: `<var> contains <substring>` |
+
+**Variable interpolation:**
+
+The run argument is available as `{{ input }}` in every step. Step outputs stored via `output:` are available as `{{ variable_name }}` in subsequent steps.
+
+**`when:` conditions:**
+
+A `when:` condition takes the form `<variable> contains <substring>`. The step is **skipped** when the referenced variable's value does not contain the substring (case-insensitive). If the variable is not yet set, the step is skipped.
+
+**Example workflow:**
+
+```yaml
+---
+name: review-and-fix
+description: Review a PR and open a fix branch if blockers are found.
+steps:
+  - name: review
+    agent: reviewer
+    arg: "{{ input }}"
+    output: review_result
+
+  - name: fix
+    agent: coder
+    arg: "{{ input }}"
+    when: "review_result contains BLOCKER"
+---
+
+# Workflow: review-and-fix
+
+Reviews a pull request using the reviewer agent. If the review output contains
+the word "BLOCKER", the coder agent is invoked to open a fix branch.
+```
+
+Run with `uio workflow run review-and-fix "owner/repo#42"`.
+
 ---
 
 ## Comparison table
 
-| | **Agent** | **Skill** | **Prompt** |
-|---|---|---|---|
-| Tool-use loop | Yes | Yes | No |
-| `run_command` access | Yes | Yes | No |
-| MCP tool access | Yes | Yes | No |
-| Iteration cap | 10 | 10 | — |
-| Complexity tier | `small` / `large` | `small` / `large` | — |
-| `invokable` frontmatter | No | No | Optional |
-| Typical use | Multi-step workflow | Focused subtask | One-shot query |
+| | **Agent** | **Skill** | **Prompt** | **Workflow** |
+|---|---|---|---|---|
+| Tool-use loop | Yes | Yes | No | No (orchestrates others) |
+| `run_command` access | Yes | Yes | No | No |
+| MCP tool access | Yes | Yes | No | No |
+| Iteration cap | 10 | 10 | — | One pass per step |
+| Complexity tier | `small` / `large` | `small` / `large` | — | Set per step |
+| `steps:` frontmatter | No | No | No | Yes |
+| Typical use | Multi-step workflow | Focused subtask | One-shot query | Pipeline of agents/skills |
 
 Tools (`run_command`, MCP tools) are not definition types — they are capabilities the model invokes at runtime. See the [Glossary](#glossary) for the Tool definition and the skill vs tool distinction.
 
@@ -65,11 +122,12 @@ Tools (`run_command`, MCP tools) are not definition types — they are capabilit
 ```
 my-project/
 ├── .uio/
-│   ├── agents/    *.agent.md
-│   ├── skills/    *.skill.md
-│   └── prompts/   *.prompt.md
-├── uio.toml       # optional project config
-└── uio_cost.jsonl # cost ledger (add to .gitignore)
+│   ├── agents/      *.agent.md
+│   ├── skills/      *.skill.md
+│   ├── prompts/     *.prompt.md
+│   └── workflows/   *.workflow.md
+├── uio.toml         # optional project config
+└── uio_cost.jsonl   # cost ledger (add to .gitignore)
 ```
 
 Run `uio init` to scaffold this structure. Run `uio init --examples` to also install the bundled example definitions.
@@ -80,7 +138,7 @@ The directories are configurable via `uio.toml` (see [Configuration](06-configur
 
 ## How a definition becomes a run
 
-Every `uio agent run` / `uio skill run` / `uio prompt run` invocation:
+Every `uio agent run` / `uio skill run` / `uio prompt run` / `uio workflow run` invocation:
 
 1. Reads the definition file fresh from disk (no caching — edits take effect immediately)
 2. Parses the YAML frontmatter block
@@ -101,12 +159,13 @@ The definition file is the single source of truth for behaviour. Moving, editing
 
 | Layer | uio primitive |
 |---|---|
+| **Workflows** | `.workflow.md` — deterministic pipelines of agents and skills |
 | **Agents** | `.agent.md` — autonomous decision-makers |
 | **Skills** | `.skill.md` — composable, user-directed subtasks |
 | **Prompts** | `.prompt.md` — single-shot instructions |
 | **Tools** | MCP tools + `run_command` — agent-directed capabilities |
 
-This vocabulary is intentional. **"Agentic Stack"** is the umbrella term for the agents + skills + prompts + tools model that `uio` provides. See the [Glossary](#glossary) below for precise term definitions.
+This vocabulary is intentional. **"Agentic Stack"** is the umbrella term for the workflows + agents + skills + prompts + tools model that `uio` provides. See the [Glossary](#glossary) below for precise term definitions.
 
 ---
 
@@ -118,5 +177,6 @@ This vocabulary is intentional. **"Agentic Stack"** is the umbrella term for the
 | **Skill** | A focused, composable subtask. Runs the same tool-use loop as an agent internally, but is **user-directed**: you invoke it explicitly with `uio skill run <name>`. Skills may also be referenced by name inside agent definition bodies. Skills are small, reusable building blocks; agents are higher-level workflows. |
 | **Prompt** | A single-shot LLM instruction. The definition body is sent once and the response is printed — no tool-use loop. Defined in `*.prompt.md`. |
 | **Tool** | An external capability the **model** invokes mid-loop. Tools are agent-directed: the agent decides when and how to call them. Examples: `run_command` (built-in), MCP tools such as GitHub or filesystem access. This is the key distinction from skills — a tool is called by the model; a skill is called by you. |
+| **Workflow** | A deterministic pipeline that chains agents and skills sequentially. Defined in `*.workflow.md`. The structure is fixed; the runtime executes steps in order with `{{ variable }}` interpolation and optional `when:` conditions — no LLM orchestrates the sequence. |
 | **Memory** | Persistent context injected into agent runs across sessions. Not yet implemented (planned). |
 | **Guardrails** | Per-definition constraints on cost, tool access, and iteration count. Not yet implemented (planned). |

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import textwrap
+from unittest.mock import patch
 
-
-from uio.core.workflow import _eval_when, _interpolate, parse_workflow_steps
+from uio.core.workflow import _eval_when, _interpolate, parse_workflow_steps, run_workflow
 from uio.schema.parser import check_workflow_steps, validate_workflow_definition
 
 
@@ -267,3 +267,227 @@ def test_workflow_list_shows_workflows(tmp_path, monkeypatch):
     assert "review-and-fix" in result.output
     assert "Review a PR" in result.output
     assert "2" in result.output  # step count
+
+
+# ---------------------------------------------------------------------------
+# run_workflow execution
+# ---------------------------------------------------------------------------
+
+_MINIMAL_CFG: dict = {
+    "dirs": {
+        "agents": ".uio/agents",
+        "skills": ".uio/skills",
+        "workflows": ".uio/workflows",
+        "memory": None,
+    },
+    "runtime": {
+        "default_provider": None,
+        "timeout": 10,
+        "max_iterations": 5,
+        "max_iterations_large": 10,
+        "cost_ledger": "uio_cost.jsonl",
+        "routing_chain": None,
+        "context_max_tokens": 1000,
+        "anthropic_max_tokens": None,
+    },
+    "large_agents": {"names": []},
+    "mcp": {},
+    "mcp_plugins": [],
+}
+
+
+def _make_cfg(tmp_path) -> dict:
+    cfg = {k: dict(v) if isinstance(v, dict) else v for k, v in _MINIMAL_CFG.items()}
+    cfg["dirs"] = dict(_MINIMAL_CFG["dirs"])
+    cfg["dirs"]["workflows"] = str(tmp_path / "workflows")
+    cfg["dirs"]["agents"] = str(tmp_path / "agents")
+    cfg["dirs"]["skills"] = str(tmp_path / "skills")
+    return cfg
+
+
+def _write_workflow(tmp_path, name: str, content: str) -> None:
+    wf_dir = tmp_path / "workflows"
+    wf_dir.mkdir(exist_ok=True)
+    (wf_dir / f"{name}.workflow.md").write_text(content)
+
+
+def test_run_workflow_sequences_and_threads_output(tmp_path):
+    _write_workflow(
+        tmp_path,
+        "seq",
+        textwrap.dedent("""\
+            ---
+            name: seq
+            description: D.
+            steps:
+              - name: step-a
+                agent: agent-a
+                arg: "{{ input }}"
+                output: result_a
+              - name: step-b
+                agent: agent-b
+                arg: "{{ result_a }}"
+            ---
+            Body.
+        """),
+    )
+    cfg = _make_cfg(tmp_path)
+    calls: list[tuple[str, str | None]] = []
+
+    def fake_run_agent(name, arg, **kwargs):
+        calls.append((name, arg))
+        return f"output-of-{name}"
+
+    with patch("uio.core.runner.run_agent", side_effect=fake_run_agent):
+        run_workflow("seq", "my-input", cfg=cfg)
+
+    assert calls[0] == ("agent-a", "my-input")
+    assert calls[1] == ("agent-b", "output-of-agent-a")  # output threaded
+
+
+def test_run_workflow_when_condition_skips_step(tmp_path):
+    _write_workflow(
+        tmp_path,
+        "cond",
+        textwrap.dedent("""\
+            ---
+            name: cond
+            description: D.
+            steps:
+              - name: check
+                agent: checker
+                arg: "{{ input }}"
+                output: check_result
+              - name: fix
+                agent: fixer
+                arg: "{{ input }}"
+                when: "check_result contains BLOCKER"
+            ---
+            Body.
+        """),
+    )
+    cfg = _make_cfg(tmp_path)
+    calls: list[str] = []
+
+    def fake_run_agent(name, arg, **kwargs):
+        calls.append(name)
+        return "All good, no issues."
+
+    with patch("uio.core.runner.run_agent", side_effect=fake_run_agent):
+        run_workflow("cond", "pr-ref", cfg=cfg)
+
+    assert calls == ["checker"]  # fixer was skipped — no BLOCKER in output
+
+
+def test_run_workflow_when_condition_runs_step(tmp_path):
+    _write_workflow(
+        tmp_path,
+        "cond2",
+        textwrap.dedent("""\
+            ---
+            name: cond2
+            description: D.
+            steps:
+              - name: check
+                agent: checker
+                arg: "{{ input }}"
+                output: check_result
+              - name: fix
+                agent: fixer
+                arg: "{{ input }}"
+                when: "check_result contains BLOCKER"
+            ---
+            Body.
+        """),
+    )
+    cfg = _make_cfg(tmp_path)
+    calls: list[str] = []
+
+    def fake_run_agent(name, arg, **kwargs):
+        calls.append(name)
+        return "Found a BLOCKER in the diff."
+
+    with patch("uio.core.runner.run_agent", side_effect=fake_run_agent):
+        run_workflow("cond2", "pr-ref", cfg=cfg)
+
+    assert calls == ["checker", "fixer"]  # fixer ran — BLOCKER present
+
+
+def test_run_workflow_warns_on_none_output(tmp_path, capsys):
+    _write_workflow(
+        tmp_path,
+        "cap",
+        textwrap.dedent("""\
+            ---
+            name: cap
+            description: D.
+            steps:
+              - name: capped
+                agent: slow-agent
+                arg: "{{ input }}"
+                output: capped_result
+            ---
+            Body.
+        """),
+    )
+    cfg = _make_cfg(tmp_path)
+
+    def fake_run_agent(name, arg, **kwargs):
+        return None  # simulates iteration cap
+
+    with patch("uio.core.runner.run_agent", side_effect=fake_run_agent):
+        run_workflow("cap", "arg", cfg=cfg)
+
+    captured = capsys.readouterr()
+    assert "Warning" in captured.err
+    assert "capped_result" in captured.err
+
+
+def test_run_workflow_no_steps(tmp_path, capsys):
+    _write_workflow(
+        tmp_path,
+        "empty",
+        textwrap.dedent("""\
+            ---
+            name: empty
+            description: D.
+            steps: []
+            ---
+            Body.
+        """),
+    )
+    cfg = _make_cfg(tmp_path)
+    with patch("uio.core.runner.run_agent") as mock_agent:
+        run_workflow("empty", None, cfg=cfg)
+        mock_agent.assert_not_called()
+
+
+def test_run_workflow_skill_step(tmp_path):
+    _write_workflow(
+        tmp_path,
+        "skill-wf",
+        textwrap.dedent("""\
+            ---
+            name: skill-wf
+            description: D.
+            steps:
+              - name: summarise
+                skill: summarise
+                arg: "{{ input }}"
+                output: summary
+            ---
+            Body.
+        """),
+    )
+    cfg = _make_cfg(tmp_path)
+    calls: list[tuple[str, str]] = []
+
+    def fake_run_agent(name, arg, **kwargs):
+        calls.append((name, kwargs.get("definition_path", "")))
+        return "the summary"
+
+    with patch("uio.core.runner.run_agent", side_effect=fake_run_agent):
+        run_workflow("skill-wf", "some text", cfg=cfg)
+
+    assert calls[0][0] == "summarise"
+    assert ".skill.md" in calls[0][1]  # resolved as a skill, not an agent

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,0 +1,269 @@
+"""Tests for workflow definition parsing and execution."""
+
+from __future__ import annotations
+
+import textwrap
+
+
+from uio.core.workflow import _eval_when, _interpolate, parse_workflow_steps
+from uio.schema.parser import check_workflow_steps, validate_workflow_definition
+
+
+# ---------------------------------------------------------------------------
+# parse_workflow_steps
+# ---------------------------------------------------------------------------
+
+
+def test_parse_workflow_steps_empty():
+    assert parse_workflow_steps({}) == []
+    assert parse_workflow_steps({"steps": []}) == []
+
+
+def test_parse_workflow_steps_agent_step():
+    fm = {
+        "steps": [{"name": "review", "agent": "reviewer", "arg": "{{ input }}", "output": "result"}]
+    }
+    steps = parse_workflow_steps(fm)
+    assert len(steps) == 1
+    assert steps[0].name == "review"
+    assert steps[0].agent == "reviewer"
+    assert steps[0].skill is None
+    assert steps[0].arg == "{{ input }}"
+    assert steps[0].output == "result"
+    assert steps[0].when is None
+
+
+def test_parse_workflow_steps_skill_step():
+    fm = {"steps": [{"name": "summarise", "skill": "summarise", "arg": "{{ review_result }}"}]}
+    steps = parse_workflow_steps(fm)
+    assert steps[0].skill == "summarise"
+    assert steps[0].agent is None
+
+
+def test_parse_workflow_steps_with_when():
+    fm = {"steps": [{"name": "fix", "agent": "coder", "when": "result contains BLOCKER"}]}
+    steps = parse_workflow_steps(fm)
+    assert steps[0].when == "result contains BLOCKER"
+
+
+def test_parse_workflow_steps_skips_non_dicts():
+    fm = {"steps": ["not-a-dict", {"name": "ok", "agent": "coder"}]}
+    steps = parse_workflow_steps(fm)
+    assert len(steps) == 1
+    assert steps[0].name == "ok"
+
+
+# ---------------------------------------------------------------------------
+# _interpolate
+# ---------------------------------------------------------------------------
+
+
+def test_interpolate_replaces_input():
+    result = _interpolate("run against {{ input }}", {"input": "owner/repo#1"})
+    assert result == "run against owner/repo#1"
+
+
+def test_interpolate_replaces_multiple():
+    result = _interpolate("{{ a }} and {{ b }}", {"a": "X", "b": "Y"})
+    assert result == "X and Y"
+
+
+def test_interpolate_unknown_variable_preserved():
+    result = _interpolate("hello {{ unknown }}", {})
+    assert result == "hello {{ unknown }}"
+
+
+def test_interpolate_whitespace_in_braces():
+    result = _interpolate("{{  input  }}", {"input": "val"})
+    assert result == "val"
+
+
+# ---------------------------------------------------------------------------
+# _eval_when
+# ---------------------------------------------------------------------------
+
+
+def test_eval_when_substring_present():
+    variables = {"review_result": "This has a BLOCKER in it"}
+    assert _eval_when("review_result contains BLOCKER", variables) is True
+
+
+def test_eval_when_substring_absent():
+    variables = {"review_result": "All good, no issues."}
+    assert _eval_when("review_result contains BLOCKER", variables) is False
+
+
+def test_eval_when_case_insensitive():
+    variables = {"result": "found a blocker here"}
+    assert _eval_when("result contains BLOCKER", variables) is True
+
+
+def test_eval_when_variable_missing_returns_false():
+    assert _eval_when("missing_var contains foo", {}) is False
+
+
+def test_eval_when_quoted_substring():
+    variables = {"out": "critical: BLOCKER detected"}
+    assert _eval_when('out contains "BLOCKER"', variables) is True
+
+
+def test_eval_when_bad_syntax_returns_true(capsys):
+    result = _eval_when("this-is-bad-syntax", {})
+    assert result is True
+    captured = capsys.readouterr()
+    assert "unrecognised" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# validate_workflow_definition
+# ---------------------------------------------------------------------------
+
+
+def test_validate_workflow_valid(tmp_path):
+    f = tmp_path / "my.workflow.md"
+    f.write_text("---\nname: My Workflow\ndescription: Does stuff.\nsteps: []\n---\nBody.\n")
+    from uio.schema.parser import parse_definition_file
+
+    fm, _ = parse_definition_file(str(f))
+    errors = validate_workflow_definition(str(f), fm)
+    assert errors == []
+
+
+def test_validate_workflow_missing_name(tmp_path):
+    f = tmp_path / "w.workflow.md"
+    f.write_text("---\ndescription: No name.\n---\nBody.\n")
+    from uio.schema.parser import parse_definition_file
+
+    fm, _ = parse_definition_file(str(f))
+    errors = validate_workflow_definition(str(f), fm)
+    assert any("name" in e for e in errors)
+
+
+def test_validate_workflow_missing_description(tmp_path):
+    f = tmp_path / "w.workflow.md"
+    f.write_text("---\nname: W\n---\nBody.\n")
+    from uio.schema.parser import parse_definition_file
+
+    fm, _ = parse_definition_file(str(f))
+    errors = validate_workflow_definition(str(f), fm)
+    assert any("description" in e for e in errors)
+
+
+def test_validate_workflow_unknown_key(tmp_path):
+    f = tmp_path / "w.workflow.md"
+    f.write_text("---\nname: W\ndescription: D.\nunknown_key: bad\n---\nBody.\n")
+    from uio.schema.parser import parse_definition_file
+
+    fm, _ = parse_definition_file(str(f))
+    errors = validate_workflow_definition(str(f), fm)
+    assert any("unknown_key" in e for e in errors)
+
+
+def test_validate_workflow_steps_not_list(tmp_path):
+    f = tmp_path / "w.workflow.md"
+    f.write_text("---\nname: W\ndescription: D.\nsteps: not-a-list\n---\nBody.\n")
+    from uio.schema.parser import parse_definition_file
+
+    fm, _ = parse_definition_file(str(f))
+    errors = validate_workflow_definition(str(f), fm)
+    assert any("steps" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# check_workflow_steps
+# ---------------------------------------------------------------------------
+
+
+def test_check_workflow_steps_valid():
+    fm = {
+        "steps": [
+            {"name": "review", "agent": "reviewer", "arg": "{{ input }}", "output": "r"},
+            {"name": "fix", "skill": "fixer", "when": "r contains X"},
+        ]
+    }
+    warnings = check_workflow_steps("w.workflow.md", fm)
+    assert warnings == []
+
+
+def test_check_workflow_steps_both_agent_and_skill():
+    fm = {"steps": [{"name": "s", "agent": "a", "skill": "b"}]}
+    warnings = check_workflow_steps("w.workflow.md", fm)
+    assert any("mutually exclusive" in w for w in warnings)
+
+
+def test_check_workflow_steps_neither_agent_nor_skill():
+    fm = {"steps": [{"name": "s"}]}
+    warnings = check_workflow_steps("w.workflow.md", fm)
+    assert any("neither" in w for w in warnings)
+
+
+def test_check_workflow_steps_unknown_key():
+    fm = {"steps": [{"name": "s", "agent": "a", "typo_key": "val"}]}
+    warnings = check_workflow_steps("w.workflow.md", fm)
+    assert any("typo_key" in w for w in warnings)
+
+
+def test_check_workflow_steps_non_dict_step():
+    fm = {"steps": ["not-a-dict"]}
+    warnings = check_workflow_steps("w.workflow.md", fm)
+    assert any("not a mapping" in w for w in warnings)
+
+
+# ---------------------------------------------------------------------------
+# workflow list CLI
+# ---------------------------------------------------------------------------
+
+
+def test_workflow_list_no_workflows(tmp_path, monkeypatch):
+    from click.testing import CliRunner
+
+    from uio.cli.workflow import workflow_list_cmd
+
+    cfg = {
+        "dirs": {
+            "workflows": str(tmp_path / "workflows"),
+        }
+    }
+    monkeypatch.setattr("uio.cli.workflow.load_config", lambda: cfg)
+    runner = CliRunner()
+    result = runner.invoke(workflow_list_cmd, [])
+    assert result.exit_code == 0
+    assert "No workflows found" in result.output
+
+
+def test_workflow_list_shows_workflows(tmp_path, monkeypatch):
+    from click.testing import CliRunner
+
+    from uio.cli.workflow import workflow_list_cmd
+
+    wf_dir = tmp_path / "workflows"
+    wf_dir.mkdir()
+    (wf_dir / "review-and-fix.workflow.md").write_text(
+        textwrap.dedent("""\
+            ---
+            name: review-and-fix
+            description: Review a PR and open a fix branch.
+            steps:
+              - name: review
+                agent: reviewer
+                arg: "{{ input }}"
+              - name: fix
+                agent: coder
+                arg: "{{ input }}"
+                when: "review_result contains BLOCKER"
+            ---
+
+            # Workflow: review-and-fix
+
+            Body text here.
+        """)
+    )
+
+    cfg = {"dirs": {"workflows": str(wf_dir)}}
+    monkeypatch.setattr("uio.cli.workflow.load_config", lambda: cfg)
+    runner = CliRunner()
+    result = runner.invoke(workflow_list_cmd, [])
+    assert result.exit_code == 0
+    assert "review-and-fix" in result.output
+    assert "Review a PR" in result.output
+    assert "2" in result.output  # step count

--- a/uio/cli/main.py
+++ b/uio/cli/main.py
@@ -116,9 +116,10 @@ def init_cmd(examples: bool) -> None:
     agents_dir = Path(cfg["dirs"]["agents"])
     skills_dir = Path(cfg["dirs"]["skills"])
     prompts_dir = Path(cfg["dirs"]["prompts"])
+    workflows_dir = Path(cfg["dirs"]["workflows"])
     memory_dir = Path(cfg["dirs"]["memory"])
 
-    for d in (agents_dir, skills_dir, prompts_dir, memory_dir):
+    for d in (agents_dir, skills_dir, prompts_dir, workflows_dir, memory_dir):
         d.mkdir(parents=True, exist_ok=True)
         click.echo(f"  Created directory: {d}/")
 
@@ -227,7 +228,7 @@ def validate_cmd(strict: bool) -> None:
         for path in sorted(glob(f"{directory}/{pattern}")):
             total += 1
             try:
-                fm, body = parse_definition_file(path)
+                fm, _ = parse_definition_file(path)
             except Exception as e:
                 errors.append(f"{path}: could not parse: {e}")
                 continue

--- a/uio/cli/main.py
+++ b/uio/cli/main.py
@@ -19,6 +19,7 @@ from uio.cli.memory import memory_group
 from uio.cli.prompt import prompt_group
 from uio.cli.registry import registry_group
 from uio.cli.skill import skill_group
+from uio.cli.workflow import workflow_group
 from uio.config import load_config
 from uio.examples import EXAMPLES
 from uio.schema.parser import (
@@ -29,8 +30,10 @@ from uio.schema.parser import (
     check_skill_references,
     check_stopping_criteria,
     check_thinking_complexity,
+    check_workflow_steps,
     parse_definition_file,
     validate_definition,
+    validate_workflow_definition,
 )
 
 _EXAMPLE_AGENT = """\
@@ -79,6 +82,7 @@ def main() -> None:
 main.add_command(agent_group, "agent")
 main.add_command(skill_group, "skill")
 main.add_command(prompt_group, "prompt")
+main.add_command(workflow_group, "workflow")
 main.add_command(chat_cmd, "chat")
 main.add_command(cost_cmd, "cost")
 main.add_command(config_group, "config")
@@ -188,17 +192,20 @@ def validate_cmd(strict: bool) -> None:
     """
     cfg = load_config()
     skills_dir = cfg["dirs"]["skills"]
-    patterns = [
+    agent_skill_prompt_patterns = [
         (cfg["dirs"]["agents"], "*.agent.md"),
         (skills_dir, "*.skill.md"),
         (cfg["dirs"]["prompts"], "*.prompt.md"),
+    ]
+    workflow_patterns = [
+        (cfg["dirs"]["workflows"], "*.workflow.md"),
     ]
 
     errors: list[str] = []
     warnings: list[str] = []
     total = 0
 
-    for directory, pattern in patterns:
+    for directory, pattern in agent_skill_prompt_patterns:
         for path in sorted(glob(f"{directory}/{pattern}")):
             total += 1
             try:
@@ -215,6 +222,17 @@ def validate_cmd(strict: bool) -> None:
             warnings.extend(check_minimal_body(path, body))
             if strict:
                 warnings.extend(check_stopping_criteria(path, body))
+
+    for directory, pattern in workflow_patterns:
+        for path in sorted(glob(f"{directory}/{pattern}")):
+            total += 1
+            try:
+                fm, body = parse_definition_file(path)
+            except Exception as e:
+                errors.append(f"{path}: could not parse: {e}")
+                continue
+            errors.extend(validate_workflow_definition(path, fm))
+            warnings.extend(check_workflow_steps(path, fm))
 
     if total == 0:
         click.echo("  No definition files found.")

--- a/uio/cli/workflow.py
+++ b/uio/cli/workflow.py
@@ -1,0 +1,83 @@
+"""uio workflow subcommands: run, list."""
+
+from __future__ import annotations
+
+import click
+
+from uio.cli._helpers import list_definitions, print_definition_table
+from uio.config import load_config
+from uio.core.tools import SHELL_CHOICES
+from uio.core.workflow import run_workflow
+
+
+@click.group("workflow", no_args_is_help=True)
+def workflow_group() -> None:
+    """Run and discover multi-step workflows.
+
+    Workflows are loaded from .uio/workflows/*.workflow.md.
+    """
+
+
+@workflow_group.command("run")
+@click.argument("workflow_name", metavar="WORKFLOW")
+@click.argument("arg", required=False)
+@click.option(
+    "--provider",
+    default=None,
+    help="LLM provider: gemini, openai, or ollama (default: auto-routes).",
+)
+@click.option("--model", default=None, help="Model name override.")
+@click.option("--no-mcp", is_flag=True, default=False, help="Disable all MCP servers.")
+@click.option(
+    "--shell",
+    type=click.Choice(SHELL_CHOICES),
+    default=None,
+    help="Shell for run_command (default: powershell on Windows, bash/sh on POSIX).",
+)
+def workflow_run_cmd(
+    workflow_name: str,
+    arg: str | None,
+    provider: str | None,
+    model: str | None,
+    no_mcp: bool,
+    shell: str | None,
+) -> None:
+    """Run a named workflow sequentially.
+
+    WORKFLOW is the workflow name (stem of the .workflow.md file).
+    ARG is an optional positional argument injected as {{ input }} in step args.
+
+    \b
+    Examples:
+      uio workflow run review-and-fix
+      uio workflow run review-and-fix "owner/repo#42"
+    """
+    cfg = load_config()
+    run_workflow(
+        workflow_name,
+        arg,
+        cfg=cfg,
+        provider=provider,
+        model=model,
+        no_mcp=no_mcp,
+        shell=shell,
+    )
+
+
+@workflow_group.command("list")
+def workflow_list_cmd() -> None:
+    """List all available workflows."""
+    cfg = load_config()
+    workflows_dir = cfg["dirs"]["workflows"]
+    defs = list_definitions(f"{workflows_dir}/*.workflow.md")
+    if not defs:
+        click.echo(f"  No workflows found (expected {workflows_dir}/*.workflow.md).")
+        return
+    rows = []
+    for stem, fm, _ in defs:
+        desc = fm.get("description", "—")
+        steps = fm.get("steps") or []
+        if len(desc) > 64:
+            desc = desc[:61] + "..."
+        rows.append([stem, str(len(steps)), desc])
+    print_definition_table(rows, ["NAME", "STEPS", "DESCRIPTION"])

--- a/uio/config.py
+++ b/uio/config.py
@@ -17,6 +17,7 @@ _DEFAULTS: dict = {
         "agents": ".uio/agents",
         "skills": ".uio/skills",
         "prompts": ".uio/prompts",
+        "workflows": ".uio/workflows",
         "memory": ".uio/memory",
     },
     "runtime": {
@@ -38,10 +39,11 @@ _DEFAULTS: dict = {
 
 _STARTER_TOML = """\
 [dirs]
-agents  = ".uio/agents"
-skills  = ".uio/skills"
-prompts = ".uio/prompts"
-memory  = ".uio/memory"
+agents    = ".uio/agents"
+skills    = ".uio/skills"
+prompts   = ".uio/prompts"
+workflows = ".uio/workflows"
+memory    = ".uio/memory"
 
 [runtime]
 # default_provider = "gemini"

--- a/uio/core/runner.py
+++ b/uio/core/runner.py
@@ -233,7 +233,7 @@ def run_agent(
     routing_chain: list[str] | None = None,
     memory_dir: str | None = None,
     context_max_tokens: int = 8000,
-) -> None:
+) -> str | None:
     if definition_path is None:
         raise ValueError("definition_path must be provided")
     if not os.path.exists(definition_path):
@@ -388,7 +388,7 @@ def run_agent(
                             total_completion,
                             ledger_path,
                         )
-                        return
+                        return response.text or ""
 
                     if guardrail_max_cost is not None:
                         running_cost = estimate_cost_usd(
@@ -451,7 +451,7 @@ def run_agent(
                     total_completion,
                     ledger_path,
                 )
-                return
+                return None
 
             except GuardrailError:
                 raise

--- a/uio/core/workflow.py
+++ b/uio/core/workflow.py
@@ -147,8 +147,15 @@ def run_workflow(
             print(f"\n❌ Workflow halted at step '{step.name}': {exc}", file=sys.stderr)
             raise
 
-        if step.output is not None and result is not None:
-            variables[step.output] = result
-            print(f"  → captured output as '${step.output}'\n")
+        if step.output is not None:
+            if result is not None:
+                variables[step.output] = result
+                print(f"  → captured output as '${step.output}'\n")
+            else:
+                print(
+                    f"  [workflow] Warning: step '{step.name}' produced no output"
+                    f" (iteration cap reached?) — '${step.output}' will be empty\n",
+                    file=sys.stderr,
+                )
 
     print("\n✅ Workflow complete.")

--- a/uio/core/workflow.py
+++ b/uio/core/workflow.py
@@ -1,0 +1,154 @@
+"""Sequential workflow execution for *.workflow.md definitions."""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from dataclasses import dataclass
+
+from uio.schema.parser import parse_definition_file
+
+_VAR_RE = re.compile(r"\{\{\s*(\w+)\s*\}\}")
+_WHEN_RE = re.compile(r"^(\w+)\s+contains\s+(.+)$", re.IGNORECASE)
+
+
+@dataclass
+class WorkflowStep:
+    name: str
+    agent: str | None = None
+    skill: str | None = None
+    arg: str | None = None
+    output: str | None = None
+    when: str | None = None
+
+
+def parse_workflow_steps(frontmatter: dict) -> list[WorkflowStep]:
+    raw = frontmatter.get("steps") or []
+    steps = []
+    for s in raw:
+        if not isinstance(s, dict):
+            continue
+        steps.append(
+            WorkflowStep(
+                name=s.get("name", ""),
+                agent=s.get("agent"),
+                skill=s.get("skill"),
+                arg=s.get("arg"),
+                output=s.get("output"),
+                when=s.get("when"),
+            )
+        )
+    return steps
+
+
+def _interpolate(template: str, variables: dict[str, str]) -> str:
+    def replace(m: re.Match) -> str:
+        return variables.get(m.group(1), m.group(0))
+
+    return _VAR_RE.sub(replace, template)
+
+
+def _eval_when(condition: str, variables: dict[str, str]) -> bool:
+    """Return True when the step should run (condition is satisfied)."""
+    m = _WHEN_RE.match(condition.strip())
+    if not m:
+        print(
+            f"  [workflow] Warning: unrecognised 'when:' syntax: {condition!r}",
+            file=sys.stderr,
+        )
+        return True
+    var_name = m.group(1)
+    substring = m.group(2).strip().strip("\"'")
+    value = variables.get(var_name, "")
+    return substring.lower() in value.lower()
+
+
+def run_workflow(
+    workflow_name: str,
+    arg: str | None,
+    *,
+    cfg: dict,
+    provider: str | None = None,
+    model: str | None = None,
+    no_mcp: bool = False,
+    shell: str | None = None,
+) -> None:
+    from uio.core.runner import GuardrailError, run_agent
+
+    workflows_dir = cfg["dirs"]["workflows"]
+    path = f"{workflows_dir}/{workflow_name}.workflow.md"
+
+    if not os.path.exists(path):
+        sys.exit(f"Error: workflow not found: {path}")
+
+    fm, _ = parse_definition_file(path)
+    steps = parse_workflow_steps(fm)
+
+    if not steps:
+        print("  [workflow] No steps defined. Nothing to do.")
+        return
+
+    variables: dict[str, str] = {"input": arg or ""}
+
+    print(f"\n🔄 Workflow: {fm.get('name', workflow_name)}")
+    print(f"   Steps: {len(steps)}")
+    if arg:
+        print(f"   Input: {arg}")
+    print()
+
+    for i, step in enumerate(steps, 1):
+        print(f"[step {i}/{len(steps)}: {step.name}]")
+
+        if step.when and not _eval_when(step.when, variables):
+            print(f"  Skipped — when: '{step.when}' not satisfied\n")
+            continue
+
+        if step.agent:
+            def_path = f"{cfg['dirs']['agents']}/{step.agent}.agent.md"
+            runner_name = step.agent
+        elif step.skill:
+            def_path = f"{cfg['dirs']['skills']}/{step.skill}.skill.md"
+            runner_name = step.skill
+        else:
+            print(
+                f"  [workflow] Error: step '{step.name}' has neither 'agent' nor 'skill'",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        step_arg = _interpolate(step.arg, variables) if step.arg else arg
+
+        try:
+            result = run_agent(
+                runner_name,
+                step_arg,
+                provider=provider or cfg["runtime"].get("default_provider"),
+                model=model,
+                timeout=cfg["runtime"]["timeout"],
+                no_mcp=no_mcp,
+                mcp_cfg=cfg["mcp"],
+                mcp_plugins=cfg.get("mcp_plugins", []),
+                definition_path=def_path,
+                ledger_path=cfg["runtime"]["cost_ledger"],
+                large_agent_names=cfg["large_agents"]["names"],
+                shell_override=shell,
+                max_iterations=cfg["runtime"]["max_iterations"],
+                max_iterations_large=cfg["runtime"]["max_iterations_large"],
+                anthropic_max_tokens=cfg["runtime"].get("anthropic_max_tokens"),
+                routing_chain=cfg["runtime"].get("routing_chain"),
+                memory_dir=cfg["dirs"]["memory"],
+                context_max_tokens=cfg["runtime"]["context_max_tokens"],
+            )
+        except GuardrailError as exc:
+            print(f"\n❌ Workflow halted at step '{step.name}': guardrail — {exc}", file=sys.stderr)
+            sys.exit(1)
+        except SystemExit as exc:
+            print(f"\n❌ Workflow halted at step '{step.name}': {exc}", file=sys.stderr)
+            raise
+
+        if step.output is not None and result is not None:
+            variables[step.output] = result
+            print(f"  → captured output as '${step.output}'\n")
+
+    print("\n✅ Workflow complete.")

--- a/uio/schema/parser.py
+++ b/uio/schema/parser.py
@@ -228,7 +228,9 @@ def validate_workflow_definition(path: str, frontmatter: dict) -> list[str]:
         if key not in _WORKFLOW_KNOWN_KEYS:
             errors.append(f"{path}: unrecognised workflow frontmatter key '{key}'")
     steps = frontmatter.get("steps")
-    if steps is not None and not isinstance(steps, list):
+    if steps is None:
+        errors.append(f"{path}: missing required field 'steps'")
+    elif not isinstance(steps, list):
         errors.append(f"{path}: 'steps' must be a list, got {type(steps).__name__}")
     return errors
 

--- a/uio/schema/parser.py
+++ b/uio/schema/parser.py
@@ -212,3 +212,46 @@ def check_minimal_body(path: str, body: str) -> list[str]:
     if len(body) < 100:
         return [f"{path}: body is very short ({len(body)} chars); consider adding more detail"]
     return []
+
+
+_WORKFLOW_KNOWN_KEYS = {"name", "description", "steps"}
+_STEP_KNOWN_KEYS = {"name", "agent", "skill", "arg", "output", "when"}
+
+
+def validate_workflow_definition(path: str, frontmatter: dict) -> list[str]:
+    """Return error strings for a *.workflow.md file."""
+    errors = []
+    for field in REQUIRED_FIELDS:
+        if not frontmatter.get(field):
+            errors.append(f"{path}: missing required field '{field}'")
+    for key in frontmatter:
+        if key not in _WORKFLOW_KNOWN_KEYS:
+            errors.append(f"{path}: unrecognised workflow frontmatter key '{key}'")
+    steps = frontmatter.get("steps")
+    if steps is not None and not isinstance(steps, list):
+        errors.append(f"{path}: 'steps' must be a list, got {type(steps).__name__}")
+    return errors
+
+
+def check_workflow_steps(path: str, frontmatter: dict) -> list[str]:
+    """Warn about individual step problems in a *.workflow.md file."""
+    warnings = []
+    steps = frontmatter.get("steps") or []
+    if not isinstance(steps, list):
+        return warnings
+    for i, step in enumerate(steps):
+        if not isinstance(step, dict):
+            warnings.append(f"{path}: step {i + 1} is not a mapping")
+            continue
+        for key in step:
+            if key not in _STEP_KNOWN_KEYS:
+                warnings.append(f"{path}: step {i + 1} has unrecognised key '{key}'")
+        has_agent = "agent" in step
+        has_skill = "skill" in step
+        if has_agent and has_skill:
+            warnings.append(
+                f"{path}: step {i + 1} defines both 'agent' and 'skill' — they are mutually exclusive"
+            )
+        elif not has_agent and not has_skill:
+            warnings.append(f"{path}: step {i + 1} has neither 'agent' nor 'skill'")
+    return warnings


### PR DESCRIPTION
## Summary

- Adds the `*.workflow.md` definition type — a **deterministic pipeline** that chains agents and skills sequentially with `{{ variable }}` interpolation between steps and optional `when: <var> contains <substring>` conditional gating
- Implements `uio workflow run <name> [arg]` and `uio workflow list` CLI commands; extends `uio validate` to check workflow files
- Modifies `run_agent()` to return the final assistant text so workflow steps can thread outputs into subsequent step arguments
- Ships a `definitions/workflows/review-and-fix.workflow.md` example and full documentation update in `docs/02-concepts.md`

## Acceptance criteria covered

- [x] `*.workflow.md` frontmatter (`name`, `description`) and `steps:` block syntax documented in `docs/02-concepts.md`
- [x] Each step supports `name`, `agent`/`skill` (mutually exclusive), `arg` (with `{{ variable }}` interpolation), `output`, and `when:` (string-contains condition)
- [x] `uio workflow run <name> [arg]` executes steps sequentially, injecting the run argument as `{{ input }}`
- [x] `when:` skips a step if the referenced variable does not contain the specified substring (case-insensitive)
- [x] Step failures halt the workflow and print which step failed with its exit reason
- [x] `definitions/workflows/review-and-fix.workflow.md` example demonstrates agent chaining with a conditional step
- [x] `uio workflow list` prints all available workflows with name, step count, and description

## Test plan

- [ ] `pytest tests/test_workflow.py -v` — 27 tests covering parsing, interpolation, `when:` evaluation, schema validation, and the `workflow list` CLI
- [ ] `uio workflow list` in a project with `.uio/workflows/*.workflow.md` files — verify table output
- [ ] `uio workflow run review-and-fix "owner/repo#1"` — verify step sequencing and conditional skip when reviewer output lacks "BLOCKER"
- [ ] `uio validate` in a project with a workflow file — verify errors are surfaced for missing fields and bad step definitions

Closes #163

---
🤖 Generated with [uio AI Coder](https://github.com/jomkz/uio)