### PR TITLE
feat: enhance planner agent with plan action, idempotency, and sub-issue linking

### DIFF
--- a/definitions/agents/planner.agent.md
+++ b/definitions/agents/planner.agent.md
@@ -5,7 +5,7 @@ complexity: large
 capabilities:
   - vcs
 vcs-identity: planner
-argument-hint: "<task-description>"
+argument-hint: "<issue-number-or-description>"
 ---
 
 # Agent: planner
@@ -28,12 +28,12 @@ If no explicit `owner/repo` is provided, derive it from the current working dire
 
 **Plan an issue** — when asked to plan, decompose, or break down an existing issue:
 1. Run `/github-fetch-issue` with `owner/repo` and `issue-number` to get the full body and all comments.
-2. **Idempotency check** — scan existing comments for a prior planning comment (look for a `## Planning comment` heading or a list of child issue links). If one is found, report its URL and stop — do not create duplicate comments or issues.
+2. **Idempotency check** — scan existing comments for a prior planning comment (look for a `## Planning comment` heading or a list of child issue links). If one is found, report its URL and stop. Also search for open issues whose titles match the expected child issue titles (`mcp__mcp-github__search_issues` with `repo:<owner>/<repo> is:open "<title>"`): if matching child issues exist but no planning comment, reuse their URLs and proceed from step 6.
 3. Analyse whether the issue describes decomposable work (large feature, roadmap item, multi-step initiative). If it is already scoped to a single task, fall back to posting a triage comment as in "Comment on an issue".
 4. Propose 3–7 discrete, independently-implementable child issues with explicit dependency ordering.
 5. **Create child issues first** (so their URLs are known before the comment is written) — for each child issue, run `/github-create-issue`. Child issue bodies must include a `Parent issue: #N` line and a `Depends on: #N` line where ordering constraints exist. Collect all created issue URLs.
-6. Post a single planning comment via `/github-post-comment` that includes: triage assessment, sequencing rationale, and a table or list linking every created child issue URL.
-7. **Attempt sub-issue linking (best effort)** — for each created child issue, retrieve its database ID (`gh api repos/<owner>/<repo>/issues/<number> --jq '.id'`) then call `mcp__mcp-github__sub_issue_write` with `method: add`, `issue_number: <parent-number>`, and `sub_issue_id: <child-id>`. If any call returns an error (including 403), add a note to the planning comment ("Sub-issue linking unavailable — child issues reference the parent in their body.") and continue — do not abort.
+6. **Attempt sub-issue linking (best effort)** — for each created child issue, retrieve its database ID (`gh api repos/<owner>/<repo>/issues/<number> --jq '.id'`) then call `mcp__mcp-github__sub_issue_write` with `method: add`, `issue_number: <parent-number>`, and `sub_issue_id: <child-id>`. Note the outcome (success or failure reason) for inclusion in the planning comment — do not abort on error.
+7. Post a single planning comment via `/github-post-comment` that includes: triage assessment, sequencing rationale, a table or list linking every created child issue URL, and a one-line note if sub-issue linking was unavailable.
 8. Report the planning comment URL and stop.
 
 **Comment on an issue** — when the argument references an existing issue URL or `owner/repo#number` for an issue:

--- a/definitions/agents/planner.agent.md
+++ b/definitions/agents/planner.agent.md
@@ -26,6 +26,16 @@ If no explicit `owner/repo` is provided, derive it from the current working dire
 2. Run `/github-create-issue` with `owner/repo`, `title`, and `body`.
 3. Report the created issue URL and stop.
 
+**Plan an issue** — when asked to plan, decompose, or break down an existing issue:
+1. Run `/github-fetch-issue` with `owner/repo` and `issue-number` to get the full body and all comments.
+2. **Idempotency check** — scan existing comments for a prior planning comment (look for a `## Planning comment` heading or a list of child issue links). If one is found, report its URL and stop — do not create duplicate comments or issues.
+3. Analyse whether the issue describes decomposable work (large feature, roadmap item, multi-step initiative). If it is already scoped to a single task, fall back to posting a triage comment as in "Comment on an issue".
+4. Propose 3–7 discrete, independently-implementable child issues with explicit dependency ordering.
+5. **Create child issues first** (so their URLs are known before the comment is written) — for each child issue, run `/github-create-issue`. Child issue bodies must include a `Parent issue: #N` line and a `Depends on: #N` line where ordering constraints exist. Collect all created issue URLs.
+6. Post a single planning comment via `/github-post-comment` that includes: triage assessment, sequencing rationale, and a table or list linking every created child issue URL.
+7. **Attempt sub-issue linking (best effort)** — for each created child issue, retrieve its database ID (`gh api repos/<owner>/<repo>/issues/<number> --jq '.id'`) then call `mcp__mcp-github__sub_issue_write` with `method: add`, `issue_number: <parent-number>`, and `sub_issue_id: <child-id>`. If any call returns an error (including 403), add a note to the planning comment ("Sub-issue linking unavailable — child issues reference the parent in their body.") and continue — do not abort.
+8. Report the planning comment URL and stop.
+
 **Comment on an issue** — when the argument references an existing issue URL or `owner/repo#number` for an issue:
 1. Run `/github-fetch-issue` with `owner/repo` and `issue-number` to fetch the title, body, and all comments.
 2. Draft a substantive comment: triage assessment, next-step proposal, or analysis as appropriate.
@@ -44,7 +54,7 @@ If no explicit `owner/repo` is provided, derive it from the current working dire
 3. Produce a structured Markdown summary with: milestone goal, open vs closed counts, blockers, PRs awaiting review, and a recommended next action.
 4. Print the summary and stop.
 
-**Decompose work into child issues** — when the argument describes a large feature to break down:
+**Decompose work into child issues** — when the argument directly describes a large feature to break down (not referencing an existing issue):
 1. Analyse the feature description.
 2. Propose 3–7 discrete, independently-implementable child issues.
 3. For each child issue, run `/github-create-issue` with `owner/repo`, `title`, and `body`.
@@ -54,6 +64,7 @@ If no explicit `owner/repo` is provided, derive it from the current working dire
 
 - Issue titles must be specific and actionable (no "Fix bug" or "Improve something").
 - Issue bodies must include: **Context**, **Goal**, and **Acceptance Criteria** sections.
+- Child issues created during planning must include a `Parent issue: #N` line and a `Depends on: #N` line where ordering constraints exist.
 - PR comments must cite specific file names or line numbers when discussing code.
 - Do not speculate — only report facts visible from the data you fetch.
 

--- a/definitions/prompts/implement-issue.prompt.md
+++ b/definitions/prompts/implement-issue.prompt.md
@@ -4,6 +4,6 @@ description: Implement a GitHub issue by creating a branch, applying code change
 argument-hint: "<issue-number> [| repo: <owner>/<repo>] [| branch: <name>] [| base: <branch>]"
 ---
 
-Read `definitions/agents/coder.agent.md` and execute the workflow with this argument:
+Use the coder agent to implement the issue described in the argument.
 
 $ARGUMENTS

--- a/definitions/prompts/mcp-smoke-test.prompt.md
+++ b/definitions/prompts/mcp-smoke-test.prompt.md
@@ -4,6 +4,6 @@ description: Probe all configured MCP servers and report which ones are reachabl
 argument-hint: "[server-name ...]"
 ---
 
-Read `definitions/agents/mcp-smoke-test.agent.md` and execute the workflow with this argument:
+Use the mcp-smoke-test agent to probe all configured MCP servers described in the argument.
 
 $ARGUMENTS

--- a/definitions/prompts/plan-issue.prompt.md
+++ b/definitions/prompts/plan-issue.prompt.md
@@ -1,9 +1,11 @@
 ---
 name: plan-issue
-description: Create issues, comment on issues/PRs, and summarize project status using the AI Planner identity.
-argument-hint: "<task-description>"
+description: Fetch an issue, triage it, create child issues if applicable, and post a planning comment.
+argument-hint: "<issue-number-or-description>"
 ---
 
-Read `definitions/agents/planner.agent.md` and execute the workflow with this argument:
+Use the planner agent to plan the issue described in the argument: fetch it, triage it,
+create child issues if the issue describes decomposable work, and post a single planning
+comment that links the created issues.
 
 $ARGUMENTS

--- a/definitions/prompts/review-issue.prompt.md
+++ b/definitions/prompts/review-issue.prompt.md
@@ -4,6 +4,6 @@ description: Review a pull request and post structured review comments using the
 argument-hint: "<pr-url-or-owner/repo#number>"
 ---
 
-Read `definitions/agents/reviewer.agent.md` and execute the workflow with this argument:
+Use the reviewer agent to review the pull request described in the argument.
 
 $ARGUMENTS


### PR DESCRIPTION
## Summary

- **New "Plan an issue" action** in `planner.agent.md`: creates child issues first (so their URLs are known), then posts a single planning comment linking all of them — eliminating the two-step interaction where the user had to ask separately for child issue creation
- **Idempotency check**: scans existing comments for a prior `## Planning comment` heading before creating issues or posting again, so re-running `/plan-issue <N>` on the same issue is safe
- **Best-effort sub-issue linking**: after creating child issues, attempts `mcp__mcp-github__sub_issue_write` for each and handles 403 gracefully (notes it in the comment, does not abort)
- **Natural-language prompt bodies**: all four prompt definitions (`plan-issue`, `implement-issue`, `review-issue`, `mcp-smoke-test`) now say "Use the X agent to..." instead of hardcoding `Read \`definitions/agents/*.agent.md\`` — a path that only exists in this repo, not in a user's `.uio/` directory

## Test plan

- [ ] `uio validate` passes with no new errors
- [ ] 491 non-integration tests pass
- [ ] `/plan-issue <number>` on an issue describing decomposable work creates child issues and posts a single comment linking them in one run
- [ ] Running `/plan-issue <number>` a second time on the same issue stops after finding the existing planning comment
- [ ] Prompt files no longer reference `definitions/agents/` paths

Closes #174

---
> 🤖 Generated with [uio](https://github.com/jomkz/uio) using the AI Coder identity.