### PR TITLE
refactor: extract KNOWN_ROLES to uio/core/identities.py

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -340,3 +340,15 @@ def test_check_skill_references_ignores_numeric_segments(tmp_path):
     body = "See issue /42 and PR /123 for context."
     warnings = check_skill_references("agent.agent.md", body, str(skills_dir))
     assert warnings == []
+
+
+def test_validate_no_vcs_identity_does_not_import_github_app(tmp_path):
+    """validate_definition on a definition with no vcs-identity must not load github_app."""
+    import sys
+
+    sys.modules.pop("uio.core.github_app", None)
+    f = tmp_path / "test.agent.md"
+    f.write_text("---\nname: test\ndescription: test\n---\n# Agent: test\n")
+    fm, _ = parse_definition_file(str(f))
+    validate_definition(str(f), fm)
+    assert "uio.core.github_app" not in sys.modules

--- a/uio/core/github_app.py
+++ b/uio/core/github_app.py
@@ -25,14 +25,14 @@ from typing import Final
 
 import jwt
 
+from uio.core.identities import KNOWN_ROLES as KNOWN_ROLES  # re-export for back-compat
+
 # GitHub issues JWTs that expire at most 10 minutes from now.
 # Use 9 minutes to leave a safe margin.
 _JWT_LIFETIME_SECONDS: Final = 540
 
 # Installation tokens are valid for 1 hour; refresh 60 s before expiry.
 _TOKEN_REFRESH_BUFFER_SECONDS: Final = 60
-
-KNOWN_ROLES: Final = ("planner", "coder", "reviewer")
 
 
 class GitHubAppError(RuntimeError):

--- a/uio/core/identities.py
+++ b/uio/core/identities.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Final, Literal
 
+__all__ = ["KNOWN_ROLES", "IdentityRole"]
+
 KNOWN_ROLES: Final = ("planner", "coder", "reviewer")
 
 IdentityRole = Literal["planner", "coder", "reviewer"]

--- a/uio/core/identities.py
+++ b/uio/core/identities.py
@@ -1,0 +1,9 @@
+"""Framework-level identity names for VCS agent roles."""
+
+from __future__ import annotations
+
+from typing import Final, Literal
+
+KNOWN_ROLES: Final = ("planner", "coder", "reviewer")
+
+IdentityRole = Literal["planner", "coder", "reviewer"]

--- a/uio/core/runner.py
+++ b/uio/core/runner.py
@@ -12,11 +12,11 @@ from uio import __version__
 from uio.core.attribution import build_attribution_instructions
 from uio.core.clients import make_client, probe_tool_calling
 from uio.core.github_app import (
-    KNOWN_ROLES,
     GitHubAppError,
     env_vars_present,
     get_token_for_identity,
 )
+from uio.core.identities import KNOWN_ROLES
 from uio.core.ledger import DEFAULT_LEDGER_PATH, estimate_cost_usd, write_cost_ledger
 from uio.core.mcp import make_mcp_clients
 from uio.core.memory import build_memory_section, clear_session_memory

--- a/uio/schema/parser.py
+++ b/uio/schema/parser.py
@@ -65,7 +65,7 @@ def validate_definition(path: str, frontmatter: dict) -> list[str]:
     # vcs-identity validation
     vcs_identity = frontmatter.get("vcs-identity")
     if vcs_identity is not None:
-        from uio.core.github_app import KNOWN_ROLES
+        from uio.core.identities import KNOWN_ROLES
 
         if vcs_identity not in KNOWN_ROLES:
             errors.append(
@@ -76,7 +76,7 @@ def validate_definition(path: str, frontmatter: dict) -> list[str]:
     # github-identity is the deprecated predecessor of vcs-identity
     identity = frontmatter.get("github-identity")
     if identity is not None:
-        from uio.core.github_app import KNOWN_ROLES
+        from uio.core.identities import KNOWN_ROLES
 
         if identity not in KNOWN_ROLES:
             errors.append(
@@ -93,7 +93,7 @@ def check_identity_env(path: str, frontmatter: dict) -> list[str]:
     Non-fatal — the agent can still run using the fallback credential.
     Checks ``vcs-identity`` first, then the deprecated ``github-identity``.
     """
-    from uio.core.github_app import KNOWN_ROLES, env_vars_present
+    from uio.core.identities import KNOWN_ROLES
 
     identity = frontmatter.get("vcs-identity") or frontmatter.get("github-identity")
     if not identity or identity not in KNOWN_ROLES:
@@ -103,6 +103,8 @@ def check_identity_env(path: str, frontmatter: dict) -> list[str]:
     if provider != "github":
         # Non-GitHub providers use different env vars; skip this check for now.
         return []
+
+    from uio.core.github_app import env_vars_present
 
     if not env_vars_present(identity):
         role_upper = identity.upper()

--- a/uio/schema/parser.py
+++ b/uio/schema/parser.py
@@ -7,6 +7,8 @@ import re
 
 import yaml
 
+from uio.core.identities import KNOWN_ROLES
+
 _FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n(.*)", re.DOTALL)
 
 REQUIRED_FIELDS = ("name", "description")
@@ -65,8 +67,6 @@ def validate_definition(path: str, frontmatter: dict) -> list[str]:
     # vcs-identity validation
     vcs_identity = frontmatter.get("vcs-identity")
     if vcs_identity is not None:
-        from uio.core.identities import KNOWN_ROLES
-
         if vcs_identity not in KNOWN_ROLES:
             errors.append(
                 f"{path}: invalid 'vcs-identity' value '{vcs_identity}'"
@@ -76,8 +76,6 @@ def validate_definition(path: str, frontmatter: dict) -> list[str]:
     # github-identity is the deprecated predecessor of vcs-identity
     identity = frontmatter.get("github-identity")
     if identity is not None:
-        from uio.core.identities import KNOWN_ROLES
-
         if identity not in KNOWN_ROLES:
             errors.append(
                 f"{path}: invalid 'github-identity' value '{identity}'"
@@ -93,8 +91,6 @@ def check_identity_env(path: str, frontmatter: dict) -> list[str]:
     Non-fatal — the agent can still run using the fallback credential.
     Checks ``vcs-identity`` first, then the deprecated ``github-identity``.
     """
-    from uio.core.identities import KNOWN_ROLES
-
     identity = frontmatter.get("vcs-identity") or frontmatter.get("github-identity")
     if not identity or identity not in KNOWN_ROLES:
         return []


### PR DESCRIPTION
## Summary

- Adds `uio/core/identities.py` defining `KNOWN_ROLES` and `IdentityRole` — framework-level identity names that have no dependency on GitHub-specific code
- Updates `uio/core/github_app.py` to re-export `KNOWN_ROLES` from `uio.core.identities` for backwards compatibility
- Updates `uio/schema/parser.py` and `uio/core/runner.py` to import `KNOWN_ROLES` from `uio.core.identities` directly
- Restructures `check_identity_env` in `parser.py` so the `github_app` import is deferred until after the early-return guard — `uio validate` on a definition without `vcs-identity` no longer loads the GitHub App module

## Test plan

- [ ] `uio validate` on a definition with no `vcs-identity` field completes without importing `github_app`
- [ ] `uio validate` on a definition with an invalid `vcs-identity` still reports the correct error
- [ ] `uio validate` on a definition with a valid `vcs-identity` but missing env vars still warns correctly
- [ ] All 491 existing unit tests pass (`pytest -m "not integration"`)
- [ ] `ruff format --check .` and `ruff check .` pass with no errors

Closes #171

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)