### PR TITLE
fix: correct token double-counting in chat tool loop and respect explicit routing_chain

### DIFF
--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,0 +1,78 @@
+"""Tests for chat module token accumulation in _inner_tool_loop."""
+
+from unittest.mock import MagicMock, patch
+
+from uio.cli.chat import _inner_tool_loop
+from uio.core.clients import LLMResponse, TokenUsage
+from uio.core.tools import ToolCall
+
+
+def _resp(text=None, tool_calls=None, prompt=0, completion=0):
+    return LLMResponse(
+        text=text,
+        tool_calls=tool_calls or [],
+        usage=TokenUsage(prompt_tokens=prompt, completion_tokens=completion),
+    )
+
+
+def test_inner_tool_loop_includes_final_response_usage_in_totals():
+    """ep/ec must include the final response's usage so callers must not add it again."""
+    tool_call = ToolCall(name="run_command", args={"command": "echo hi"}, call_id="tc-1")
+    initial = _resp(tool_calls=[tool_call], prompt=10, completion=5)
+    final = _resp(text="done", prompt=20, completion=8)
+
+    client = MagicMock()
+    history = [{"role": "user", "content": "hi"}]
+
+    with (
+        patch("uio.cli.chat._stream_turn", return_value=final),
+        patch("uio.cli.chat.execute_tool", return_value="output"),
+        patch("uio.cli.chat._approval_gate", return_value=True),
+        patch("uio.cli.chat.click"),
+    ):
+        response, ep, ec = _inner_tool_loop(
+            client,
+            history,
+            "system",
+            initial,
+            auto_approve=True,
+            allow_globs=(),
+            deny_globs=(),
+            timeout=60,
+        )
+
+    assert response is final
+    assert ep == 20
+    assert ec == 8
+
+
+def test_inner_tool_loop_accumulates_multiple_inner_turns():
+    """ep/ec sums usage across all inner turns when there are multiple tool round-trips."""
+    tool_call = ToolCall(name="run_command", args={"command": "echo hi"}, call_id="tc-1")
+    initial = _resp(tool_calls=[tool_call], prompt=10, completion=5)
+    intermediate = _resp(tool_calls=[tool_call], prompt=15, completion=6)
+    final = _resp(text="done", prompt=20, completion=8)
+
+    client = MagicMock()
+    history = [{"role": "user", "content": "hi"}]
+
+    with (
+        patch("uio.cli.chat._stream_turn", side_effect=[intermediate, final]),
+        patch("uio.cli.chat.execute_tool", return_value="output"),
+        patch("uio.cli.chat._approval_gate", return_value=True),
+        patch("uio.cli.chat.click"),
+    ):
+        response, ep, ec = _inner_tool_loop(
+            client,
+            history,
+            "system",
+            initial,
+            auto_approve=True,
+            allow_globs=(),
+            deny_globs=(),
+            timeout=60,
+        )
+
+    assert response is final
+    assert ep == 15 + 20
+    assert ec == 6 + 8

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -2,7 +2,9 @@
 
 from unittest.mock import MagicMock, patch
 
-from uio.cli.chat import _inner_tool_loop
+from click.testing import CliRunner
+
+from uio.cli.chat import _inner_tool_loop, chat_cmd
 from uio.core.clients import LLMResponse, TokenUsage
 from uio.core.tools import ToolCall
 
@@ -76,3 +78,79 @@ def test_inner_tool_loop_accumulates_multiple_inner_turns():
     assert response is final
     assert ep == 15 + 20
     assert ec == 6 + 8
+
+
+def test_inner_tool_loop_none_usage_does_not_raise_and_leaves_totals_zero():
+    """The usage=None guard at line 227 of chat.py must not raise and must leave ep/ec at 0."""
+    tool_call = ToolCall(name="run_command", args={"command": "echo hi"}, call_id="tc-1")
+    initial = _resp(tool_calls=[tool_call])
+    final = LLMResponse(text="done", tool_calls=[], usage=None)
+
+    client = MagicMock()
+    history = [{"role": "user", "content": "hi"}]
+
+    with (
+        patch("uio.cli.chat._stream_turn", return_value=final),
+        patch("uio.cli.chat.execute_tool", return_value="output"),
+        patch("uio.cli.chat._approval_gate", return_value=True),
+        patch("uio.cli.chat.click"),
+    ):
+        response, ep, ec = _inner_tool_loop(
+            client,
+            history,
+            "system",
+            initial,
+            auto_approve=True,
+            allow_globs=(),
+            deny_globs=(),
+            timeout=60,
+        )
+
+    assert response is final
+    assert ep == 0
+    assert ec == 0
+
+
+def test_chat_cmd_accumulation_no_double_count():
+    """total_prompt/completion must equal initial_usage + ep/ec, not + final_usage again."""
+    tool_call = ToolCall(name="run_command", args={"command": "ls"}, call_id="tc-1")
+    initial_response = LLMResponse(
+        text=None,
+        tool_calls=[tool_call],
+        usage=TokenUsage(prompt_tokens=10, completion_tokens=5),
+    )
+    final_response = LLMResponse(
+        text="done",
+        tool_calls=[],
+        usage=TokenUsage(prompt_tokens=20, completion_tokens=8),
+    )
+    ep, ec = 20, 8  # final_response's usage is already inside ep/ec
+
+    captured: dict = {}
+
+    def fake_show_cost(provider, model, p, c):
+        captured["prompt"] = p
+        captured["completion"] = c
+
+    runner = CliRunner()
+    with (
+        patch(
+            "uio.cli.chat.load_config",
+            return_value={
+                "runtime": {"timeout": 60, "cost_ledger": None, "default_provider": None}
+            },
+        ),
+        patch("uio.cli.chat.select_provider_chain", return_value=["ollama"]),
+        patch("uio.cli.chat.select_model", return_value="test-model"),
+        patch("uio.cli.chat.make_client", return_value=MagicMock()),
+        patch("builtins.input", side_effect=["hello", EOFError()]),
+        patch("uio.cli.chat._stream_turn", return_value=initial_response),
+        patch("uio.cli.chat._inner_tool_loop", return_value=(final_response, ep, ec)),
+        patch("uio.cli.chat._show_session_cost", side_effect=fake_show_cost),
+        patch("uio.cli.chat.write_cost_ledger"),
+    ):
+        runner.invoke(chat_cmd, ["--tools"])
+
+    # Must be initial (10/5) + loop ep/ec (20/8) = 30/13, not 50/21 (double-counted)
+    assert captured.get("prompt") == 30
+    assert captured.get("completion") == 13

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -260,6 +260,13 @@ def test_provider_chain_custom_chain_preserves_order(monkeypatch):
     assert chain.index("gemini") < chain.index("openai") < chain.index("ollama")
 
 
+def test_provider_chain_no_ollama_fallback_when_chain_excludes_ollama(monkeypatch):
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    chain = select_provider_chain(None, routing_chain=["gemini", "openai"])
+    assert chain == []
+
+
 # ── estimate_cost_usd ──────────────────────────────────────────────────────────
 
 

--- a/uio/cli/chat.py
+++ b/uio/cli/chat.py
@@ -411,9 +411,6 @@ def chat_cmd(
             )
             total_prompt += ep
             total_completion += ec
-            if response.usage:
-                total_prompt += response.usage.prompt_tokens
-                total_completion += response.usage.completion_tokens
 
         history.append(_assistant_turn(client, response.text or ""))
         click.echo()

--- a/uio/core/routing.py
+++ b/uio/core/routing.py
@@ -74,8 +74,8 @@ def select_provider_chain(
         key_env = PROVIDER_KEY_ENV[p]
         if key_env is None or os.environ.get(key_env):
             available.append(p)
-    # For small complexity, always fall back to Ollama if nothing else is available.
+    # For small complexity, fall back to Ollama only when it is in the active chain.
     # For large complexity, Ollama is excluded — an empty list tells the runner to exit cleanly.
-    if not available and complexity != "large":
+    if not available and complexity != "large" and "ollama" in chain:
         return ["ollama"]
     return available


### PR DESCRIPTION
## Summary

- **Bug 1 — Token double-counting (`uio/cli/chat.py`):** After `_inner_tool_loop` returns, `chat_cmd` was adding `response.usage` a second time even though the final response's token counts are already accumulated inside `ep`/`ec` by the loop itself. The duplicate `if response.usage:` block (3 lines) has been removed.
- **Bug 2 — Ollama fallback ignores explicit `routing_chain` (`uio/core/routing.py`):** The small-complexity fallback to `["ollama"]` fired unconditionally when the active chain yielded no available providers, even when `"ollama"` was not in the user-configured `routing_chain`. The guard now checks `"ollama" in chain` before falling back.
- **Tests:** Added `tests/test_chat.py` with two tests verifying `_inner_tool_loop` includes the final response's usage in `ep`/`ec`; added `test_provider_chain_no_ollama_fallback_when_chain_excludes_ollama` to `test_routing.py`.

## Test plan

- [ ] `pytest tests/test_routing.py tests/test_clients.py tests/test_chat.py` — all 85 tests pass
- [ ] Run `uio chat --tools` with a session that triggers at least one tool call; verify `/cost` shows a realistic (non-doubled) token count
- [ ] Set `routing_chain = ["gemini", "openai"]` in `uio.toml` with no cloud API keys; verify `uio` exits cleanly rather than routing to Ollama

Closes #184

---
> 🤖 Generated by [uio AI Coder](https://github.com/jomkz/uio)