### PR TITLE
fix(runner): inject VCS alias table when capabilities: [vcs] is declared

### DIFF
--- a/tests/test_runner_retry.py
+++ b/tests/test_runner_retry.py
@@ -102,3 +102,53 @@ class TestChatRetry:
         # chat was called once on gemini (no retry), then succeeded on openai
         assert mock_client.chat.call_count == 1
         assert second_client.chat.call_count == 1
+
+
+class TestVcsAliasPreamble:
+    """Verify that the VCS alias table is injected based on capabilities, not only vcs-identity."""
+
+    def _make_run_args(self, tmp_path, frontmatter_extra: str = ""):
+        defn = tmp_path / "test.agent.md"
+        defn.write_text(f"---\nname: test-agent\n{frontmatter_extra}---\nDo the task.\n")
+        return {
+            "agent_name": "test-agent",
+            "definition_path": str(defn),
+            "no_mcp": True,
+            "ledger_path": str(tmp_path / "ledger.jsonl"),
+        }
+
+    def _run_and_capture_system(self, tmp_path, frontmatter_extra: str = "") -> str:
+        from uio.core.clients import LLMResponse
+        from uio.core.runner import run_agent
+
+        terminal = LLMResponse(text="Done.", tool_calls=[])
+        captured: dict[str, str] = {}
+
+        mock_client = MagicMock()
+        mock_client.build_history.return_value = [{"role": "user", "content": "begin"}]
+
+        def chat_capture(**kwargs):
+            captured["system"] = kwargs.get("system", "")
+            return terminal
+
+        mock_client.chat.side_effect = chat_capture
+        mock_client.usage = None
+
+        with (
+            patch("uio.core.runner.make_client", return_value=mock_client),
+            patch("uio.core.runner.select_provider_chain", return_value=["gemini"]),
+        ):
+            run_agent(**self._make_run_args(tmp_path, frontmatter_extra))
+
+        return captured.get("system", "")
+
+    def test_capabilities_vcs_injects_alias_table(self, tmp_path):
+        """capabilities: [vcs] without vcs-identity should include the VCS alias table."""
+        system = self._run_and_capture_system(tmp_path, "capabilities: [vcs]\n")
+        assert "VCS Tool Aliases" in system
+        assert "vcs__list_issues" in system
+
+    def test_no_vcs_capability_omits_alias_table(self, tmp_path):
+        """An agent with neither capabilities nor vcs-identity should not get the alias table."""
+        system = self._run_and_capture_system(tmp_path)
+        assert "VCS Tool Aliases" not in system

--- a/tests/test_runner_retry.py
+++ b/tests/test_runner_retry.py
@@ -152,3 +152,29 @@ class TestVcsAliasPreamble:
         """An agent with neither capabilities nor vcs-identity should not get the alias table."""
         system = self._run_and_capture_system(tmp_path)
         assert "VCS Tool Aliases" not in system
+
+    def test_vcs_identity_still_injects_alias_table(self, tmp_path):
+        """vcs-identity path continues to inject the alias table (regression guard)."""
+        from uio.core.clients import LLMResponse
+        from uio.core.runner import run_agent
+
+        terminal = LLMResponse(text="Done.", tool_calls=[])
+        captured: dict[str, str] = {}
+
+        mock_client = MagicMock()
+        mock_client.build_history.return_value = [{"role": "user", "content": "begin"}]
+
+        def chat_capture(**kwargs):
+            captured["system"] = kwargs.get("system", "")
+            return terminal
+
+        mock_client.chat.side_effect = chat_capture
+
+        with (
+            patch("uio.core.runner.make_client", return_value=mock_client),
+            patch("uio.core.runner.select_provider_chain", return_value=["gemini"]),
+            patch("uio.core.runner._inject_vcs_identity", return_value="coder"),
+        ):
+            run_agent(**self._make_run_args(tmp_path))
+
+        assert "VCS Tool Aliases" in captured.get("system", "")

--- a/uio/core/runner.py
+++ b/uio/core/runner.py
@@ -266,9 +266,9 @@ def run_agent(
     for name in failed:
         del mcp_clients[name]
 
-    # Determine VCS provider for tool alias injection (only when a vcs-identity is active).
+    # Inject the alias table when vcs-identity is set OR when capabilities includes "vcs".
     vcs_provider: str | None = None
-    if role in KNOWN_ROLES:
+    if role in KNOWN_ROLES or "vcs" in (frontmatter.get("capabilities") or []):
         vcs_provider = frontmatter.get("vcs-provider", "github")
 
     preamble = _build_preamble(bool(mcp_clients), shell_override, vcs_provider)

--- a/uio/core/runner.py
+++ b/uio/core/runner.py
@@ -267,8 +267,11 @@ def run_agent(
         del mcp_clients[name]
 
     # Inject the alias table when vcs-identity is set OR when capabilities includes "vcs".
+    _caps = frontmatter.get("capabilities") or []
+    if isinstance(_caps, str):
+        _caps = [_caps]
     vcs_provider: str | None = None
-    if role in KNOWN_ROLES or "vcs" in (frontmatter.get("capabilities") or []):
+    if role in KNOWN_ROLES or "vcs" in _caps:
         vcs_provider = frontmatter.get("vcs-provider", "github")
 
     preamble = _build_preamble(bool(mcp_clients), shell_override, vcs_provider)


### PR DESCRIPTION
## Summary

- Decouples VCS tool alias table injection from the `vcs-identity` system
- Previously, the alias preamble (mapping `vcs__*` names to concrete MCP tool names) was only injected when `vcs-identity` was set; agents with `capabilities: [vcs]` but no identity received nothing
- Now `vcs_provider` is resolved whenever `capabilities` includes `"vcs"` **or** `vcs-identity` is set — matching the documented intent of the `capabilities` field
- Adds two unit tests verifying the positive and negative cases

## Test plan

- [ ] `pytest tests/test_runner_retry.py::TestVcsAliasPreamble` — new tests pass
- [ ] `pytest -m "not integration"` — full suite (527 tests) passes
- [ ] `ruff format --check . && ruff check .` — no lint errors
- [ ] Create an agent definition with `capabilities: [vcs]` and no `vcs-identity`, run it, confirm the system prompt contains the VCS alias table

Closes #185

---
🤖 Generated with [uio AI Coder](https://github.com/jomkz/uio)