### PR TITLE
fix(chat): implement streaming for AnthropicClient

### DIFF
--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
 
-from uio.cli.chat import _inner_tool_loop, chat_cmd
+from uio.cli.chat import _inner_tool_loop, _stream_anthropic, chat_cmd
 from uio.core.clients import LLMResponse, TokenUsage
 from uio.core.tools import ToolCall
 
@@ -154,3 +154,40 @@ def test_chat_cmd_accumulation_no_double_count():
     # Must be initial (10/5) + loop ep/ec (20/8) = 30/13, not 50/21 (double-counted)
     assert captured.get("prompt") == 30
     assert captured.get("completion") == 13
+
+
+def test_stream_anthropic_streams_text_updates_raw_content_and_returns_response():
+    """_stream_anthropic echoes text chunks and returns a populated LLMResponse."""
+    from uio.core.clients import AnthropicClient
+
+    with patch("anthropic.Anthropic"):
+        client = AnthropicClient(model="claude-test", tools=[])
+
+    fake_text_block = MagicMock()
+    fake_text_block.type = "text"
+    fake_text_block.text = "Hello, world!"
+
+    fake_usage = MagicMock()
+    fake_usage.input_tokens = 12
+    fake_usage.output_tokens = 7
+
+    fake_msg = MagicMock()
+    fake_msg.content = [fake_text_block]
+    fake_msg.usage = fake_usage
+
+    stream_ctx = MagicMock()
+    stream_ctx.__enter__ = MagicMock(return_value=stream_ctx)
+    stream_ctx.__exit__ = MagicMock(return_value=False)
+    stream_ctx.text_stream = ["Hello, ", "world!"]
+    stream_ctx.get_final_message = MagicMock(return_value=fake_msg)
+    client._client.messages.stream = MagicMock(return_value=stream_ctx)
+
+    with patch("uio.cli.chat.click") as mock_click:
+        result = _stream_anthropic(client, "system", [{"role": "user", "content": "hi"}])
+
+    assert result.text == "Hello, world!"
+    assert result.tool_calls == []
+    assert result.usage == TokenUsage(prompt_tokens=12, completion_tokens=7)
+    mock_click.echo.assert_any_call("Hello, ", nl=False)
+    mock_click.echo.assert_any_call("world!", nl=False)
+    assert client._last_raw_content == [{"type": "text", "text": "Hello, world!"}]

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -191,3 +191,50 @@ def test_stream_anthropic_streams_text_updates_raw_content_and_returns_response(
     mock_click.echo.assert_any_call("Hello, ", nl=False)
     mock_click.echo.assert_any_call("world!", nl=False)
     assert client._last_raw_content == [{"type": "text", "text": "Hello, world!"}]
+
+
+def test_stream_anthropic_tool_use_block_builds_calls_and_raw_content():
+    """_stream_anthropic correctly extracts tool_use blocks from the final message."""
+    from uio.core.clients import AnthropicClient
+
+    with patch("anthropic.Anthropic"):
+        client = AnthropicClient(model="claude-test", tools=[])
+
+    fake_tool_block = MagicMock()
+    fake_tool_block.type = "tool_use"
+    fake_tool_block.id = "call-123"
+    fake_tool_block.name = "run_command"
+    fake_tool_block.input = {"command": "echo hi"}
+
+    fake_usage = MagicMock()
+    fake_usage.input_tokens = 8
+    fake_usage.output_tokens = 3
+
+    fake_msg = MagicMock()
+    fake_msg.content = [fake_tool_block]
+    fake_msg.usage = fake_usage
+
+    stream_ctx = MagicMock()
+    stream_ctx.__enter__ = MagicMock(return_value=stream_ctx)
+    stream_ctx.__exit__ = MagicMock(return_value=False)
+    stream_ctx.text_stream = []
+    stream_ctx.get_final_message = MagicMock(return_value=fake_msg)
+    client._client.messages.stream = MagicMock(return_value=stream_ctx)
+
+    with patch("uio.cli.chat.click"):
+        result = _stream_anthropic(client, "system", [{"role": "user", "content": "hi"}])
+
+    assert result.text is None
+    assert len(result.tool_calls) == 1
+    assert result.tool_calls[0] == ToolCall(
+        name="run_command", args={"command": "echo hi"}, call_id="call-123"
+    )
+    assert result.usage == TokenUsage(prompt_tokens=8, completion_tokens=3)
+    assert client._last_raw_content == [
+        {
+            "type": "tool_use",
+            "id": "call-123",
+            "name": "run_command",
+            "input": {"command": "echo hi"},
+        }
+    ]

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -15,7 +15,7 @@ from uio.core.clients import (
     OpenAIClient,
     _ANTHROPIC_DEFAULT_MAX_TOKENS,
     _sanitize_schema_for_gemini,
-    _serialize_anthropic_block,
+    serialize_anthropic_block,
     _to_anthropic_tool,
 )
 from uio.core.tools import ToolCall
@@ -320,7 +320,7 @@ def test_anthropic_append_turn_without_raw_content_falls_back_to_response():
     assert history[1]["content"] == [{"type": "text", "text": "Done."}]
 
 
-# ── _serialize_anthropic_block ────────────────────────────────────────────────
+# ── serialize_anthropic_block ─────────────────────────────────────────────────
 
 
 def _block(type_: str, **kwargs):
@@ -329,12 +329,12 @@ def _block(type_: str, **kwargs):
 
 def test_serialize_text_block():
     block = _block("text", text="hello")
-    assert _serialize_anthropic_block(block) == {"type": "text", "text": "hello"}
+    assert serialize_anthropic_block(block) == {"type": "text", "text": "hello"}
 
 
 def test_serialize_tool_use_block():
     block = _block("tool_use", id="toolu_01", name="run_command", input={"command": "ls"})
-    result = _serialize_anthropic_block(block)
+    result = serialize_anthropic_block(block)
     assert result == {
         "type": "tool_use",
         "id": "toolu_01",
@@ -345,18 +345,18 @@ def test_serialize_tool_use_block():
 
 def test_serialize_thinking_block():
     block = _block("thinking", thinking="I think...", signature="sig_xyz")
-    result = _serialize_anthropic_block(block)
+    result = serialize_anthropic_block(block)
     assert result == {"type": "thinking", "thinking": "I think...", "signature": "sig_xyz"}
 
 
 def test_serialize_redacted_thinking_block():
     block = _block("redacted_thinking", data="<redacted>")
-    assert _serialize_anthropic_block(block) == {"type": "redacted_thinking", "data": "<redacted>"}
+    assert serialize_anthropic_block(block) == {"type": "redacted_thinking", "data": "<redacted>"}
 
 
 def test_serialize_unknown_block_type():
     block = _block("future_type")
-    assert _serialize_anthropic_block(block) == {"type": "future_type"}
+    assert serialize_anthropic_block(block) == {"type": "future_type"}
 
 
 # ── AnthropicClient max_tokens / complexity ───────────────────────────────────

--- a/uio/cli/chat.py
+++ b/uio/cli/chat.py
@@ -13,7 +13,7 @@ from uio.core.clients import (
     GeminiClient,
     LLMClient,
     LLMResponse,
-    _serialize_anthropic_block,
+    serialize_anthropic_block,
     make_client,
     OpenAIClient,
     TokenUsage,
@@ -164,12 +164,18 @@ def _stream_anthropic(client: LLMClient, system: str, history: list) -> LLMRespo
     text_chunks: list[str] = []
     usage: TokenUsage | None = None
 
+    stream_kwargs: dict = {}
+    if client._complexity == "large":
+        budget = min(10000, max(1024, client._max_tokens - 4096))
+        stream_kwargs["thinking"] = {"type": "enabled", "budget_tokens": budget}
+
     with client._client.messages.stream(
         model=client._model,
         max_tokens=client._max_tokens,
         system=system,
         tools=client._tools,
         messages=history,
+        **stream_kwargs,
     ) as stream:
         for text in stream.text_stream:
             click.echo(text, nl=False)
@@ -179,7 +185,7 @@ def _stream_anthropic(client: LLMClient, system: str, history: list) -> LLMRespo
     if text_chunks:
         click.echo()
 
-    client._last_raw_content = [_serialize_anthropic_block(b) for b in msg.content]
+    client._last_raw_content = [serialize_anthropic_block(b) for b in msg.content]
     calls = [
         ToolCall(name=b.name, args=b.input, call_id=b.id)
         for b in msg.content

--- a/uio/cli/chat.py
+++ b/uio/cli/chat.py
@@ -9,9 +9,11 @@ import click
 
 from uio.config import load_config
 from uio.core.clients import (
+    AnthropicClient,
     GeminiClient,
     LLMClient,
     LLMResponse,
+    _serialize_anthropic_block,
     make_client,
     OpenAIClient,
     TokenUsage,
@@ -42,6 +44,10 @@ def _is_openai_compat(client: LLMClient) -> bool:
 
 def _is_gemini(client: LLMClient) -> bool:
     return isinstance(client, GeminiClient)
+
+
+def _is_anthropic(client: LLMClient) -> bool:
+    return isinstance(client, AnthropicClient)
 
 
 def _user_turn(client: LLMClient, text: str) -> dict:
@@ -153,12 +159,48 @@ def _stream_gemini(client: LLMClient, system: str, history: list) -> LLMResponse
     return LLMResponse(text="".join(text_chunks) or None, tool_calls=calls, usage=usage)
 
 
+def _stream_anthropic(client: LLMClient, system: str, history: list) -> LLMResponse:
+    assert isinstance(client, AnthropicClient)
+    text_chunks: list[str] = []
+    usage: TokenUsage | None = None
+
+    with client._client.messages.stream(
+        model=client._model,
+        max_tokens=client._max_tokens,
+        system=system,
+        tools=client._tools,
+        messages=history,
+    ) as stream:
+        for text in stream.text_stream:
+            click.echo(text, nl=False)
+            text_chunks.append(text)
+        msg = stream.get_final_message()
+
+    if text_chunks:
+        click.echo()
+
+    client._last_raw_content = [_serialize_anthropic_block(b) for b in msg.content]
+    calls = [
+        ToolCall(name=b.name, args=b.input, call_id=b.id)
+        for b in msg.content
+        if b.type == "tool_use"
+    ]
+    if msg.usage:
+        usage = TokenUsage(
+            prompt_tokens=msg.usage.input_tokens,
+            completion_tokens=msg.usage.output_tokens,
+        )
+    return LLMResponse(text="".join(text_chunks) or None, tool_calls=calls, usage=usage)
+
+
 def _stream_turn(client: LLMClient, system: str, history: list) -> LLMResponse:
     try:
         if _is_openai_compat(client):
             return _stream_openai(client, system, history)
         if _is_gemini(client):
             return _stream_gemini(client, system, history)
+        if _is_anthropic(client):
+            return _stream_anthropic(client, system, history)
     except Exception as e:
         click.echo(f"\n  [stream error, retrying without streaming: {e}]", err=True)
     response = client.chat(system=system, history=history)

--- a/uio/core/clients.py
+++ b/uio/core/clients.py
@@ -247,7 +247,7 @@ def _to_anthropic_tool(tool: dict) -> dict:
 _ANTHROPIC_DEFAULT_MAX_TOKENS = 16000
 
 
-def _serialize_anthropic_block(block) -> dict:
+def serialize_anthropic_block(block) -> dict:
     """Convert an Anthropic SDK content block to a plain dict for history storage."""
     if block.type == "text":
         return {"type": "text", "text": block.text}
@@ -294,7 +294,7 @@ class AnthropicClient(LLMClient):
             messages=history,
             **kwargs,
         )
-        self._last_raw_content = [_serialize_anthropic_block(b) for b in resp.content]
+        self._last_raw_content = [serialize_anthropic_block(b) for b in resp.content]
         text = next((b.text for b in resp.content if b.type == "text"), None)
         calls = [
             ToolCall(name=b.name, args=b.input, call_id=b.id)


### PR DESCRIPTION
## Summary

- Adds `_stream_anthropic()` in `uio/cli/chat.py` which calls `client.messages.stream()` to emit tokens incrementally as they arrive, eliminating the silent hang during long Anthropic responses.
- Adds `_is_anthropic()` helper and dispatches from `_stream_turn()` to `_stream_anthropic()`, matching the existing OpenAI and Gemini streaming paths.
- Updates `client._last_raw_content` from the final streamed message so `append_turn()` continues to round-trip thinking blocks correctly.
- Adds a unit test in `tests/test_chat.py` verifying text streaming, `_last_raw_content` population, and returned `LLMResponse`.

## Test plan

- [x] `pytest -m "not integration"` — 559 tests pass
- [x] `ruff format --check` and `ruff check` — no violations
- [ ] Manual: `uio chat --provider anthropic` — tokens should appear incrementally rather than after the full response

Closes #201

---
🤖 Generated with [uio AI Coder](https://github.com/jomkz/uio)