### PR TITLE
refactor: call load_config() once in agent_inspect_cmd

### DIFF
--- a/tests/test_cli_agent_inspect.py
+++ b/tests/test_cli_agent_inspect.py
@@ -1,0 +1,55 @@
+"""Tests for agent_inspect_cmd in uio.cli.agent."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from uio.cli.agent import agent_inspect_cmd
+
+
+_AGENT_MD = """\
+---
+name: test-agent
+description: A minimal test agent
+complexity: small
+---
+
+Body line one.
+"""
+
+
+def _cfg(tmp_path):
+    return {
+        "dirs": {"agents": str(tmp_path)},
+        "large_agents": {"names": []},
+    }
+
+
+def test_agent_inspect_calls_load_config_once(tmp_path):
+    (tmp_path / "test-agent.agent.md").write_text(_AGENT_MD)
+    with patch("uio.cli.agent.load_config", return_value=_cfg(tmp_path)) as mock_cfg:
+        result = CliRunner().invoke(agent_inspect_cmd, ["test-agent"])
+
+    assert result.exit_code == 0
+    assert "Complexity:" in result.output
+    mock_cfg.assert_called_once()
+
+
+def test_agent_inspect_output_fields(tmp_path):
+    (tmp_path / "test-agent.agent.md").write_text(_AGENT_MD)
+    with patch("uio.cli.agent.load_config", return_value=_cfg(tmp_path)):
+        result = CliRunner().invoke(agent_inspect_cmd, ["test-agent"])
+
+    assert result.exit_code == 0
+    assert "Name:" in result.output
+    assert "Description:" in result.output
+    assert "Complexity:" in result.output
+
+
+def test_agent_inspect_missing_agent_exits_nonzero(tmp_path):
+    with patch("uio.cli.agent.load_config", return_value=_cfg(tmp_path)):
+        result = CliRunner().invoke(agent_inspect_cmd, ["no-such-agent"])
+
+    assert result.exit_code != 0

--- a/uio/cli/agent.py
+++ b/uio/cli/agent.py
@@ -154,7 +154,7 @@ def agent_inspect_cmd(agent_name: str) -> None:
     click.echo(f"  Name:        {fm.get('name', agent_name)}")
     click.echo(f"  Description: {fm.get('description', '—')}")
     click.echo(
-        f"  Complexity:  {infer_complexity(agent_name, fm, None, load_config()['large_agents']['names'])}"
+        f"  Complexity:  {infer_complexity(agent_name, fm, None, cfg['large_agents']['names'])}"
     )
     if fm.get("tools"):
         click.echo(f"  Tools:       {', '.join(fm['tools'])}")


### PR DESCRIPTION
## Summary

- `agent_inspect_cmd` was calling `load_config()` twice: once to get `cfg` and again inline inside the `infer_complexity` call on the next line
- Replaced the second `load_config()` call with the already-assigned `cfg` variable
- This eliminates redundant file I/O and the subtle risk of config state diverging between the two calls

## Test plan

- [ ] Run `uio agent inspect <agent>` and verify output is unchanged
- [ ] `ruff format --check` and `ruff check` both pass
- [ ] `pytest -m "not integration"` passes (560 tests)

Closes #202

---
> 🤖 Generated with [Claude Code](https://claude.ai/claude-code) — AI Coder identity