### PR TITLE
fix(runner): preserve session memory when run_agent raises

### DIFF
--- a/tests/test_runner_retry.py
+++ b/tests/test_runner_retry.py
@@ -215,3 +215,100 @@ class TestRunAgentExceptions:
                     no_mcp=True,
                     ledger_path=str(tmp_path / "ledger.jsonl"),
                 )
+
+
+class TestSessionMemoryOnFailure:
+    """Session memory must be preserved when run_agent raises."""
+
+    def _make_run_args(self, tmp_path):
+        defn = tmp_path / "test.agent.md"
+        defn.write_text("---\nname: test-agent\n---\nDo the task.\n")
+        return {
+            "agent_name": "test-agent",
+            "definition_path": str(defn),
+            "no_mcp": True,
+            "ledger_path": str(tmp_path / "ledger.jsonl"),
+        }
+
+    def _write_session_memory(self, memory_dir):
+        """Write a session-scoped memory file and return its path."""
+        mem_file = memory_dir / "state.memory.md"
+        mem_file.write_text(
+            "---\nname: state\ndescription: mid-run state\nscope: session\n---\ndiagnostic data\n"
+        )
+        return mem_file
+
+    def test_memory_preserved_when_provider_exhausted(self, tmp_path):
+        """Session memory files are not cleared when run_agent raises ProviderExhaustedError."""
+        from uio.core.runner import ProviderExhaustedError, run_agent
+
+        memory_dir = tmp_path / "memory"
+        memory_dir.mkdir()
+        mem_file = self._write_session_memory(memory_dir)
+
+        with (
+            patch("uio.core.runner.make_client", side_effect=RuntimeError("network error")),
+            patch("uio.core.runner.select_provider_chain", return_value=["gemini"]),
+        ):
+            with pytest.raises(ProviderExhaustedError):
+                run_agent(
+                    **self._make_run_args(tmp_path),
+                    memory_dir=str(memory_dir),
+                )
+
+        assert "diagnostic data" in mem_file.read_text()
+
+    def test_memory_cleared_on_clean_finish(self, tmp_path):
+        """Session memory is cleared after a normal (tool-free) agent completion."""
+        from uio.core.clients import LLMResponse
+        from uio.core.runner import run_agent
+
+        memory_dir = tmp_path / "memory"
+        memory_dir.mkdir()
+        mem_file = self._write_session_memory(memory_dir)
+
+        mock_client = MagicMock()
+        mock_client.build_history.return_value = [{"role": "user", "content": "begin"}]
+        mock_client.chat.return_value = LLMResponse(text="Done.", tool_calls=[])
+        mock_client.usage = None
+
+        with (
+            patch("uio.core.runner.make_client", return_value=mock_client),
+            patch("uio.core.runner.select_provider_chain", return_value=["gemini"]),
+        ):
+            run_agent(
+                **self._make_run_args(tmp_path),
+                memory_dir=str(memory_dir),
+            )
+
+        assert "diagnostic data" not in mem_file.read_text()
+
+    def test_memory_cleared_on_iteration_cap(self, tmp_path):
+        """Session memory is cleared when the agent hits the iteration cap (clean exit)."""
+        from uio.core.clients import LLMResponse
+        from uio.core.runner import run_agent
+        from uio.core.tools import ToolCall
+
+        memory_dir = tmp_path / "memory"
+        memory_dir.mkdir()
+        mem_file = self._write_session_memory(memory_dir)
+
+        tc = ToolCall(name="run_command", args={"command": "echo x"}, call_id="t1")
+        mock_client = MagicMock()
+        mock_client.build_history.return_value = [{"role": "user", "content": "begin"}]
+        mock_client.chat.return_value = LLMResponse(text=None, tool_calls=[tc])
+        mock_client.usage = None
+
+        with (
+            patch("uio.core.runner.make_client", return_value=mock_client),
+            patch("uio.core.runner.select_provider_chain", return_value=["gemini"]),
+            patch("uio.core.runner.execute_tool", return_value="ok"),
+        ):
+            result = run_agent(
+                **self._make_run_args(tmp_path),
+                memory_dir=str(memory_dir),
+                max_iterations=2,
+            )
+
+        assert result is None
+        assert "diagnostic data" not in mem_file.read_text()

--- a/tests/test_runner_retry.py
+++ b/tests/test_runner_retry.py
@@ -312,3 +312,41 @@ class TestSessionMemoryOnFailure:
 
         assert result is None
         assert "diagnostic data" not in mem_file.read_text()
+
+    def test_memory_preserved_when_guardrail_exceeded(self, tmp_path):
+        """Session memory is preserved when a cost guardrail fires."""
+        from uio.core.clients import LLMResponse
+        from uio.core.runner import GuardrailError, run_agent
+        from uio.core.tools import ToolCall
+
+        memory_dir = tmp_path / "memory"
+        memory_dir.mkdir()
+        mem_file = self._write_session_memory(memory_dir)
+
+        tc = ToolCall(name="run_command", args={"command": "echo x"}, call_id="t1")
+        mock_client = MagicMock()
+        mock_client.build_history.return_value = [{"role": "user", "content": "begin"}]
+        mock_client.chat.return_value = LLMResponse(text=None, tool_calls=[tc])
+        mock_client.usage = None
+
+        defn = tmp_path / "guardrail.agent.md"
+        defn.write_text(
+            "---\nname: test-agent\nguardrails:\n  max_cost_usd: 0.000001\n---\nDo the task.\n"
+        )
+
+        with (
+            patch("uio.core.runner.make_client", return_value=mock_client),
+            patch("uio.core.runner.select_provider_chain", return_value=["gemini"]),
+            patch("uio.core.runner.execute_tool", return_value="ok"),
+            patch("uio.core.runner.estimate_cost_usd", return_value=999.0),
+        ):
+            with pytest.raises(GuardrailError):
+                run_agent(
+                    agent_name="test-agent",
+                    definition_path=str(defn),
+                    no_mcp=True,
+                    ledger_path=str(tmp_path / "ledger.jsonl"),
+                    memory_dir=str(memory_dir),
+                )
+
+        assert "diagnostic data" in mem_file.read_text()

--- a/uio/core/runner.py
+++ b/uio/core/runner.py
@@ -330,6 +330,7 @@ def run_agent(
         else (max_iterations_large if resolved_complexity == "large" else max_iterations)
     )
 
+    _clean_exit = False
     try:
         last_error: Exception | None = None
         for candidate_provider in provider_chain:
@@ -406,6 +407,7 @@ def run_agent(
                             total_completion,
                             ledger_path,
                         )
+                        _clean_exit = True
                         return response.text or ""
 
                     if guardrail_max_cost is not None:
@@ -469,6 +471,7 @@ def run_agent(
                     total_completion,
                     ledger_path,
                 )
+                _clean_exit = True
                 return None
 
             except GuardrailError:
@@ -485,5 +488,5 @@ def run_agent(
     finally:
         for client in mcp_clients.values():
             client.close()
-        if memory_dir:
+        if memory_dir and _clean_exit:
             clear_session_memory(memory_dir)


### PR DESCRIPTION
## Summary

- `clear_session_memory` was called unconditionally in the `finally` block of `run_agent`, wiping any session memory accumulated before the failure
- Added a `_clean_exit` flag (defaulting to `False`) that is set to `True` only on the two clean exit paths: normal agent completion and iteration cap
- The `finally` block now calls `clear_session_memory` only when `_clean_exit` is `True`, preserving memory on exception paths for post-mortem debugging

## Test plan

- [x] `TestSessionMemoryOnFailure::test_memory_preserved_when_provider_exhausted` — verifies memory files survive a `ProviderExhaustedError`
- [x] `TestSessionMemoryOnFailure::test_memory_cleared_on_clean_finish` — verifies memory is still cleared after a successful run
- [x] `TestSessionMemoryOnFailure::test_memory_cleared_on_iteration_cap` — verifies memory is cleared when the agent hits the iteration cap
- [x] Full suite (`pytest -m "not integration"`) — 570 passed, 0 failures

Closes #204

---
> 🤖 Generated with [uio AI Coder](https://github.com/jomkz/uio) — review before merging.