### PR TITLE
fix(ledger): warn once when provider/model is not in pricing table

### DIFF
--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -4,6 +4,7 @@ import json
 import logging
 from pathlib import Path
 
+import uio.core.ledger as ledger_module
 
 from uio.core.ledger import estimate_cost_usd, write_cost_ledger
 
@@ -18,18 +19,23 @@ def test_estimate_openai_mini():
     assert abs(cost - (0.15 + 0.60)) < 1e-9
 
 
-def test_estimate_unknown_provider():
-    cost = estimate_cost_usd("unknown", "unknown-model", 1_000_000, 1_000_000)
+def test_estimate_unknown_provider(monkeypatch, caplog):
+    monkeypatch.setattr(ledger_module, "_warned_unknown_models", set())
+    with caplog.at_level(logging.WARNING, logger="uio.core.ledger"):
+        cost = estimate_cost_usd("unknown", "unknown-model", 1_000_000, 1_000_000)
     assert cost == 0.0
+    assert any("unknown/unknown-model" in r.message for r in caplog.records)
 
 
-def test_estimate_unknown_model_logs_warning(caplog):
+def test_estimate_unknown_model_logs_warning(monkeypatch, caplog):
+    monkeypatch.setattr(ledger_module, "_warned_unknown_models", set())
     with caplog.at_level(logging.WARNING, logger="uio.core.ledger"):
         estimate_cost_usd("acme", "acme-turbo", 1_000, 500)
     assert any("acme/acme-turbo" in r.message for r in caplog.records)
 
 
-def test_estimate_unknown_model_warns_once(caplog):
+def test_estimate_unknown_model_warns_once(monkeypatch, caplog):
+    monkeypatch.setattr(ledger_module, "_warned_unknown_models", set())
     with caplog.at_level(logging.WARNING, logger="uio.core.ledger"):
         estimate_cost_usd("acme2", "acme2-turbo", 1_000, 500)
         estimate_cost_usd("acme2", "acme2-turbo", 2_000, 1_000)

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1,6 +1,7 @@
 """Tests for cost ledger: estimation and file append."""
 
 import json
+import logging
 from pathlib import Path
 
 
@@ -20,6 +21,20 @@ def test_estimate_openai_mini():
 def test_estimate_unknown_provider():
     cost = estimate_cost_usd("unknown", "unknown-model", 1_000_000, 1_000_000)
     assert cost == 0.0
+
+
+def test_estimate_unknown_model_logs_warning(caplog):
+    with caplog.at_level(logging.WARNING, logger="uio.core.ledger"):
+        estimate_cost_usd("acme", "acme-turbo", 1_000, 500)
+    assert any("acme/acme-turbo" in r.message for r in caplog.records)
+
+
+def test_estimate_unknown_model_warns_once(caplog):
+    with caplog.at_level(logging.WARNING, logger="uio.core.ledger"):
+        estimate_cost_usd("acme2", "acme2-turbo", 1_000, 500)
+        estimate_cost_usd("acme2", "acme2-turbo", 2_000, 1_000)
+    matching = [r for r in caplog.records if "acme2/acme2-turbo" in r.message]
+    assert len(matching) == 1
 
 
 def test_write_creates_file(tmp_path):

--- a/uio/core/ledger.py
+++ b/uio/core/ledger.py
@@ -24,7 +24,7 @@ def estimate_cost_usd(
     if costs is None:
         if key not in _warned_unknown_models:
             _warned_unknown_models.add(key)
-            _log.warning("[ledger] unknown model '%s' — cost not tracked", key)
+            _log.warning("unknown model '%s' — cost not tracked", key)
         costs = (0.0, 0.0)
     return (prompt_tokens * costs[0] + completion_tokens * costs[1]) / 1_000_000
 

--- a/uio/core/ledger.py
+++ b/uio/core/ledger.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime
 import json
+import logging
 import os
 import sys
 
@@ -11,12 +12,20 @@ from uio.core.clients import TOKEN_COSTS_PER_1M
 
 DEFAULT_LEDGER_PATH = "uio_cost.jsonl"
 
+_log = logging.getLogger(__name__)
+_warned_unknown_models: set[str] = set()
+
 
 def estimate_cost_usd(
     provider: str, model: str, prompt_tokens: int, completion_tokens: int
 ) -> float:
     key = f"{provider}/{model}"
-    costs = TOKEN_COSTS_PER_1M.get(key) or TOKEN_COSTS_PER_1M.get(provider, (0.0, 0.0))
+    costs = TOKEN_COSTS_PER_1M.get(key) or TOKEN_COSTS_PER_1M.get(provider)
+    if costs is None:
+        if key not in _warned_unknown_models:
+            _warned_unknown_models.add(key)
+            _log.warning("[ledger] unknown model '%s' — cost not tracked", key)
+        costs = (0.0, 0.0)
     return (prompt_tokens * costs[0] + completion_tokens * costs[1]) / 1_000_000
 
 


### PR DESCRIPTION
## Summary

- `estimate_cost_usd` in `uio/core/ledger.py` previously silently returned `0.0` for any provider/model combination not found in `TOKEN_COSTS_PER_1M`, masking missing pricing entries
- A `logging.warning` is now emitted the first time an unknown `provider/model` key is encountered, using a module-level set to suppress duplicate warnings within the same process
- A unit test (`test_estimate_unknown_model_logs_warning`) verifies the warning fires for an unknown key, and a second test (`test_estimate_unknown_model_warns_once`) confirms it fires exactly once per unique key

## Test plan

- [ ] `pytest -m "not integration" tests/test_ledger.py` — all 9 tests pass
- [ ] `ruff format --check . && ruff check .` — no lint or format errors
- [ ] Call `estimate_cost_usd("acme", "unknown", ...)` twice in a Python shell; confirm the `[ledger] unknown model 'acme/unknown'` warning appears exactly once in the log output

Closes #205