### PR TITLE
docs: add language choice rationale

### DIFF
--- a/docs/18-design-decisions.md
+++ b/docs/18-design-decisions.md
@@ -1,8 +1,6 @@
 # Design decisions
 
-This page documents the rationale behind key design decisions in uio.
-
----
+This page documents the rationale behind key design decisions in uio. It will grow as more decisions are recorded.
 
 ## Why Python?
 
@@ -19,6 +17,6 @@ tight feedback-loop CLI, so cold-start latency is rarely the pain point. If spec
 (e.g. token estimation, file scanning) ever become bottlenecks, a targeted Rust extension via
 PyO3 would be preferable to a full rewrite.
 
-**Summary:** Python is well-matched to what uio actually does. uio's value is in its agent
+Python is well-matched to what uio actually does. uio's value is in its agent
 definitions and workflow logic — the language that lets you iterate fastest on prompts, routing,
 and integrations is the right one.

--- a/docs/18-design-decisions.md
+++ b/docs/18-design-decisions.md
@@ -1,0 +1,24 @@
+# Design decisions
+
+This page documents the rationale behind key design decisions in uio.
+
+---
+
+## Why Python?
+
+uio's core bottleneck is waiting on LLM API responses and subprocess output — both are I/O-bound,
+not CPU-bound, so a systems language offers no meaningful speed advantage. The codebase is oriented
+around string manipulation, YAML/TOML parsing, and subprocess orchestration, which Python handles
+idiomatically. The ecosystem for LLM SDKs, GitHub API clients, and AI tooling is also far richer
+in Python.
+
+## What about CLI startup time?
+
+A compiled binary would start faster, but uio is a long-running orchestration tool, not a
+tight feedback-loop CLI, so cold-start latency is rarely the pain point. If specific hot paths
+(e.g. token estimation, file scanning) ever become bottlenecks, a targeted Rust extension via
+PyO3 would be preferable to a full rewrite.
+
+**Summary:** Python is well-matched to what uio actually does. uio's value is in its agent
+definitions and workflow logic — the language that lets you iterate fastest on prompts, routing,
+and integrations is the right one.

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@
 | [15 — Use cases](15-use-cases.md) | Worked examples: repo health, code review, issue planning, AI-authored PRs, multi-agent pipelines |
 | [16 — About](16-about.md) | The origin story — why uio exists and where the name comes from |
 | [17 — GitHub App identities](17-github-app-identities.md) | Dedicated GitHub App identities for agents — setup, frontmatter, and links to governance and runbooks |
+| [18 — Design decisions](18-design-decisions.md) | Why Python? Language choice rationale and answers to common implementation questions |
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@
 | [15 — Use cases](15-use-cases.md) | Worked examples: repo health, code review, issue planning, AI-authored PRs, multi-agent pipelines |
 | [16 — About](16-about.md) | The origin story — why uio exists and where the name comes from |
 | [17 — GitHub App identities](17-github-app-identities.md) | Dedicated GitHub App identities for agents — setup, frontmatter, and links to governance and runbooks |
-| [18 — Design decisions](18-design-decisions.md) | Why Python? Language choice rationale and answers to common implementation questions |
+| [18 — Design decisions](18-design-decisions.md) | Language choice rationale: why Python, and the CLI startup time trade-off |
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #212

- Adds `docs/18-design-decisions.md` — a new "Design decisions" page containing the language choice rationale from issue #212, covering why Python is a good fit for uio's workload and addressing the CLI startup time question
- Updates `docs/README.md` contents table to link to the new page

## Changes

- `docs/18-design-decisions.md` — new file with "Why Python?" and "What about CLI startup time?" sections
- `docs/README.md` — entry 18 added to the contents table

## Test plan

- [ ] `pytest` passes locally
- [ ] `ruff check .` passes locally
- [ ] `ruff format --check .` passes locally
- [ ] New page renders correctly in Markdown preview
- [ ] Link in `docs/README.md` resolves to the new file

## Notes for reviewers

Docs-only change — no Python source files modified.