### PR TITLE
docs: fix routing chain order in container and internals docs

### DIFF
--- a/docs/13-internals.md
+++ b/docs/13-internals.md
@@ -64,7 +64,7 @@ Known keys: `name description complexity tools timeout argument-hint invokable`
 
 ### Routing layer — `uio/core/routing.py`
 
-`ROUTING_CHAIN = ["gemini", "openai", "ollama"]` — the auto-routing order.
+`ROUTING_CHAIN = ["ollama", "openai", "gemini", "anthropic"]` — the auto-routing order.
 
 `PROVIDER_KEY_ENV` maps each provider to its required API key env var (`None` for Ollama).
 

--- a/docs/14-container.md
+++ b/docs/14-container.md
@@ -147,9 +147,9 @@ environments and regulated on-premises deployments.
 
 ### How provider routing works with the sidecar
 
-`uio` tries providers in order: **Gemini → OpenAI → Ollama**. A provider is included only if
+`uio` tries providers in order: **Ollama → OpenAI → Gemini → Anthropic**. A provider is included only if
 its API key is present in the environment. Ollama has no key requirement and is always the
-final fallback.
+first fallback when no cloud keys are set.
 
 The compose file wires `OLLAMA_BASE_URL=http://ollama:11434/v1` so the uio container reaches
 the Ollama sidecar over the compose network. With no cloud keys set:
@@ -161,7 +161,7 @@ ROUTING_CHAIN: [ollama]  ← only Ollama is available, selected immediately
 With cloud keys set (passed through from the host), cloud providers take priority:
 
 ```
-ROUTING_CHAIN: [gemini, openai, ollama]  ← Gemini tried first; Ollama is the fallback
+ROUTING_CHAIN: [ollama, openai, gemini, anthropic]  ← Ollama first; cloud providers tried in order
 ```
 
 ### First-time setup


### PR DESCRIPTION
## Summary
- Fix routing order in docs/14-container.md to match actual ROUTING_CHAIN
- Fix routing order in docs/13-internals.md to match actual ROUTING_CHAIN
- Add missing `anthropic` provider to both descriptions

Closes #217

## Test plan
- [ ] Verify docs/14-container.md routing description matches `["ollama", "openai", "gemini", "anthropic"]`
- [ ] Verify docs/13-internals.md routing description matches `["ollama", "openai", "gemini", "anthropic"]`
- [ ] Verify `anthropic` is present in both descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)