### PR TITLE
docs: fix stale fallback prose in routing chain docs

### DIFF
--- a/docs/13-internals.md
+++ b/docs/13-internals.md
@@ -72,7 +72,7 @@ Known keys: `name description complexity tools timeout argument-hint invokable`
 
 `select_model(provider, complexity, model_override)` — returns the model string. Resolution order: `model_override` → `LLM_MODEL` env var → tier-based default from `PROVIDER_DEFAULTS` / `PROVIDER_SMALL_MODELS`.
 
-`select_provider_chain(provider_override)` — if `provider_override` is set, returns `[provider_override]`. Otherwise returns all providers in `ROUTING_CHAIN` whose API key is set, with Ollama always included as the final fallback.
+`select_provider_chain(provider_override)` — if `provider_override` is set, returns `[provider_override]`. Otherwise returns all providers in `ROUTING_CHAIN` whose API key is set, with Ollama always included as the first entry.
 
 ---
 

--- a/docs/14-container.md
+++ b/docs/14-container.md
@@ -147,9 +147,9 @@ environments and regulated on-premises deployments.
 
 ### How provider routing works with the sidecar
 
-`uio` tries providers in order: **Gemini → OpenAI → Ollama**. A provider is included only if
+`uio` tries providers in order: **Ollama → OpenAI → Gemini → Anthropic**. A provider is included only if
 its API key is present in the environment. Ollama has no key requirement and is always the
-final fallback.
+first option tried when no cloud keys are set.
 
 The compose file wires `OLLAMA_BASE_URL=http://ollama:11434/v1` so the uio container reaches
 the Ollama sidecar over the compose network. With no cloud keys set:
@@ -158,7 +158,7 @@ the Ollama sidecar over the compose network. With no cloud keys set:
 ROUTING_CHAIN: [ollama]  ← only Ollama is available, selected immediately
 ```
 
-With cloud keys set (passed through from the host), cloud providers take priority:
+With cloud keys set (passed through from the host), cloud providers are added to the chain after Ollama:
 
 ```
 ROUTING_CHAIN: [gemini, openai, ollama]  ← Gemini tried first; Ollama is the fallback


### PR DESCRIPTION
## Summary

Follow-up to #232. That PR corrected the routing chain order and the bold arrow notation in two doc pages, but three surrounding prose sentences were not updated and still contradict the corrected chain:

- `docs/14-container.md` line ~152: "Ollama … is always the final fallback" → now says "first option tried when no cloud keys are set"
- `docs/14-container.md` line ~161: "cloud providers take priority" → now says "cloud providers are added to the chain after Ollama"
- `docs/13-internals.md` line ~75: `select_provider_chain` description ends with "final fallback" → now says "first entry"

Closes #217

## Test plan

- [ ] `docs/14-container.md` — "How provider routing works with the sidecar" section: opening sentence names Ollama first; last sentence of the paragraph says "first option tried", not "final fallback"
- [ ] `docs/14-container.md` — cloud-keys sentence says "added to the chain after Ollama", not "take priority"
- [ ] `docs/13-internals.md` — `select_provider_chain` description says "first entry", not "final fallback"

🤖 Generated with [Claude Code](https://claude.com/claude-code)