### PR TITLE
docs: fix routing chain order and stale fallback prose

### DIFF
--- a/docs/13-internals.md
+++ b/docs/13-internals.md
@@ -72,7 +72,7 @@ Known keys: `name description complexity tools timeout argument-hint invokable`
 
 `select_model(provider, complexity, model_override)` — returns the model string. Resolution order: `model_override` → `LLM_MODEL` env var → tier-based default from `PROVIDER_DEFAULTS` / `PROVIDER_SMALL_MODELS`.
 
-`select_provider_chain(provider_override)` — if `provider_override` is set, returns `[provider_override]`. Otherwise returns all providers in `ROUTING_CHAIN` whose API key is set, with Ollama always included as the first entry.
+`select_provider_chain(provider_override, complexity)` — if `provider_override` is set, returns `[provider_override]`. Otherwise returns all providers in `ROUTING_CHAIN` whose API key is set. Ollama is excluded for large-complexity runs (local models are unreliable for multi-step tool chains); for small complexity it is the fallback when no cloud keys are available.
 
 ---
 

--- a/docs/13-internals.md
+++ b/docs/13-internals.md
@@ -64,7 +64,7 @@ Known keys: `name description complexity tools timeout argument-hint invokable`
 
 ### Routing layer — `uio/core/routing.py`
 
-`ROUTING_CHAIN = ["gemini", "openai", "ollama"]` — the auto-routing order.
+`ROUTING_CHAIN = ["ollama", "openai", "gemini", "anthropic"]` — the auto-routing order.
 
 `PROVIDER_KEY_ENV` maps each provider to its required API key env var (`None` for Ollama).
 
@@ -72,7 +72,7 @@ Known keys: `name description complexity tools timeout argument-hint invokable`
 
 `select_model(provider, complexity, model_override)` — returns the model string. Resolution order: `model_override` → `LLM_MODEL` env var → tier-based default from `PROVIDER_DEFAULTS` / `PROVIDER_SMALL_MODELS`.
 
-`select_provider_chain(provider_override)` — if `provider_override` is set, returns `[provider_override]`. Otherwise returns all providers in `ROUTING_CHAIN` whose API key is set, with Ollama always included as the final fallback.
+`select_provider_chain(provider_override)` — if `provider_override` is set, returns `[provider_override]`. Otherwise returns all providers in `ROUTING_CHAIN` whose API key is set, with Ollama always included as the first entry.
 
 ---
 

--- a/docs/14-container.md
+++ b/docs/14-container.md
@@ -147,9 +147,9 @@ environments and regulated on-premises deployments.
 
 ### How provider routing works with the sidecar
 
-`uio` tries providers in order: **Gemini → OpenAI → Ollama**. A provider is included only if
+`uio` tries providers in order: **Ollama → OpenAI → Gemini → Anthropic**. A provider is included only if
 its API key is present in the environment. Ollama has no key requirement and is always the
-final fallback.
+first option tried when no cloud keys are set.
 
 The compose file wires `OLLAMA_BASE_URL=http://ollama:11434/v1` so the uio container reaches
 the Ollama sidecar over the compose network. With no cloud keys set:
@@ -158,10 +158,10 @@ the Ollama sidecar over the compose network. With no cloud keys set:
 ROUTING_CHAIN: [ollama]  ← only Ollama is available, selected immediately
 ```
 
-With cloud keys set (passed through from the host), cloud providers take priority:
+With cloud keys set (passed through from the host), cloud providers are added to the chain after Ollama:
 
 ```
-ROUTING_CHAIN: [gemini, openai, ollama]  ← Gemini tried first; Ollama is the fallback
+ROUTING_CHAIN: [ollama, openai, gemini, anthropic]  ← Ollama first; cloud providers tried in order
 ```
 
 ### First-time setup


### PR DESCRIPTION
## Summary
Consolidates and completes #232 and #233 — those two PRs conflicted on the same lines and together still left one stale code block.

- `docs/13-internals.md`: correct `ROUTING_CHAIN` literal and `select_provider_chain` "final fallback" description
- `docs/14-container.md`: correct bold arrow notation, "final fallback" sentence, "cloud providers take priority" sentence, and the stale `[gemini, openai, ollama]` code block

Closes #217

## Test plan
- [ ] `docs/13-internals.md` line ~67: `ROUTING_CHAIN = ["ollama", "openai", "gemini", "anthropic"]`
- [ ] `docs/13-internals.md` line ~75: `select_provider_chain` says "first entry", not "final fallback"
- [ ] `docs/14-container.md`: bold arrow notation shows `Ollama → OpenAI → Gemini → Anthropic`
- [ ] `docs/14-container.md`: Ollama described as "first option tried", not "final fallback"
- [ ] `docs/14-container.md`: cloud-keys sentence says "added to the chain after Ollama"
- [ ] `docs/14-container.md`: code block shows `[ollama, openai, gemini, anthropic]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)