### PR TITLE
docs: fix stale glossary, capabilities field, and deprecated github-identity example

### DIFF
--- a/docs/02-concepts.md
+++ b/docs/02-concepts.md
@@ -178,5 +178,5 @@ This vocabulary is intentional. **"Agentic Stack"** is the umbrella term for the
 | **Prompt** | A single-shot LLM instruction. The definition body is sent once and the response is printed — no tool-use loop. Defined in `*.prompt.md`. |
 | **Tool** | An external capability the **model** invokes mid-loop. Tools are agent-directed: the agent decides when and how to call them. Examples: `run_command` (built-in), MCP tools such as GitHub or filesystem access. This is the key distinction from skills — a tool is called by the model; a skill is called by you. |
 | **Workflow** | A deterministic pipeline that chains agents and skills sequentially. Defined in `*.workflow.md`. The structure is fixed; the runtime executes steps in order with `{{ variable }}` interpolation and optional `when:` conditions — no LLM orchestrates the sequence. |
-| **Memory** | Persistent context injected into agent runs across sessions. Not yet implemented (planned). |
-| **Guardrails** | Per-definition constraints on cost, tool access, and iteration count. Not yet implemented (planned). |
+| **Memory** | Persistent context injected into agent runs across sessions. |
+| **Guardrails** | Per-definition constraints on cost, tool access, and iteration count. |

--- a/docs/04-frontmatter.md
+++ b/docs/04-frontmatter.md
@@ -243,7 +243,6 @@ name: deep-review
 description: Multi-step code review with externalised reasoning.
 complexity: large
 capabilities:
-  - vcs
   - thinking
 ---
 

--- a/docs/04-frontmatter.md
+++ b/docs/04-frontmatter.md
@@ -35,8 +35,8 @@ name: My Agent
 description: Does something useful.
 complexity: small
 capabilities:
-  - terminal
-  - github
+  - vcs
+  - thinking
 timeout: 300
 vcs-identity: planner
 ---
@@ -47,7 +47,7 @@ vcs-identity: planner
 | `name` | string | Yes | — | Display name |
 | `description` | string | Yes | — | One-line summary |
 | `complexity` | `large` \| `small` | No | `small` | Model tier selection — see below |
-| `capabilities` | list of strings | No | — | Informational only; documents which capability families the agent uses; not enforced by the runtime. Common values: `vcs`, `terminal`, `github`, `thinking`. (`tools` is an accepted legacy alias.) |
+| `capabilities` | list of strings | No | — | Declares which capability families the agent uses. Enforced by `validate_definition()` — unknown values produce an error. Accepted values: `vcs`, `db`, `browser`, `search`, `chat`, `tracker`, `ci`, `cloud`, `docs`, `monitor`, `email`, `vector`, `container`, `fs`, `http`, `kv`, `git`, `thinking`. (`tools` is an accepted legacy alias.) |
 | `timeout` | integer (seconds) | No | 300 | Per-command shell timeout for `run_command` calls |
 | `vcs-identity` | `planner` \| `coder` \| `reviewer` | No | — | VCS App identity to obtain for this agent's repository operations — see below |
 | `vcs-provider` | `github` \| `gitlab` | No | `github` | VCS platform targeted by `vcs-identity`; controls which MCP tool aliases are injected |
@@ -196,7 +196,7 @@ Known keys (do not produce warnings):
 
 ```
 name  description  complexity  capabilities  tools  timeout  argument-hint  invokable
-vcs-identity  vcs-provider  github-identity
+max_tokens  guardrails  context  github-identity  vcs-identity  vcs-provider
 ```
 
 Any other key produces an error. This is intentional — it catches typos like `Complexity: large` (capitalised) that would silently be ignored.
@@ -215,8 +215,8 @@ name: repo-health
 description: Run tests, lint, TODO count, stale branches, and open PRs.
 complexity: large
 capabilities:
-  - terminal
-  - github
+  - vcs
+  - fs
 timeout: 600
 ---
 
@@ -243,7 +243,7 @@ name: deep-review
 description: Multi-step code review with externalised reasoning.
 complexity: large
 capabilities:
-  - github
+  - vcs
   - thinking
 ---
 

--- a/docs/13-internals.md
+++ b/docs/13-internals.md
@@ -48,7 +48,7 @@ A regex is used instead of a streaming YAML parser because frontmatter is always
 - `name` and `description` are present and non-empty (error if missing)
 - All keys are in the known-keys set (warning if unknown)
 
-Known keys: `name description complexity tools timeout argument-hint invokable`
+Known keys: `name description complexity tools capabilities timeout argument-hint invokable max_tokens guardrails context github-identity vcs-identity vcs-provider`
 
 ---
 

--- a/docs/13-internals.md
+++ b/docs/13-internals.md
@@ -46,7 +46,7 @@ A regex is used instead of a streaming YAML parser because frontmatter is always
 
 `validate_definition(path, frontmatter)` checks:
 - `name` and `description` are present and non-empty (error if missing)
-- All keys are in the known-keys set (warning if unknown)
+- All keys are in the known-keys set (error if unknown)
 
 Known keys: `name description complexity tools capabilities timeout argument-hint invokable max_tokens guardrails context github-identity vcs-identity vcs-provider`
 

--- a/docs/17-github-app-identities.md
+++ b/docs/17-github-app-identities.md
@@ -26,11 +26,11 @@ capabilities:
 ---
 ```
 
-uio obtains a short-lived GitHub App installation token before the agent loop starts and
-sets `GH_TOKEN` — both the `gh` CLI and GitHub MCP server pick it up automatically.
-
 > **Deprecated alias:** `github-identity` is accepted for backwards compatibility but
 > new definitions should use `vcs-identity`.
+
+uio obtains a short-lived GitHub App installation token before the agent loop starts and
+sets `GH_TOKEN` — both the `gh` CLI and GitHub MCP server pick it up automatically.
 
 ## Further reading
 

--- a/docs/17-github-app-identities.md
+++ b/docs/17-github-app-identities.md
@@ -14,21 +14,23 @@ distinct permission scope, enforcing separation of duties at the GitHub App laye
 
 ## Declaring an identity
 
-Add `github-identity` to your agent's frontmatter:
+Add `vcs-identity` to your agent's frontmatter:
 
 ```yaml
 ---
 name: my-github-agent
 description: An agent that opens pull requests.
-github-identity: coder   # planner | coder | reviewer
+vcs-identity: coder   # planner | coder | reviewer
 capabilities:
-  - terminal
   - vcs
 ---
 ```
 
 uio obtains a short-lived GitHub App installation token before the agent loop starts and
 sets `GH_TOKEN` — both the `gh` CLI and GitHub MCP server pick it up automatically.
+
+> **Deprecated alias:** `github-identity` is accepted for backwards compatibility but
+> new definitions should use `vcs-identity`.
 
 ## Further reading
 


### PR DESCRIPTION
## Summary

- Remove `(planned)` annotations from **Memory** and **Guardrails** glossary entries in `docs/02-concepts.md` — both features are fully implemented
- Add missing frontmatter keys (`max_tokens`, `guardrails`, `context`, `capabilities`, `github-identity`, `vcs-identity`, `vcs-provider`) to the known-keys list in `docs/13-internals.md`
- Fix `capabilities` field documentation in `docs/04-frontmatter.md`: state that enforcement is active via `validate_definition()`, remove invalid `terminal`/`github` values from examples, and list the accepted values from `KNOWN_CAPABILITY_TYPES`
- Update primary frontmatter example in `docs/17-github-app-identities.md` to use `vcs-identity` and note `github-identity` as the deprecated alias

## Test plan

- [ ] `uio validate` passes on all definition files in `.uio/` (no spurious errors from renamed keys)
- [ ] Read through each changed section and confirm it matches the current code in `uio/core/vcs.py` and `uio/schema/parser.py`
- [ ] Confirm no Python source files were modified

Closes #218

---
> 🤖 Generated with [Claude Code](https://claude.com/claude-code)