### PR TITLE
docs: add workflow, memory, and mcp init CLI reference entries

### DIFF
--- a/docs/05-cli.md
+++ b/docs/05-cli.md
@@ -17,6 +17,9 @@ uio
 ├── prompt
 │   ├── run <name> [arg]
 │   └── list
+├── workflow
+│   ├── run <name> [arg]
+│   └── list
 ├── chat
 ├── cost
 ├── config
@@ -24,6 +27,12 @@ uio
 │   └── init
 ├── init
 ├── link
+├── mcp
+│   └── init
+├── memory
+│   ├── list
+│   ├── view <name>
+│   └── clear [--session]
 ├── validate
 ├── registry
 │   ├── list
@@ -156,6 +165,42 @@ Accepts `--provider`, `--model`, `--base-url`. Does not accept `--complexity`, `
 Lists all `.prompt.md` files.
 
 Output columns: NAME, ARGUMENT, DESCRIPTION
+
+---
+
+## `uio workflow`
+
+### `uio workflow run <name> [arg]`
+
+Runs a named workflow sequentially from `.uio/workflows/<name>.workflow.md`. Each step is executed in order; the output of one step is not automatically piped into the next unless the step definition references `{{ input }}`.
+
+`WORKFLOW` is the stem of the filename (without `.workflow.md`).
+`ARG` is an optional positional argument injected as `{{ input }}` in step arguments.
+
+```bash
+uio workflow run review-and-fix
+uio workflow run review-and-fix "owner/repo#42"
+uio workflow run review-and-fix --provider openai
+```
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--provider` | `gemini\|openai\|ollama` | auto | LLM provider override for every step; bypasses the routing chain |
+| `--model` | string | inferred | Model name override for every step |
+| `--no-mcp` | flag | off | Disable all MCP servers for every step |
+| `--shell` | `bash\|sh\|zsh\|powershell\|pwsh` | auto | Shell for `run_command`; auto-detects platform |
+
+Exit code: 0 on success, 1 if the workflow definition is not found or a step fails.
+
+### `uio workflow list`
+
+Lists all available workflows from the configured workflows directory (`.uio/workflows/*.workflow.md`).
+
+Output columns: NAME, STEPS, DESCRIPTION
+
+```bash
+uio workflow list
+```
 
 ---
 
@@ -299,6 +344,84 @@ uio link --force
 Running `uio link` a second time is a no-op. Adding or deleting a prompt file and re-running `uio link` adds or removes the corresponding symlink in `.claude/commands/`.
 
 If `.claude/commands` already exists as a directory symlink (legacy setup), `uio link` will prompt to replace it with a real directory. Pass `--force` to replace without prompting.
+
+---
+
+## `uio mcp`
+
+### `uio mcp init`
+
+Scaffolds an MCP configuration file for Claude Code or VS Code, populated from the `[mcp.<name>]` server definitions in `uio.toml`. Secret values are never written to disk — env var references (e.g. `${GITHUB_PERSONAL_ACCESS_TOKEN}`) are emitted instead.
+
+Declare the servers you want to expose in `uio.toml` first:
+
+```toml
+[mcp.github]
+command  = "github-mcp-server stdio"
+env_keys = ["GITHUB_PERSONAL_ACCESS_TOKEN"]
+```
+
+Then generate the platform config:
+
+```bash
+uio mcp init --for claude                 # writes .mcp.json
+uio mcp init --for vscode                 # writes .vscode/mcp.json
+uio mcp init --for claude --global        # merges into ~/.claude/settings.json
+uio mcp init --for claude --force         # overwrites an existing .mcp.json
+uio mcp init --for vscode --dry-run       # print planned output without writing
+```
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--for` | `claude\|vscode` | — | **Required.** Target platform. `claude` writes `.mcp.json`; `vscode` writes `.vscode/mcp.json`. |
+| `--global` | flag | off | *(claude only)* Merge server entries into `~/.claude/settings.json` instead of writing a project-level `.mcp.json`. |
+| `--force` | flag | off | Overwrite the target file (or existing `mcpServers.<name>` entry when `--global`) if it already exists. |
+| `--dry-run` | flag | off | Print the planned output without writing any files. |
+
+Exit code: 0 on success, 1 if no `[mcp.*]` sections are found in `uio.toml`.
+
+`.mcp.json` is added to `.gitignore` automatically by `uio init` because env var references vary per developer.
+
+See [MCP Integration](08-mcp.md) for full context on configuring and using MCP servers.
+
+---
+
+## `uio memory`
+
+### `uio memory list`
+
+Lists all memory files from `.uio/memory/*.memory.md` with their name, scope, and estimated body size in tokens.
+
+Output columns: NAME, SCOPE, TOKENS
+
+```bash
+uio memory list
+```
+
+### `uio memory view <name>`
+
+Prints the full body of the named memory file to stdout.
+
+`NAME` is the value of the `name` frontmatter field (or the file stem if the field is absent).
+
+```bash
+uio memory view my-context
+```
+
+Exit code: 0 on success, 1 if the named memory file is not found.
+
+### `uio memory clear [--session]`
+
+Truncates memory file bodies. Without `--session`, clears ALL memory files (both project-scoped and session-scoped). With `--session`, clears only session-scoped memory files.
+
+```bash
+uio memory clear            # clear all memory files
+uio memory clear --session  # clear only session-scoped files
+```
+
+| Flag | Description |
+|---|---|
+| `--session` | Clear only memory files with `scope: session` in their frontmatter (default: clear all). |
 
 ---
 

--- a/docs/05-cli.md
+++ b/docs/05-cli.md
@@ -351,7 +351,10 @@ If `.claude/commands` already exists as a directory symlink (legacy setup), `uio
 
 ### `uio mcp init`
 
-Scaffolds an MCP configuration file for Claude Code or VS Code, populated from the `[mcp.<name>]` server definitions in `uio.toml`. Secret values are never written to disk — env var references (e.g. `${GITHUB_PERSONAL_ACCESS_TOKEN}`) are emitted instead.
+Scaffolds an MCP configuration file for Claude Code or VS Code, populated from the `[mcp.<name>]` server definitions in `uio.toml`. Secret values are never written to disk:
+
+- For `--for claude`: `env_keys` become `${KEY_NAME}` env var references read from the environment at startup.
+- For `--for vscode`: `env_keys` become `${input:key-name}` prompt references backed by a VS Code `inputs` block (`promptString`, `password: true`) — VS Code prompts the user to enter each secret at startup.
 
 Declare the servers you want to expose in `uio.toml` first:
 
@@ -368,7 +371,7 @@ uio mcp init --for claude                 # writes .mcp.json
 uio mcp init --for vscode                 # writes .vscode/mcp.json
 uio mcp init --for claude --global        # merges into ~/.claude/settings.json
 uio mcp init --for claude --force         # overwrites an existing .mcp.json
-uio mcp init --for vscode --dry-run       # print planned output without writing
+uio mcp init --for vscode --dry-run       # print target path without writing
 ```
 
 | Flag | Type | Default | Description |
@@ -376,11 +379,11 @@ uio mcp init --for vscode --dry-run       # print planned output without writing
 | `--for` | `claude\|vscode` | — | **Required.** Target platform. `claude` writes `.mcp.json`; `vscode` writes `.vscode/mcp.json`. |
 | `--global` | flag | off | *(claude only)* Merge server entries into `~/.claude/settings.json` instead of writing a project-level `.mcp.json`. |
 | `--force` | flag | off | Overwrite the target file (or existing `mcpServers.<name>` entry when `--global`) if it already exists. |
-| `--dry-run` | flag | off | Print the planned output without writing any files. |
+| `--dry-run` | flag | off | Print the target path without writing any files. |
 
 Exit code: 0 on success, 1 if no `[mcp.*]` sections are found in `uio.toml`.
 
-`.mcp.json` is added to `.gitignore` automatically by `uio init` because env var references vary per developer.
+`.mcp.json` is added to `.gitignore` automatically by `uio init` if a `.gitignore` already exists, because secret references vary per developer.
 
 See [MCP Integration](08-mcp.md) for full context on configuring and using MCP servers.
 

--- a/docs/08-mcp.md
+++ b/docs/08-mcp.md
@@ -191,7 +191,7 @@ uio mcp init --for vscode    # writes .vscode/mcp.json for VS Code
 uio mcp init --for claude --global   # merges into ~/.claude/settings.json
 ```
 
-Secret values are never written to disk — `env_keys` declared in `uio.toml` become env var references (`${MY_TOKEN}`) in the output file.
+Secret values are never written to disk. For `--for claude`, `env_keys` become `${MY_TOKEN}` env var references. For `--for vscode`, they become `${input:my-token}` prompt references — VS Code prompts the user to enter each secret at startup.
 
 See [`uio mcp init`](05-cli.md#uio-mcp-init) in the CLI reference for the full flag list.
 

--- a/docs/08-mcp.md
+++ b/docs/08-mcp.md
@@ -122,6 +122,8 @@ stdio MCP servers are per-process: each host (uio, VS Code, Claude Code) spawns 
 
 To give VS Code agents the same MCP tools that uio provides, add each server from `uio.toml` to `.vscode/mcp.json`. The servers configured in this project are already mirrored — see `.vscode/mcp.json`. The `{cwd}` placeholder used in `uio.toml` maps to `${workspaceFolder}` in VS Code config.
 
+`uio mcp init --for vscode` generates `.vscode/mcp.json` automatically from the `[mcp.<name>]` sections in `uio.toml`. See [`uio mcp init`](05-cli.md#uio-mcp-init) in the CLI reference for the full flag list.
+
 ### Writing agents that work in both environments
 
 Because tool names differ between uio and VS Code, agent definitions that hardcode `mcp__github__*` tool names will only work in uio. Agent definitions that describe *what to do* rather than which specific tool call to invoke will work in both — the model discovers available tools at runtime and adapts.
@@ -176,6 +178,22 @@ export MCP_GITHUB_COMMAND="gh mcp server"
 5. **Shutdown** — `close()` closes the stdin pipe and terminates the process on session end.
 
 Communication uses newline-delimited JSON. Each request includes an incrementing `id`; responses are matched by `id`. The client spins on `stdout.readline()` until the matching response arrives.
+
+---
+
+## Generating platform config files with `uio mcp init`
+
+Once you have defined your MCP servers in `uio.toml`, run `uio mcp init` to scaffold the platform-specific config file without manually writing env var references:
+
+```bash
+uio mcp init --for claude    # writes .mcp.json for Claude Code
+uio mcp init --for vscode    # writes .vscode/mcp.json for VS Code
+uio mcp init --for claude --global   # merges into ~/.claude/settings.json
+```
+
+Secret values are never written to disk — `env_keys` declared in `uio.toml` become env var references (`${MY_TOKEN}`) in the output file.
+
+See [`uio mcp init`](05-cli.md#uio-mcp-init) in the CLI reference for the full flag list.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a `uio workflow` section to `docs/05-cli.md` documenting `run` (with `--provider`, `--model`, `--no-mcp`, `--shell` flags) and `list` subcommands
- Adds a `uio memory` section documenting `list`, `view <name>`, and `clear [--session]` with flag tables and examples
- Adds a `uio mcp init` section documenting `--for`, `--global`, `--force`, and `--dry-run` with examples showing all three output targets
- Updates the command tree at the top of `docs/05-cli.md` to include the three new command groups
- Adds cross-references in `docs/08-mcp.md`: a new "Generating platform config files with `uio mcp init`" section and a note in the VS Code mirroring subsection

## Test plan

- [ ] Read through the new `uio workflow` section and verify flags match `uio/cli/workflow.py`
- [ ] Read through the new `uio memory` section and verify flags match `uio/cli/memory.py`
- [ ] Read through the new `uio mcp init` section and verify flags match `uio/cli/mcp.py`
- [ ] Confirm command tree in `docs/05-cli.md` reflects all three new groups
- [ ] Confirm `docs/08-mcp.md` links back to the CLI reference

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)