### PR TITLE
docs: document VCS tool alias system and GitLab provider support (#223)

### DIFF
--- a/docs/04-frontmatter.md
+++ b/docs/04-frontmatter.md
@@ -110,6 +110,83 @@ vcs-provider: gitlab
 
 Non-GitHub providers do not validate `vcs-identity` env vars at startup (env var names vary by installation).
 
+### VCS tool aliases
+
+The alias table is injected into the system prompt whenever **either** of these conditions is true:
+
+- `capabilities` includes `"vcs"`, or
+- `vcs-identity` is set to any recognised value (`planner`, `coder`, `reviewer`)
+
+When triggered, uio prepends a `## VCS Tool Aliases` preamble block to the system prompt. The block lists every abstract `vcs__*` name and the concrete MCP tool name it resolves to for the active provider. The LLM can then call `vcs__list_pull_requests` (for example) without knowing whether the underlying server is GitHub or GitLab.
+
+**Prefer `vcs__*` names in agent bodies.** Using the abstract names keeps the definition portable — switching between providers requires only a `vcs-provider:` change in frontmatter, not a rewrite of the agent body.
+
+The full alias table across both supported providers:
+
+| Abstract name | GitHub concrete | GitLab concrete |
+|---|---|---|
+| `vcs__add_issue_comment` | `mcp__github__add_issue_comment` | `mcp__gitlab__create_note` |
+| `vcs__create_branch` | `mcp__github__create_branch` | `mcp__gitlab__create_branch` |
+| `vcs__create_issue` | `mcp__github__create_issue` | `mcp__gitlab__create_issue` |
+| `vcs__create_or_update_file` | `mcp__github__create_or_update_file` | `mcp__gitlab__create_or_update_file` |
+| `vcs__create_pull_request` | `mcp__github__create_pull_request` | `mcp__gitlab__create_merge_request` |
+| `vcs__get_file_contents` | `mcp__github__get_file_contents` | `mcp__gitlab__get_file` |
+| `vcs__get_issue` | `mcp__github__get_issue` | `mcp__gitlab__get_issue` |
+| `vcs__get_pull_request` | `mcp__github__get_pull_request` | `mcp__gitlab__get_merge_request` |
+| `vcs__list_branches` | `mcp__github__list_branches` | `mcp__gitlab__list_branches` |
+| `vcs__list_issues` | `mcp__github__list_issues` | `mcp__gitlab__list_issues` |
+| `vcs__list_pull_requests` | `mcp__github__list_pull_requests` | `mcp__gitlab__list_merge_requests` |
+| `vcs__merge_pull_request` | `mcp__github__merge_pull_request` | GitHub only — no GitLab equivalent |
+| `vcs__push_files` | `mcp__github__push_files` | `mcp__gitlab__push_files` |
+| `vcs__search_code` | `mcp__github__search_code` | `mcp__gitlab__search` |
+| `vcs__search_repositories` | `mcp__github__search_repositories` | GitHub only — no GitLab equivalent |
+| `vcs__update_issue` | `mcp__github__update_issue` | `mcp__gitlab__update_issue` |
+
+`vcs__merge_pull_request` and `vcs__search_repositories` have no GitLab equivalent; agents that use them must guard against GitLab deployments or omit those calls when `vcs-provider: gitlab` is set.
+
+#### Worked example — provider-agnostic PR triage agent
+
+The following agent uses only `vcs__*` names. It works on both GitHub and GitLab by changing one frontmatter line.
+
+```markdown
+---
+name: pr-triage
+description: Labels and summarises open pull requests by age and size.
+complexity: small
+capabilities:
+  - vcs
+vcs-provider: github   # switch to "gitlab" to target a GitLab instance
+---
+
+# Agent: pr-triage
+
+You are a pull-request triage assistant. Scan all open pull requests and
+produce a brief triage report grouped by urgency.
+
+## Steps
+
+1. Call `vcs__list_pull_requests` with `state: "open"` to retrieve open PRs.
+2. For each PR, note: title, author, created date, and number of changed files
+   (call `vcs__get_pull_request` if you need details).
+3. Classify each PR:
+   - **Stale** — open more than 14 days with no recent activity
+   - **Large** — more than 50 files changed
+   - **Ready** — recent activity, small diff, not yet reviewed
+4. Print a Markdown table: PR number | title | author | age | classification.
+5. Summarise the totals at the end (stale / large / ready / other).
+
+Do not modify any PR. This is a read-only reporting task.
+```
+
+To retarget this agent at a GitLab instance, change the frontmatter to:
+
+```yaml
+vcs-provider: gitlab
+```
+
+No other edits are needed — `vcs__list_pull_requests` resolves to
+`mcp__gitlab__list_merge_requests` automatically.
+
 ### `github-identity` (deprecated)
 
 `github-identity` is a deprecated alias for `vcs-identity`. It is still accepted by the parser for backwards compatibility, but new definitions should use `vcs-identity`.

--- a/docs/04-frontmatter.md
+++ b/docs/04-frontmatter.md
@@ -117,6 +117,8 @@ The alias table is injected into the system prompt whenever **either** of these 
 - `capabilities` includes `"vcs"`, or
 - `vcs-identity` is set to any recognised value (`planner`, `coder`, `reviewer`)
 
+> **Note:** `vcs-identity` is GitHub App authentication only. Combining `vcs-identity` with `vcs-provider: gitlab` causes a hard startup error. To target GitLab, use `capabilities: [vcs]` + `vcs-provider: gitlab` and omit `vcs-identity`.
+
 When triggered, uio prepends a `## VCS Tool Aliases` preamble block to the system prompt. The block lists every abstract `vcs__*` name and the concrete MCP tool name it resolves to for the active provider. The LLM can then call `vcs__list_pull_requests` (for example) without knowing whether the underlying server is GitHub or GitLab.
 
 **Prefer `vcs__*` names in agent bodies.** Using the abstract names keeps the definition portable — switching between providers requires only a `vcs-provider:` change in frontmatter, not a rewrite of the agent body.
@@ -186,6 +188,8 @@ vcs-provider: gitlab
 
 No other edits are needed — `vcs__list_pull_requests` resolves to
 `mcp__gitlab__list_merge_requests` automatically.
+
+Before switching providers, make sure the GitLab MCP server is registered in `uio.toml` and `GITLAB_TOKEN` is set — see [GitLab setup in the providers reference](07-providers.md#gitlab).
 
 ### `github-identity` (deprecated)
 

--- a/docs/07-providers.md
+++ b/docs/07-providers.md
@@ -161,6 +161,72 @@ All Ollama runs are recorded in the cost ledger with `estimated_cost_usd: 0.0`.
 
 ---
 
+## GitLab
+
+GitLab is not an LLM provider — it is a **VCS provider** for agent definitions that use `vcs-identity` or `capabilities: [vcs]`. When `vcs-provider: gitlab` is set in frontmatter, uio wires up the GitLab MCP server's tool aliases so agents can use the provider-neutral `vcs__*` names against a GitLab instance.
+
+### MCP server
+
+The GitLab MCP server is the official `@gitlab/mcp-server` npm package maintained by GitLab.
+
+**Install globally:**
+
+```bash
+npm install -g @gitlab/mcp-server
+```
+
+**Or run without installing via npx (recommended):**
+
+```bash
+npx -y @gitlab/mcp-server stdio
+```
+
+### Required environment variable
+
+| Variable | Description |
+|---|---|
+| `GITLAB_TOKEN` | A GitLab personal access token with `api` scope |
+
+Generate a token at **GitLab → User Settings → Access Tokens**. Select the `api` scope. No other scopes are required for standard agent operations.
+
+```bash
+export GITLAB_TOKEN=glpat-xxxxxxxxxxxxxxxxxxxx
+```
+
+### Register in `uio.toml`
+
+Add the GitLab plugin under `[[mcp.plugins]]`:
+
+```toml
+[[mcp.plugins]]
+name     = "gitlab"
+type     = "vcs"
+command  = "npx -y @gitlab/mcp-server stdio"
+env_keys = ["GITLAB_TOKEN"]
+```
+
+The `type = "vcs"` field tells uio this plugin provides VCS tools. The `env_keys` list specifies which environment variables must be present for the plugin to be activated — if `GITLAB_TOKEN` is absent, the plugin is skipped and uio logs a warning.
+
+### How it differs from GitHub
+
+| Aspect | GitHub | GitLab |
+|---|---|---|
+| Tool prefix | `mcp__github__*` | `mcp__gitlab__*` |
+| Pull requests | Called "pull requests" | Called "merge requests" |
+| `vcs__list_pull_requests` | `mcp__github__list_pull_requests` | `mcp__gitlab__list_merge_requests` |
+| `vcs__create_pull_request` | `mcp__github__create_pull_request` | `mcp__gitlab__create_merge_request` |
+| `vcs__add_issue_comment` | `mcp__github__add_issue_comment` | `mcp__gitlab__create_note` |
+| `vcs__get_file_contents` | `mcp__github__get_file_contents` | `mcp__gitlab__get_file` |
+| `vcs__search_code` | `mcp__github__search_code` | `mcp__gitlab__search` |
+| `vcs__merge_pull_request` | `mcp__github__merge_pull_request` | **No equivalent** |
+| `vcs__search_repositories` | `mcp__github__search_repositories` | **No equivalent** |
+
+The two GitHub-only aliases (`vcs__merge_pull_request` and `vcs__search_repositories`) have no GitLab counterpart. Agents that call these tools will receive a tool-not-found error when running against a GitLab deployment. Design provider-agnostic agents to avoid these two operations, or guard them behind a provider check.
+
+See [VCS tool aliases](04-frontmatter.md#vcs-tool-aliases) in the frontmatter reference for the full alias table.
+
+---
+
 ## LiteLLM proxy
 
 LiteLLM provides an OpenAI-compatible proxy for 100+ providers (Anthropic, Mistral, Groq, Bedrock, etc.). uio's OpenAI client works with any LiteLLM deployment.

--- a/docs/07-providers.md
+++ b/docs/07-providers.md
@@ -175,7 +175,7 @@ The GitLab MCP server is the official `@gitlab/mcp-server` npm package maintaine
 npm install -g @gitlab/mcp-server
 ```
 
-**Or run without installing via npx (recommended):**
+Alternatively, run it without a global install using npx (recommended — no installation step required):
 
 ```bash
 npx -y @gitlab/mcp-server stdio


### PR DESCRIPTION
## Summary

Closes #223

Documents the VCS tool alias system and GitLab provider support that were previously undocumented.

## Changes

- **`docs/04-frontmatter.md`** — Added a `### VCS tool aliases` subsection after the existing `vcs-provider` section. Covers:
  - When the alias table is injected (either `capabilities: [vcs]` or `vcs-identity` is set)
  - How it works: uio injects a preamble mapping abstract `vcs__*` names to provider-specific MCP tool names
  - Full three-column table of all 16 abstract names with their GitHub and GitLab concrete names, marking the two GitHub-only entries (`vcs__merge_pull_request`, `vcs__search_repositories`) as having no GitLab equivalent
  - Guidance to prefer `vcs__*` names for provider-agnostic agent definitions
  - Worked example: a complete provider-agnostic PR triage agent that switches providers with one frontmatter line change

- **`docs/07-providers.md`** — Added a new `## GitLab` section after the Ollama section. Covers:
  - What the GitLab MCP server is (`@gitlab/mcp-server` npm package)
  - Installation via `npm install -g` or `npx -y`
  - Required env var: `GITLAB_TOKEN` (personal access token with `api` scope)
  - How to register it in `uio.toml` using `[[mcp.plugins]]`
  - Comparison table showing how it differs from GitHub (MR vs PR terminology, two GitHub-only aliases)
  - Cross-reference link to the alias table in `04-frontmatter.md`

## Test plan

- [ ] `pytest` passes locally
- [ ] `ruff check .` passes locally
- [ ] `ruff format --check .` passes locally
- [ ] Verify the alias table in `04-frontmatter.md` matches `VCS_TOOL_MAP` in `uio/core/vcs.py` (16 GitHub entries, 14 GitLab entries)
- [ ] Verify the worked PR triage example uses only `vcs__*` names (no provider-specific names)
- [ ] Verify the GitLab section in `07-providers.md` matches the `uio.toml` config example in `uio/config.py` lines 78–82

## Notes for reviewers

The documentation was derived directly from `uio/core/vcs.py` (`VCS_TOOL_MAP`) and `uio/core/runner.py` (lines 279–285, alias injection trigger). No source code was modified — this is a documentation-only change.

---

> This pull request was created by the [uio AI Coder](https://github.com/jomkz/uio) agent.