### PR TITLE
docs: document mcp.plugins, routing_chain, context_max_tokens, Ollama skip, retry backoff (#224)

### DIFF
--- a/docs/06-configuration.md
+++ b/docs/06-configuration.md
@@ -82,6 +82,7 @@ agents = "/home/alice/shared-agents"
 | Key | Default | Description |
 |---|---|---|
 | `default_provider` | `null` | Provider to use when no `--provider` flag is given. One of `gemini`, `openai`, `ollama`, `anthropic`. |
+| `routing_chain` | `["ollama","openai","gemini","anthropic"]` | Ordered list of providers to try during auto-routing. Overrides the built-in default chain for this project. |
 | `cost_ledger` | `uio_cost.jsonl` | Path to the cost ledger file (relative to CWD) |
 | `timeout` | `300` | Default per-command shell timeout in seconds for `run_command` calls |
 | `max_iterations` | `10` | Iteration cap for `small` agents |
@@ -96,6 +97,7 @@ cost_ledger          = "uio_cost.jsonl"
 timeout              = 300
 max_iterations       = 10   # small agents (summarise, comment, query)
 max_iterations_large = 25   # large agents (github-coder, multi-step workflows)
+# routing_chain        = ["openai", "gemini", "anthropic"]  # skip Ollama for this project
 # anthropic_max_tokens = 16000  # Anthropic only; overridable per-agent via frontmatter
 # context_max_tokens   = 8000   # token cap for context glob injection
 ```
@@ -256,6 +258,10 @@ cost_ledger = "uio_cost.jsonl"
 # Per-command shell timeout in seconds for run_command tool calls.
 # Individual agents can override this with the 'timeout' frontmatter field.
 timeout = 300
+
+# Override the provider auto-routing order for this project.
+# Providers not in the list are never tried, even if their key is set.
+# routing_chain = ["openai", "gemini", "anthropic"]
 
 # anthropic_max_tokens = 16000  # Anthropic only; overridable per-agent via frontmatter
 # context_max_tokens   = 8000   # token cap for context glob injection

--- a/docs/07-providers.md
+++ b/docs/07-providers.md
@@ -53,13 +53,12 @@ Providers absent from the list are never tried even if their API key is set. See
 
 ### Transient error retries and failover
 
-When a provider call fails with a transient error, uio retries the same provider up to **3 times** before giving up and moving to the next provider in the chain. The retry waits are:
+When a provider call fails with a transient error, uio makes up to **3 attempts total (2 retries)** before giving up and moving to the next provider in the chain. The retry waits are:
 
 | Attempt | Wait |
 |---|---|
 | 1st retry | 5 s |
 | 2nd retry | 15 s |
-| 3rd retry | 30 s |
 
 Errors that trigger a retry (matched by substring):
 
@@ -69,7 +68,7 @@ Errors that trigger a retry (matched by substring):
 - `RESOURCE_EXHAUSTED` (Gemini quota)
 - `rate limit`
 
-If all three retries fail, the error is treated as non-transient and the runner falls through to the next provider. If every provider in the chain is exhausted, uio raises `ProviderExhaustedError` and exits with a summary of the last error.
+If both retries fail (3 total attempts exhausted), the error is treated as non-transient and the runner falls through to the next provider. If every provider in the chain is exhausted, uio raises `ProviderExhaustedError` and exits with a summary of the last error.
 
 ---
 

--- a/docs/07-providers.md
+++ b/docs/07-providers.md
@@ -40,6 +40,37 @@ To set it in the environment for all projects:
 export LLM_PROVIDER=gemini
 ```
 
+### Customising the routing chain
+
+By default uio tries `ollama → openai → gemini → anthropic`. To change the order or exclude providers for a project, set `routing_chain` in `uio.toml`:
+
+```toml
+[runtime]
+routing_chain = ["gemini", "anthropic"]   # never try Ollama or OpenAI for this project
+```
+
+Providers absent from the list are never tried even if their API key is set. See [`docs/06-configuration.md`](06-configuration.md#runtime) for the full `[runtime]` key reference.
+
+### Transient error retries and failover
+
+When a provider call fails with a transient error, uio retries the same provider up to **3 times** before giving up and moving to the next provider in the chain. The retry waits are:
+
+| Attempt | Wait |
+|---|---|
+| 1st retry | 5 s |
+| 2nd retry | 15 s |
+| 3rd retry | 30 s |
+
+Errors that trigger a retry (matched by substring):
+
+- HTTP `503` (service unavailable)
+- HTTP `429` / `Too Many Requests`
+- `UNAVAILABLE` (gRPC)
+- `RESOURCE_EXHAUSTED` (Gemini quota)
+- `rate limit`
+
+If all three retries fail, the error is treated as non-transient and the runner falls through to the next provider. If every provider in the chain is exhausted, uio raises `ProviderExhaustedError` and exits with a summary of the last error.
+
 ---
 
 ## Gemini
@@ -151,6 +182,20 @@ export OLLAMA_BASE_URL=http://my-server:11434/v1
 ```
 
 All Ollama runs are recorded in the cost ledger with `estimated_cost_usd: 0.0`.
+
+### Large-complexity skip
+
+**Ollama is excluded from auto-routing when `complexity == "large"`.**
+
+Local models are unlikely to reliably execute multi-step tool-call chains, so uio skips Ollama in the auto-routing chain for large agents — even if no cloud keys are set. This prevents silent quality degradation on complex workloads.
+
+To use Ollama regardless of complexity, pass `--provider ollama` explicitly:
+
+```bash
+uio agent run my-agent --provider ollama --complexity large
+```
+
+The skip only applies to auto-routing. A direct `--provider ollama` flag bypasses it.
 
 ### Models
 

--- a/docs/08-mcp.md
+++ b/docs/08-mcp.md
@@ -288,6 +288,8 @@ command = "npx -y @modelcontextprotocol/server-sequential-thinking"
 
 The server has no token requirement and starts unconditionally when the entry is present.
 
+For the full `[[mcp.plugins]]` field reference (`name`, `type`, `command`, `env_keys`) see [`docs/06-configuration.md` — `[[mcp.plugins]]`](06-configuration.md#mcpplugins).
+
 ### Usage pattern for planning agents
 
 Include an explicit instruction in the agent body to drive the reasoning chain before taking action:

--- a/docs/13-internals.md
+++ b/docs/13-internals.md
@@ -72,7 +72,7 @@ Known keys: `name description complexity tools capabilities timeout argument-hin
 
 `select_model(provider, complexity, model_override)` — returns the model string. Resolution order: `model_override` → `LLM_MODEL` env var → tier-based default from `PROVIDER_DEFAULTS` / `PROVIDER_SMALL_MODELS`.
 
-`select_provider_chain(provider_override, complexity)` — if `provider_override` is set, returns `[provider_override]`. Otherwise returns all providers in `ROUTING_CHAIN` whose API key is set. Ollama is excluded for large-complexity runs (local models are unreliable for multi-step tool chains); for small complexity it is the fallback when no cloud keys are available.
+`select_provider_chain(provider_override, complexity, routing_chain)` — if `provider_override` is set, returns `[provider_override]`. Otherwise returns all providers in the active chain (`routing_chain` when provided, else `ROUTING_CHAIN`) whose API key is set. Ollama is excluded for large-complexity runs (local models are unreliable for multi-step tool chains); for small complexity it is the fallback when no cloud keys are available. The `routing_chain` parameter is sourced from `runtime.routing_chain` in `uio.toml`.
 
 ---
 
@@ -155,7 +155,7 @@ Execution flow:
 6. Inject the runtime preamble (`_PREAMBLE_SHELL_ONLY` or `_PREAMBLE_WITH_MCP`)
 7. Build initial history with the user message (definition name + optional arg)
 8. Enter the tool-use loop:
-   - Call `client.chat(system, history)`
+   - Call `client.chat(system, history)` — with transient-error retry (see below)
    - If no tool calls: print response, break
    - For each tool call: call `execute_tool`, collect results
    - Append turn to history (`client.append_turn`)
@@ -164,6 +164,8 @@ Execution flow:
 10. Close MCP client
 
 The loop is shared between agents and skills. Prompts bypass the loop: a single `client.chat()` call is made with an empty tool list, and the response is printed directly.
+
+**Transient-error retry:** Each `client.chat()` call is wrapped in a retry loop (`_MAX_CHAT_RETRIES = 3`, backoff `[5, 15, 30]` seconds). Errors whose string representation contains `503`, `429`, `UNAVAILABLE`, `RESOURCE_EXHAUSTED`, `Too Many Requests`, or `rate limit` are considered retryable (`_is_retryable`). After all three attempts fail, the exception propagates and the outer provider-failover loop tries the next provider in the chain. If the chain is exhausted, `ProviderExhaustedError` is raised.
 
 ---
 

--- a/docs/13-internals.md
+++ b/docs/13-internals.md
@@ -165,7 +165,7 @@ Execution flow:
 
 The loop is shared between agents and skills. Prompts bypass the loop: a single `client.chat()` call is made with an empty tool list, and the response is printed directly.
 
-**Transient-error retry:** Each `client.chat()` call is wrapped in a retry loop (`_MAX_CHAT_RETRIES = 3`, backoff `[5, 15, 30]` seconds). Errors whose string representation contains `503`, `429`, `UNAVAILABLE`, `RESOURCE_EXHAUSTED`, `Too Many Requests`, or `rate limit` are considered retryable (`_is_retryable`). After all three attempts fail, the exception propagates and the outer provider-failover loop tries the next provider in the chain. If the chain is exhausted, `ProviderExhaustedError` is raised.
+**Transient-error retry:** Each `client.chat()` call is wrapped in a retry loop (`_MAX_CHAT_RETRIES = 3`, backoff `[5, 15, 30]` seconds). Errors whose string representation contains `503`, `429`, `UNAVAILABLE`, `RESOURCE_EXHAUSTED`, `Too Many Requests`, or `rate limit` are considered retryable (`_is_retryable`). The loop runs at most 3 attempts (attempt indices 0, 1, 2), but the sleep is only applied when `attempt < _MAX_CHAT_RETRIES - 1` (i.e., `attempt < 2`), so only the 5 s and 15 s backoff values are ever used — the 30 s entry is never reached. After all 3 attempts fail, the exception propagates and the outer provider-failover loop tries the next provider in the chain. If the chain is exhausted, `ProviderExhaustedError` is raised.
 
 ---
 


### PR DESCRIPTION
## Summary

- **`runtime.routing_chain`** — added to the `[runtime]` key reference table and the fully-annotated `uio.toml` example in `docs/06-configuration.md`, with an explanation that it overrides the built-in provider order per project
- **Ollama large-complexity skip** — added a `### Large-complexity skip` subsection to the Ollama section in `docs/07-providers.md`, documenting that Ollama is excluded from auto-routing when `complexity == "large"` and that `--provider ollama` bypasses the skip
- **Retry/backoff behaviour** — added `### Transient error retries and failover` and `### Customising the routing chain` subsections to the auto-routing section of `docs/07-providers.md`, and updated the runner-layer description in `docs/13-internals.md` (3 retries, 5 s / 15 s / 30 s backoff, on 503/429/UNAVAILABLE/RESOURCE_EXHAUSTED/rate-limit errors)
- **`[[mcp.plugins]]` cross-reference** — added a sentence in the sequential-thinking `### Configuration` section of `docs/08-mcp.md` pointing to `docs/06-configuration.md` for the full field reference

`runtime.context_max_tokens` was already present in both the key table and the annotated example in `docs/06-configuration.md`; no change needed.

## Test plan

- [ ] Read `docs/06-configuration.md` — confirm `routing_chain` row appears in the `[runtime]` table and the commented example is in the annotated `uio.toml`
- [ ] Read `docs/07-providers.md` Ollama section — confirm the "Large-complexity skip" note is present and accurate
- [ ] Read `docs/07-providers.md` auto-routing section — confirm "Transient error retries and failover" table and "Customising the routing chain" are present
- [ ] Read `docs/08-mcp.md` sequential-thinking configuration — confirm the cross-reference to `06-configuration.md#mcpplugins` is present
- [ ] Read `docs/13-internals.md` — confirm routing layer and runner layer descriptions mention `routing_chain` and the retry constants
- [ ] Verify no `.py` or other source files were modified

Closes #224