### PR TITLE
feat: assign issue to bot identity before starting implementation

### DIFF
--- a/definitions/agents/coder.agent.md
+++ b/definitions/agents/coder.agent.md
@@ -124,26 +124,33 @@ If no blocking questions are found, proceed to step 0d.
 
 **Skip this step** (print a note: "No issue number provided — skipping self-assignment") and proceed to step 1 when no issue number was given.
 
-**Resolve the bot login.** Prefer the MCP tool if available:
+**Resolve the bot login (MCP path only).** Login resolution is required only when using the MCP tool for assignment; the CLI path uses `@me` directly and does not need it.
+
+If the MCP tool is available, call:
 
 ```
 mcp__mcp-github__get_me   # returns { login: "..." }
 ```
 
-Fall back to the CLI:
+If the MCP tool is unavailable, fall back to:
 
 ```bash
 gh api user --jq '.login'
 ```
 
+If **both** the MCP call and the CLI fallback fail, print a visible warning and proceed to step 1 without attempting assignment:
+
+```
+⚠ Could not resolve bot login: <error> — skipping self-assignment
+```
+
 **Attempt assignment.** Prefer the MCP tool if available:
 
 ```
-mcp__mcp-github__issue_write  method=update  owner=<owner>  repo=<repo>
-  issue_number=<number>  assignees=["<login>"]
+mcp__mcp-github__issue_write  query={"method": "update", "owner": "<owner>", "repo": "<repo>", "issue_number": <number>, "assignees": ["<login>"]}
 ```
 
-Fall back to the CLI:
+Fall back to the CLI (the `@me` alias resolves automatically; `<login>` is not used here):
 
 ```bash
 gh issue edit <number> --repo <owner>/<repo> --add-assignee @me
@@ -154,6 +161,8 @@ gh issue edit <number> --repo <owner>/<repo> --add-assignee @me
 ```
 ⚠ Could not assign issue: <error> — continuing
 ```
+
+Proceed to step 1.
 
 ### 1. Understand the target repository
 

--- a/definitions/agents/coder.agent.md
+++ b/definitions/agents/coder.agent.md
@@ -116,7 +116,44 @@ If one or more blocking questions are found:
 
 2. **Stop immediately** — do not clone, do not create a branch, do not write any code.
 
-If no blocking questions are found, proceed to step 1.
+If no blocking questions are found, proceed to step 0d.
+
+---
+
+#### 0d. Assign the issue to the bot identity (if issue number provided)
+
+**Skip this step** (print a note: "No issue number provided — skipping self-assignment") and proceed to step 1 when no issue number was given.
+
+**Resolve the bot login.** Prefer the MCP tool if available:
+
+```
+mcp__mcp-github__get_me   # returns { login: "..." }
+```
+
+Fall back to the CLI:
+
+```bash
+gh api user --jq '.login'
+```
+
+**Attempt assignment.** Prefer the MCP tool if available:
+
+```
+mcp__mcp-github__issue_write  method=update  owner=<owner>  repo=<repo>
+  issue_number=<number>  assignees=["<login>"]
+```
+
+Fall back to the CLI:
+
+```bash
+gh issue edit <number> --repo <owner>/<repo> --add-assignee @me
+```
+
+**On failure** (any error from either the MCP call or the CLI), print a visible warning and continue — do not halt the workflow:
+
+```
+⚠ Could not assign issue: <error> — continuing
+```
 
 ### 1. Understand the target repository
 


### PR DESCRIPTION
## Summary

- Adds new step **0d** to `definitions/agents/coder.agent.md`, inserted between step 0c (blocking-question scan) and step 1 (clone/explore).
- The step resolves the bot login via `mcp__mcp-github__get_me` (MCP) or `gh api user --jq '.login'` (CLI), then assigns the issue using `mcp__mcp-github__issue_write` with `method: update` (MCP) or `gh issue edit --add-assignee @me` (CLI).
- Assignment failure emits a visible warning (`⚠ Could not assign issue: <error> — continuing`) and does not halt the workflow.
- The step is skipped with a printed note when no issue number was provided; all existing steps 1–9 are unchanged.

## Test plan

- [ ] Invoke the coder agent with an issue number; confirm the issue is assigned to the bot after step 0d runs.
- [ ] Revoke assignment permissions for the token; confirm the agent prints the warning and continues to step 1 without aborting.
- [ ] Invoke the coder agent without an issue number; confirm the skip note is printed and step 1 proceeds normally.
- [ ] Verify no changes to steps 1–9 in the rendered agent definition.

Closes #244