### PR TITLE
docs: position uio as the agent runtime for CI/CD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
 # uio
 
-`uio` is a lightweight, provider-agnostic framework for building the **Agentic Stack** — agents, skills, prompts, and tools — as plain markdown files with YAML frontmatter. The `uio` CLI discovers and executes them against any supported LLM provider. The [origin story](docs/16-about.md) covers how and why.
+`uio` is the agent runtime for CI/CD. Define agents, skills, and prompts as plain markdown files with YAML frontmatter — checked into your repo, executed headlessly in pipelines, and wired to any LLM provider. The [origin story](docs/16-about.md) covers how and why.
+
+## Why uio instead of an interactive assistant?
+
+Interactive assistants (chat UIs, IDE plugins) are built for humans in the loop. uio is built for the opposite: **automated, headless, version-controlled agent workflows** that run without a human present.
+
+| Need | Interactive assistant | uio |
+|---|---|---|
+| Runs in CI/CD pipelines | No | Yes |
+| Definitions stored in git | No | Yes — plain markdown files |
+| Reproducible across environments | No | Yes — provider-agnostic |
+| Scriptable / composable | Limited | Yes — `uio agent run`, `uio skill run` |
+| Auditable history of changes | No | Yes — git blame, PR diffs |
+
+If your use case is "trigger an agent on push, review its output in a PR" — that is exactly what uio is designed for.
 
 ## Concepts
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 `uio` is the agent runtime for CI/CD. Define agents, skills, and prompts as plain markdown files with YAML frontmatter — checked into your repo, executed headlessly in pipelines, and wired to any LLM provider. The [origin story](docs/16-about.md) covers how and why.
 
-## Why uio instead of an interactive assistant?
+## uio vs. interactive assistants
 
-Interactive assistants (chat UIs, IDE plugins) are built for humans in the loop. uio is built for the opposite: **automated, headless, version-controlled agent workflows** that run without a human present.
+Interactive assistants (chat UIs, IDE plugins) are built for humans in the loop. uio is built for the other end of the spectrum: **automated, headless, version-controlled agent workflows** that run without a human present.
 
-| Need | Interactive assistant | uio |
+| Need | Interactive assistant (e.g. Copilot, Cursor) | uio |
 |---|---|---|
-| Runs in CI/CD pipelines | No | Yes |
+| Designed for headless CI/CD execution | No | Yes |
 | Definitions stored in git | No | Yes — plain markdown files |
 | Reproducible across environments | No | Yes — provider-agnostic |
 | Scriptable / composable | Limited | Yes — `uio agent run`, `uio skill run` |


### PR DESCRIPTION
## Summary

- Rewrites the opening paragraph to lead with CI/CD positioning: "uio is the agent runtime for CI/CD"
- Adds a "Why uio instead of an interactive assistant?" section with a comparison table covering pipelines, git-stored definitions, reproducibility, scriptability, and auditability
- Keeps definition-as-code and headless/scriptable nature prominent above the fold, immediately after the one-line intro

## Test plan

- [ ] Read the updated README on GitHub and confirm the first sentence leads with "uio is the agent runtime for CI/CD"
- [ ] Confirm the "Why uio instead of an interactive assistant?" section appears above the Concepts table
- [ ] Confirm no other sections were modified
- [ ] Verify the comparison table renders correctly on GitHub

Closes #256

---

> This pull request was created by [uio AI Coder](https://github.com/jomkz/uio) · powered by claude-sonnet-4-6