### PR TITLE
docs: add "Where uio sits" competitive positioning page

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ watching.
 | Auditable cost records | No | Yes — JSONL ledger, `uio cost` |
 | Multi-agent GitHub identities | No | Yes — planner / coder / reviewer App identities |
 | Definition sharing | No | Yes — git-hosted registries |
+| Auditable history of changes | No | Yes — git blame, PR diffs |
 
 If your use case is "trigger an agent on push, review its output in a PR" — that is
 exactly what uio is designed for. See [docs/20-positioning.md](docs/20-positioning.md)

--- a/README.md
+++ b/README.md
@@ -2,9 +2,15 @@
 
 `uio` is the agent runtime for CI/CD. Define agents, skills, and prompts as plain markdown files with YAML frontmatter — checked into your repo, executed headlessly in pipelines, and wired to any LLM provider. The [origin story](docs/16-about.md) covers how and why.
 
-## uio vs. interactive assistants
+## Why uio?
 
-Interactive assistants (chat UIs, IDE plugins) are built for humans in the loop. uio is built for the other end of the spectrum: **automated, headless, version-controlled agent workflows** that run without a human present.
+uio occupies a distinct niche: **definition-as-code automation**. The agents, skills,
+and prompts you author live in your repo, run headlessly in CI/CD, carry distinct
+GitHub App identities, and produce auditable cost records.
+
+Interactive assistants (chat UIs, IDE plugins, terminal REPLs) are what you open when
+you want to build something at a terminal. uio is what runs at 3am when no one is
+watching.
 
 | Need | Interactive assistant (e.g. Copilot, Cursor) | uio |
 |---|---|---|
@@ -12,9 +18,13 @@ Interactive assistants (chat UIs, IDE plugins) are built for humans in the loop.
 | Definitions stored in git | No | Yes — plain markdown files |
 | Reproducible across environments | No | Yes — provider-agnostic |
 | Scriptable / composable | Limited | Yes — `uio agent run`, `uio skill run` |
-| Auditable history of changes | No | Yes — git blame, PR diffs |
+| Auditable cost records | No | Yes — JSONL ledger, `uio cost` |
+| Multi-agent GitHub identities | No | Yes — planner / coder / reviewer App identities |
+| Definition sharing | No | Yes — git-hosted registries |
 
-If your use case is "trigger an agent on push, review its output in a PR" — that is exactly what uio is designed for.
+If your use case is "trigger an agent on push, review its output in a PR" — that is
+exactly what uio is designed for. See [docs/20-positioning.md](docs/20-positioning.md)
+for the full comparison and rationale.
 
 ## Concepts
 

--- a/docs/20-positioning.md
+++ b/docs/20-positioning.md
@@ -27,7 +27,7 @@ schema to the [JSONL cost ledger](10-cost.md) to the
 
 ## Comparison table
 
-| Dimension | Interactive tools | uio |
+| Dimension | Interactive assistant (e.g. Copilot, Cursor) | uio |
 |---|---|---|
 | Primary mode | Interactive TUI / chat | Headless / scriptable |
 | Definition model | None (chat-driven) | Markdown files, version-controlled |
@@ -42,25 +42,11 @@ schema to the [JSONL cost ledger](10-cost.md) to the
 
 ## What this means in practice
 
-When you author a uio agent you are writing a versioned, reviewable, reusable
-automation artefact — not a session transcript. It lives next to your source code,
-evolves with it through pull requests, and runs the same way in your laptop CI and in
-production.
+Every agent definition is a PR-reviewable file — it evolves through git history
+alongside the code it automates. Every run produces a JSONL cost entry queryable with
+`uio cost`.
 
-The [use cases page](15-use-cases.md) shows end-to-end examples: repo health
-monitoring, automated code review, issue planning, AI-authored pull requests, and
-multi-agent pipelines with distinct GitHub identities.
-
-The [GitHub App identities page](17-github-app-identities.md) covers how uio gives
-each agent role (planner, coder, reviewer) a separate GitHub App identity so that
-automated commits and comments are attributable, auditable, and permission-scoped.
-
-The [cost ledger page](10-cost.md) covers the JSONL ledger format and the `uio cost`
-command — every token spent by every agent run is recorded and queryable.
-
-The [registry page](11-registry.md) covers how definition files can be shared and
-installed from git-hosted registries, so automation patterns are reusable across teams
-and organisations.
+**See also:** [use cases](15-use-cases.md) · [cost ledger](10-cost.md) · [GitHub App identities](17-github-app-identities.md) · [registries](11-registry.md)
 
 ---
 

--- a/docs/20-positioning.md
+++ b/docs/20-positioning.md
@@ -1,0 +1,75 @@
+# Where uio Sits
+
+> uio occupies a distinct niche: **definition-as-code automation**. The agents,
+> skills, and prompts you author live in your repo, run headlessly in CI/CD, carry
+> distinct GitHub App identities, and produce auditable cost records. Other tools in
+> this space are chat/session-first and interactive — they are what you open when you
+> want to build something at a terminal. uio is what runs at 3am when no one is watching.
+
+---
+
+## The niche: headless, definition-driven automation
+
+Interactive AI assistants (chat UIs, IDE plugins, terminal REPLs) are optimised for a
+human-in-the-loop workflow: you type, the model responds, you iterate. That is a
+perfectly valid way to work, and uio does not try to compete with it.
+
+uio is designed for the other moment: the push hook, the scheduled pipeline, the
+overnight batch job. No human present. No interactive session. Just a definition file
+checked into git, an LLM invocation, and an auditable output committed back to the
+repo.
+
+That distinction drives almost every design decision in uio — from the YAML frontmatter
+schema to the [JSONL cost ledger](10-cost.md) to the
+[GitHub App identity system](17-github-app-identities.md).
+
+---
+
+## Comparison table
+
+| Dimension | Interactive tools | uio |
+|---|---|---|
+| Primary mode | Interactive TUI / chat | Headless / scriptable |
+| Definition model | None (chat-driven) | Markdown files, version-controlled |
+| CI/CD fit | Underdeveloped / absent | Core use case |
+| Cost tracking | None | JSONL ledger, `uio cost` |
+| Multi-agent GitHub identities | No | planner / coder / reviewer App identities |
+| Definition sharing | No | Git-hosted [registries](11-registry.md) |
+| Complexity routing | No | small / large tiers with extended thinking |
+| Iteration caps | No | Per-tier caps, configurable |
+
+---
+
+## What this means in practice
+
+When you author a uio agent you are writing a versioned, reviewable, reusable
+automation artefact — not a session transcript. It lives next to your source code,
+evolves with it through pull requests, and runs the same way in your laptop CI and in
+production.
+
+The [use cases page](15-use-cases.md) shows end-to-end examples: repo health
+monitoring, automated code review, issue planning, AI-authored pull requests, and
+multi-agent pipelines with distinct GitHub identities.
+
+The [GitHub App identities page](17-github-app-identities.md) covers how uio gives
+each agent role (planner, coder, reviewer) a separate GitHub App identity so that
+automated commits and comments are attributable, auditable, and permission-scoped.
+
+The [cost ledger page](10-cost.md) covers the JSONL ledger format and the `uio cost`
+command — every token spent by every agent run is recorded and queryable.
+
+The [registry page](11-registry.md) covers how definition files can be shared and
+installed from git-hosted registries, so automation patterns are reusable across teams
+and organisations.
+
+---
+
+## The risk: invisibility
+
+uio is not competing for the same user at the same moment as interactive tools. The
+risk is not displacement — it is invisibility: the CI/CD automation niche is real, but
+uio needs to be louder about owning it.
+
+If you are evaluating uio and asking "how does this compare to the tool I already have
+open in my terminal?" — that is the wrong comparison. The right question is: "what
+runs my agents at 3am, commits the output to a PR, and tells me what it cost?"

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@
 | [17 — GitHub App identities](17-github-app-identities.md) | Dedicated GitHub App identities for agents — setup, frontmatter, and links to governance and runbooks |
 | [18 — Design decisions](18-design-decisions.md) | Language choice rationale: why Python, and the CLI startup time trade-off |
 | [19 — Memory system](19-memory.md) | `*.memory.md` file format, scope lifecycle, prompt injection, `uio memory` CLI, and `dirs.memory` config key |
+| [20 — Positioning](20-positioning.md) | Where uio sits relative to interactive AI tools — comparison table, design rationale, and the CI/CD niche |
 
 ---
 
@@ -75,6 +76,12 @@
 - [Memory system](19-memory.md) — file format, scope lifecycle, prompt injection, and CLI commands
 - [Configuration](06-configuration.md#dirs) — override the default `.uio/memory` directory via `dirs.memory`
 - [CLI reference — uio memory](05-cli.md#uio-memory) — `list`, `view`, and `clear` commands
+
+### I want to understand how uio compares to interactive tools
+
+- [Positioning](20-positioning.md) — where uio sits, the comparison table, and the CI/CD niche
+- [Use cases](15-use-cases.md) — see the positioning in action with end-to-end examples
+- [GitHub App identities](17-github-app-identities.md) — one of the key differentiators: per-agent GitHub identities
 
 ### I want to see what uio can do end-to-end
 


### PR DESCRIPTION
## Summary

- Add `docs/20-positioning.md`: a dedicated positioning page with the "definition-as-code automation" framing, a full 8-row comparison table (primary mode, definition model, CI/CD fit, cost tracking, multi-agent GitHub identities, definition sharing, complexity routing, iteration caps), cross-links to the cost ledger, GitHub App identities, registry, and use-cases pages, and a closing note on the invisibility risk.
- Update `docs/README.md`: add a contents-table row for the new page and a new "I want to understand how uio compares to interactive tools" reading-path section.
- Update root `README.md`: rename the existing positioning section to "Why uio?", expand it with the CI/CD niche framing and two additional table rows (cost tracking, GitHub identities, definition sharing), and add a link to the new docs page.

## Test plan

- [ ] `docs/20-positioning.md` renders correctly in a Markdown viewer — headings, table, blockquote, and internal links all resolve.
- [ ] `docs/README.md` contents table and new reading-path section appear correctly.
- [ ] Root `README.md` "Why uio?" section reads cleanly and the link to `docs/20-positioning.md` is correct.
- [ ] CI lint passes (no Python files touched).

Closes #262
Part of #194

---
> This pull request was opened by the **uio AI Coder** agent (claude-sonnet-4-6).