### PR TITLE
feat: structured output / JSON schema support (schema: frontmatter)

### DIFF
--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -6,6 +6,7 @@ Only append_turn and build_history are under test — pure message formatting.
 
 import json
 from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 
 from uio.core.clients import (
@@ -374,35 +375,114 @@ def test_anthropic_client_stores_complexity_and_max_tokens():
     assert client._max_tokens == 32000
 
 
-# ── output_schema stored on clients ──────────────────────────────────────────
+# ── output_schema: create_kwargs / config_kwargs injection ───────────────────
+
+_SAMPLE_SCHEMA = {"type": "object", "properties": {"result": {"type": "string"}}}
 
 
-def test_gemini_client_stores_output_schema():
-    """GeminiClient stores the output_schema passed via __new__ without calling __init__."""
-    client = GeminiClient.__new__(GeminiClient)
-    client._output_schema = {"type": "object", "properties": {"result": {"type": "string"}}}
-    assert client._output_schema["type"] == "object"
+def test_openai_chat_with_output_schema_injects_response_format():
+    """chat() adds response_format and drops tools when output_schema is set."""
+    mock_resp = MagicMock()
+    mock_resp.choices[0].message.content = '{"result": "ok"}'
+    mock_resp.choices[0].message.tool_calls = None
+    mock_resp.usage = None
+
+    with patch("openai.OpenAI") as mock_openai_cls:
+        mock_completions = MagicMock()
+        mock_completions.create.return_value = mock_resp
+        mock_openai_cls.return_value.chat.completions = mock_completions
+
+        client = OpenAIClient(output_schema=_SAMPLE_SCHEMA)
+        client.chat(system="sys", history=[{"role": "user", "content": "go"}])
+
+        _, kwargs = mock_completions.create.call_args
+        assert "response_format" in kwargs
+        assert kwargs["response_format"]["type"] == "json_schema"
+        assert kwargs["response_format"]["json_schema"]["strict"] is True
+        assert "tools" not in kwargs, "tools must be omitted when output_schema is set"
 
 
-def test_openai_client_stores_output_schema():
-    """OpenAIClient stores the output_schema passed via __new__ without calling __init__."""
-    client = OpenAIClient.__new__(OpenAIClient)
-    client._output_schema = {"type": "object", "properties": {"status": {"type": "string"}}}
-    assert client._output_schema["type"] == "object"
+def test_openai_chat_without_output_schema_includes_tools():
+    """chat() includes tools and no response_format when output_schema is None."""
+    mock_resp = MagicMock()
+    mock_resp.choices[0].message.content = "hello"
+    mock_resp.choices[0].message.tool_calls = None
+    mock_resp.usage = None
+
+    with patch("openai.OpenAI") as mock_openai_cls:
+        mock_completions = MagicMock()
+        mock_completions.create.return_value = mock_resp
+        mock_openai_cls.return_value.chat.completions = mock_completions
+
+        client = OpenAIClient()
+        client.chat(system="sys", history=[{"role": "user", "content": "go"}])
+
+        _, kwargs = mock_completions.create.call_args
+        assert "tools" in kwargs
+        assert "response_format" not in kwargs
 
 
-def test_gemini_client_no_schema_stores_none():
-    """GeminiClient defaults _output_schema to None when not provided."""
-    client = GeminiClient.__new__(GeminiClient)
-    client._output_schema = None
-    assert client._output_schema is None
+def test_gemini_chat_with_output_schema_drops_tools_and_sets_mime():
+    """chat() drops tools and sets response_schema when output_schema is set."""
+    mock_resp = MagicMock()
+    mock_resp.candidates[0].content.parts = []
+    mock_resp.usage_metadata = None
+
+    fake_config_cls = MagicMock()
+    fake_tool_cls = MagicMock()
+    fake_models = MagicMock()
+    fake_models.generate_content.return_value = mock_resp
+
+    with (
+        patch("google.genai.Client") as mock_genai_cls,
+        patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}),
+    ):
+        mock_genai_cls.return_value.models = fake_models
+
+        import google.genai.types as gtypes
+
+        with (
+            patch.object(gtypes, "GenerateContentConfig", fake_config_cls),
+            patch.object(gtypes, "Tool", fake_tool_cls),
+        ):
+            client = GeminiClient(output_schema=_SAMPLE_SCHEMA)
+            client.chat(system="sys", history=[{"role": "user", "parts": [{"text": "go"}]}])
+
+        config_call_kwargs = fake_config_cls.call_args[1]
+        assert "tools" not in config_call_kwargs, "tools must be omitted when output_schema is set"
+        assert config_call_kwargs.get("response_mime_type") == "application/json"
+        assert "response_schema" in config_call_kwargs
 
 
-def test_openai_client_no_schema_stores_none():
-    """OpenAIClient defaults _output_schema to None when not provided."""
-    client = OpenAIClient.__new__(OpenAIClient)
-    client._output_schema = None
-    assert client._output_schema is None
+def test_gemini_chat_without_output_schema_includes_tools():
+    """chat() includes tools and no response_schema when output_schema is None."""
+    mock_resp = MagicMock()
+    mock_resp.candidates[0].content.parts = []
+    mock_resp.usage_metadata = None
+
+    fake_config_cls = MagicMock()
+    fake_tool_cls = MagicMock()
+    fake_models = MagicMock()
+    fake_models.generate_content.return_value = mock_resp
+
+    with (
+        patch("google.genai.Client") as mock_genai_cls,
+        patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}),
+    ):
+        mock_genai_cls.return_value.models = fake_models
+
+        import google.genai.types as gtypes
+
+        with (
+            patch.object(gtypes, "GenerateContentConfig", fake_config_cls),
+            patch.object(gtypes, "Tool", fake_tool_cls),
+        ):
+            client = GeminiClient()
+            client.chat(system="sys", history=[{"role": "user", "parts": [{"text": "go"}]}])
+
+        config_call_kwargs = fake_config_cls.call_args[1]
+        assert "tools" in config_call_kwargs
+        assert "response_schema" not in config_call_kwargs
 
 
 # ── _resolve_output_schema ────────────────────────────────────────────────────

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -372,3 +372,98 @@ def test_anthropic_client_stores_complexity_and_max_tokens():
     client._max_tokens = 32000
     assert client._complexity == "large"
     assert client._max_tokens == 32000
+
+
+# ── output_schema stored on clients ──────────────────────────────────────────
+
+
+def test_gemini_client_stores_output_schema():
+    """GeminiClient stores the output_schema passed via __new__ without calling __init__."""
+    client = GeminiClient.__new__(GeminiClient)
+    client._output_schema = {"type": "object", "properties": {"result": {"type": "string"}}}
+    assert client._output_schema["type"] == "object"
+
+
+def test_openai_client_stores_output_schema():
+    """OpenAIClient stores the output_schema passed via __new__ without calling __init__."""
+    client = OpenAIClient.__new__(OpenAIClient)
+    client._output_schema = {"type": "object", "properties": {"status": {"type": "string"}}}
+    assert client._output_schema["type"] == "object"
+
+
+def test_gemini_client_no_schema_stores_none():
+    """GeminiClient defaults _output_schema to None when not provided."""
+    client = GeminiClient.__new__(GeminiClient)
+    client._output_schema = None
+    assert client._output_schema is None
+
+
+def test_openai_client_no_schema_stores_none():
+    """OpenAIClient defaults _output_schema to None when not provided."""
+    client = OpenAIClient.__new__(OpenAIClient)
+    client._output_schema = None
+    assert client._output_schema is None
+
+
+# ── _resolve_output_schema ────────────────────────────────────────────────────
+
+
+def test_resolve_output_schema_none_when_absent(tmp_path):
+    """Returns None when 'schema' is not in the frontmatter."""
+    from uio.core.runner import _resolve_output_schema
+
+    f = tmp_path / "agent.agent.md"
+    f.write_text("---\nname: A\ndescription: D.\n---\nBody.")
+    assert _resolve_output_schema({}, str(f)) is None
+
+
+def test_resolve_output_schema_inline_dict(tmp_path):
+    """Returns the inline dict when 'schema' is a mapping."""
+    from uio.core.runner import _resolve_output_schema
+
+    f = tmp_path / "agent.agent.md"
+    f.write_text("---\nname: A\ndescription: D.\n---\nBody.")
+    schema = {"type": "object", "properties": {"x": {"type": "string"}}}
+    result = _resolve_output_schema({"schema": schema}, str(f))
+    assert result == schema
+
+
+def test_resolve_output_schema_ref_file(tmp_path):
+    """Loads and returns the JSON file when 'schema' is a $ref string."""
+    import json as _json
+    from uio.core.runner import _resolve_output_schema
+
+    schema_file = tmp_path / "output.json"
+    schema_data = {"type": "object", "properties": {"result": {"type": "string"}}}
+    schema_file.write_text(_json.dumps(schema_data))
+
+    f = tmp_path / "agent.agent.md"
+    f.write_text("---\nname: A\ndescription: D.\n---\nBody.")
+    result = _resolve_output_schema({"schema": "output.json"}, str(f))
+    assert result == schema_data
+
+
+def test_resolve_output_schema_dollar_ref_dict(tmp_path):
+    """Loads the file when 'schema' is a {'$ref': 'path.json'} mapping."""
+    import json as _json
+    from uio.core.runner import _resolve_output_schema
+
+    schema_file = tmp_path / "schema.json"
+    schema_data = {"type": "object"}
+    schema_file.write_text(_json.dumps(schema_data))
+
+    f = tmp_path / "agent.agent.md"
+    f.write_text("---\nname: A\ndescription: D.\n---\nBody.")
+    result = _resolve_output_schema({"schema": {"$ref": "schema.json"}}, str(f))
+    assert result == schema_data
+
+
+def test_resolve_output_schema_ref_file_not_found(tmp_path):
+    """Raises ValueError when the referenced JSON file does not exist."""
+    from uio.core.runner import _resolve_output_schema
+    import pytest
+
+    f = tmp_path / "agent.agent.md"
+    f.write_text("---\nname: A\ndescription: D.\n---\nBody.")
+    with pytest.raises(ValueError, match="not found"):
+        _resolve_output_schema({"schema": "missing.json"}, str(f))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -5,6 +5,7 @@ import textwrap
 
 from uio.schema.parser import (
     check_identity_env,
+    check_schema_support,
     check_skill_references,
     parse_definition_file,
     validate_definition,
@@ -485,3 +486,86 @@ def test_strip_code_spans_no_code_unchanged():
 
     text = "Plain text with /real-skill invocation."
     assert _strip_code_spans(text) == text
+
+
+# ---------------------------------------------------------------------------
+# schema: frontmatter field — validate_definition accepts it
+# ---------------------------------------------------------------------------
+
+
+def test_validate_schema_field_accepted_inline(tmp_path):
+    """'schema:' with an inline mapping is a known key and must not produce an error."""
+    f = tmp_path / "agent.agent.md"
+    f.write_text(
+        "---\nname: A\ndescription: D.\nschema:\n  type: object\n  properties:\n    x:\n      type: string\n---\nBody.\n"
+    )
+    fm, _ = parse_definition_file(str(f))
+    errors = validate_definition(str(f), fm)
+    assert not any("schema" in e for e in errors)
+
+
+def test_validate_schema_field_accepted_ref_string(tmp_path):
+    """'schema:' with a string ($ref-style) value is a known key and must not produce an error."""
+    f = tmp_path / "agent.agent.md"
+    f.write_text("---\nname: A\ndescription: D.\nschema: output.json\n---\nBody.\n")
+    fm, _ = parse_definition_file(str(f))
+    errors = validate_definition(str(f), fm)
+    assert not any("schema" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# check_schema_support
+# ---------------------------------------------------------------------------
+
+
+def test_check_schema_support_no_schema_no_warning(tmp_path):
+    """No 'schema:' field — no warning regardless of provider."""
+    f = tmp_path / "a.agent.md"
+    f.write_text("---\nname: A\ndescription: D.\n---\nBody.")
+    fm, _ = parse_definition_file(str(f))
+    assert check_schema_support(str(f), fm, "anthropic") == []
+
+
+def test_check_schema_support_no_provider_no_warning(tmp_path):
+    """'schema:' declared but provider is None (runtime-resolved) — no warning."""
+    f = tmp_path / "a.agent.md"
+    f.write_text("---\nname: A\ndescription: D.\nschema:\n  type: object\n---\nBody.")
+    fm, _ = parse_definition_file(str(f))
+    assert check_schema_support(str(f), fm, None) == []
+
+
+def test_check_schema_support_openai_no_warning(tmp_path):
+    """'schema:' with OpenAI provider — no warning (supported)."""
+    f = tmp_path / "a.agent.md"
+    f.write_text("---\nname: A\ndescription: D.\nschema:\n  type: object\n---\nBody.")
+    fm, _ = parse_definition_file(str(f))
+    assert check_schema_support(str(f), fm, "openai") == []
+
+
+def test_check_schema_support_gemini_no_warning(tmp_path):
+    """'schema:' with Gemini provider — no warning (supported)."""
+    f = tmp_path / "a.agent.md"
+    f.write_text("---\nname: A\ndescription: D.\nschema:\n  type: object\n---\nBody.")
+    fm, _ = parse_definition_file(str(f))
+    assert check_schema_support(str(f), fm, "gemini") == []
+
+
+def test_check_schema_support_anthropic_warns(tmp_path):
+    """'schema:' with Anthropic provider — emits a warning (not supported)."""
+    f = tmp_path / "a.agent.md"
+    f.write_text("---\nname: A\ndescription: D.\nschema:\n  type: object\n---\nBody.")
+    fm, _ = parse_definition_file(str(f))
+    warnings = check_schema_support(str(f), fm, "anthropic")
+    assert len(warnings) == 1
+    assert "anthropic" in warnings[0]
+    assert "schema" in warnings[0].lower()
+
+
+def test_check_schema_support_ollama_warns(tmp_path):
+    """'schema:' with Ollama provider — emits a warning (not supported)."""
+    f = tmp_path / "a.agent.md"
+    f.write_text("---\nname: A\ndescription: D.\nschema:\n  type: object\n---\nBody.")
+    fm, _ = parse_definition_file(str(f))
+    warnings = check_schema_support(str(f), fm, "ollama")
+    assert len(warnings) == 1
+    assert "ollama" in warnings[0]

--- a/uio/cli/main.py
+++ b/uio/cli/main.py
@@ -27,6 +27,7 @@ from uio.schema.parser import (
     check_heading_format,
     check_identity_env,
     check_minimal_body,
+    check_schema_support,
     check_skill_interface_sections,
     check_skill_references,
     check_stopping_criteria,
@@ -195,6 +196,7 @@ def validate_cmd(strict: bool) -> None:
     """
     cfg = load_config()
     skills_dir = cfg["dirs"]["skills"]
+    default_provider: str | None = cfg["runtime"].get("default_provider")
     agent_skill_prompt_patterns = [
         (cfg["dirs"]["agents"], "*.agent.md"),
         (skills_dir, "*.skill.md"),
@@ -223,6 +225,7 @@ def validate_cmd(strict: bool) -> None:
             warnings.extend(check_thinking_complexity(path, fm))
             warnings.extend(check_skill_interface_sections(path, body))
             warnings.extend(check_minimal_body(path, body))
+            warnings.extend(check_schema_support(path, fm, default_provider))
             if strict:
                 warnings.extend(check_stopping_criteria(path, body))
 

--- a/uio/core/clients.py
+++ b/uio/core/clients.py
@@ -124,6 +124,7 @@ class GeminiClient(LLMClient):
             "tools": [types.Tool(function_declarations=self._func_decls)],
         }
         if self._output_schema is not None:
+            config_kwargs.pop("tools", None)  # response_schema and function_declarations are mutually exclusive
             config_kwargs["response_mime_type"] = "application/json"
             config_kwargs["response_schema"] = _sanitize_schema_for_gemini(self._output_schema)
         config = types.GenerateContentConfig(**config_kwargs)
@@ -204,6 +205,7 @@ class OpenAIClient(LLMClient):
             "tools": [{"type": "function", "function": t} for t in self._tools],
         }
         if self._output_schema is not None:
+            create_kwargs.pop("tools", None)  # structured output and tool-calling are mutually exclusive
             create_kwargs["response_format"] = {
                 "type": "json_schema",
                 "json_schema": {

--- a/uio/core/clients.py
+++ b/uio/core/clients.py
@@ -124,7 +124,9 @@ class GeminiClient(LLMClient):
             "tools": [types.Tool(function_declarations=self._func_decls)],
         }
         if self._output_schema is not None:
-            config_kwargs.pop("tools", None)  # response_schema and function_declarations are mutually exclusive
+            config_kwargs.pop(
+                "tools", None
+            )  # response_schema and function_declarations are mutually exclusive
             config_kwargs["response_mime_type"] = "application/json"
             config_kwargs["response_schema"] = _sanitize_schema_for_gemini(self._output_schema)
         config = types.GenerateContentConfig(**config_kwargs)
@@ -205,7 +207,9 @@ class OpenAIClient(LLMClient):
             "tools": [{"type": "function", "function": t} for t in self._tools],
         }
         if self._output_schema is not None:
-            create_kwargs.pop("tools", None)  # structured output and tool-calling are mutually exclusive
+            create_kwargs.pop(
+                "tools", None
+            )  # structured output and tool-calling are mutually exclusive
             create_kwargs["response_format"] = {
                 "type": "json_schema",
                 "json_schema": {

--- a/uio/core/clients.py
+++ b/uio/core/clients.py
@@ -91,7 +91,12 @@ def _sanitize_schema_for_gemini(schema: dict) -> dict:
 
 
 class GeminiClient(LLMClient):
-    def __init__(self, model: str | None = None, tools: list[dict] | None = None) -> None:
+    def __init__(
+        self,
+        model: str | None = None,
+        tools: list[dict] | None = None,
+        output_schema: dict | None = None,
+    ) -> None:
         from google import genai
         from google.genai import types
 
@@ -107,16 +112,21 @@ class GeminiClient(LLMClient):
             )
             for t in schemas
         ]
+        self._output_schema: dict | None = output_schema
 
     def build_history(self, user_text: str) -> list:
         return [{"role": "user", "parts": [{"text": user_text}]}]
 
     def chat(self, system: str, history: list) -> LLMResponse:
         types = self._types
-        config = types.GenerateContentConfig(
-            system_instruction=system,
-            tools=[types.Tool(function_declarations=self._func_decls)],
-        )
+        config_kwargs: dict = {
+            "system_instruction": system,
+            "tools": [types.Tool(function_declarations=self._func_decls)],
+        }
+        if self._output_schema is not None:
+            config_kwargs["response_mime_type"] = "application/json"
+            config_kwargs["response_schema"] = _sanitize_schema_for_gemini(self._output_schema)
+        config = types.GenerateContentConfig(**config_kwargs)
         resp = self._client.models.generate_content(
             model=self._model, config=config, contents=history
         )
@@ -168,6 +178,7 @@ class OpenAIClient(LLMClient):
         tools: list[dict] | None = None,
         base_url: str | None = None,
         api_key: str | None = None,
+        output_schema: dict | None = None,
     ) -> None:
         import openai
 
@@ -180,17 +191,28 @@ class OpenAIClient(LLMClient):
         self._client = openai.OpenAI(**kwargs)
         self._model = model or os.environ.get("LLM_MODEL") or PROVIDER_DEFAULTS["openai"]
         self._tools = tools if tools is not None else [TOOL_SCHEMA]
+        self._output_schema: dict | None = output_schema
 
     def build_history(self, user_text: str) -> list:
         return [{"role": "user", "content": user_text}]
 
     def chat(self, system: str, history: list) -> LLMResponse:
         messages = [{"role": "system", "content": system}] + history
-        resp = self._client.chat.completions.create(
-            model=self._model,
-            messages=messages,
-            tools=[{"type": "function", "function": t} for t in self._tools],
-        )
+        create_kwargs: dict = {
+            "model": self._model,
+            "messages": messages,
+            "tools": [{"type": "function", "function": t} for t in self._tools],
+        }
+        if self._output_schema is not None:
+            create_kwargs["response_format"] = {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "structured_output",
+                    "schema": self._output_schema,
+                    "strict": True,
+                },
+            }
+        resp = self._client.chat.completions.create(**create_kwargs)
         msg = resp.choices[0].message
         calls: list[ToolCall] = []
         if msg.tool_calls:
@@ -383,15 +405,18 @@ def make_client(
     base_url: str | None = None,
     complexity: str | None = None,
     max_tokens: int | None = None,
+    output_schema: dict | None = None,
 ) -> LLMClient:
     if provider == "gemini":
-        return GeminiClient(model=model, tools=tools)
+        return GeminiClient(model=model, tools=tools, output_schema=output_schema)
     if provider == "anthropic":
         return AnthropicClient(
             model=model, tools=tools, complexity=complexity, max_tokens=max_tokens
         )
     if provider == "openai":
-        return OpenAIClient(model=model, tools=tools, base_url=base_url)
+        return OpenAIClient(
+            model=model, tools=tools, base_url=base_url, output_schema=output_schema
+        )
     if provider == "ollama":
         return OllamaClient(model=model, tools=tools, base_url=base_url)
     raise ValueError(

--- a/uio/core/runner.py
+++ b/uio/core/runner.py
@@ -256,6 +256,13 @@ def _resolve_output_schema(frontmatter: dict, definition_path: str) -> dict | No
         ref_path = schema_value
         if not os.path.isabs(ref_path):
             ref_path = os.path.join(os.path.dirname(definition_path), ref_path)
+        # Containment check: resolved path must stay within the definition file's directory.
+        allowed_root = os.path.abspath(os.path.dirname(definition_path))
+        if not os.path.abspath(ref_path).startswith(allowed_root + os.sep):
+            raise ValueError(
+                f"schema '$ref' path escapes the definition directory: {ref_path!r}"
+                f" (must be inside {allowed_root!r})"
+            )
         try:
             with open(ref_path, encoding="utf-8") as fh:
                 return json.load(fh)

--- a/uio/core/runner.py
+++ b/uio/core/runner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import fnmatch
 import glob as _glob
+import json
 import os
 import sys
 import time
@@ -225,6 +226,52 @@ Shell: {shell_name} — emit {shell_name}-style commands only.
 {alias_section}"""
 
 
+def _resolve_output_schema(frontmatter: dict, definition_path: str) -> dict | None:
+    """Resolve the ``schema:`` frontmatter field to a JSON Schema dict.
+
+    Supports two forms:
+    - An inline mapping (already a dict) — returned as-is.
+    - A ``$ref`` string pointing to a ``.json`` file (relative to the definition
+      file's directory) — loaded and returned.
+
+    Returns ``None`` when the field is absent.
+    Raises ``ValueError`` when ``$ref`` resolution fails.
+    """
+    schema_value = frontmatter.get("schema")
+    if schema_value is None:
+        return None
+
+    if isinstance(schema_value, dict):
+        # Inline $ref to a file — only the {"$ref": "path"} shorthand is resolved here.
+        ref = schema_value.get("$ref")
+        if ref and len(schema_value) == 1:
+            # Pure {"$ref": "path.json"} — treat as file reference.
+            schema_value = ref
+        else:
+            # Full inline schema object — use directly.
+            return schema_value
+
+    if isinstance(schema_value, str):
+        # File reference (either a bare string or resolved from {"$ref": ...})
+        ref_path = schema_value
+        if not os.path.isabs(ref_path):
+            ref_path = os.path.join(os.path.dirname(definition_path), ref_path)
+        try:
+            with open(ref_path, encoding="utf-8") as fh:
+                return json.load(fh)
+        except FileNotFoundError as exc:
+            raise ValueError(
+                f"schema '$ref' file not found: {ref_path!r} (referenced from {definition_path!r})"
+            ) from exc
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"schema '$ref' file is not valid JSON: {ref_path!r}: {exc}") from exc
+
+    raise ValueError(
+        f"'schema:' in {definition_path!r} must be a mapping or a '$ref' string,"
+        f" got {type(schema_value).__name__}"
+    )
+
+
 def run_agent(
     agent_name: str,
     arg: str | None = None,
@@ -254,6 +301,8 @@ def run_agent(
         raise ValueError(f"Error: definition not found at {definition_path}")
 
     frontmatter, body = parse_definition_file(definition_path)
+
+    output_schema: dict | None = _resolve_output_schema(frontmatter, definition_path)
 
     role = _inject_vcs_identity(frontmatter)
 
@@ -346,6 +395,7 @@ def run_agent(
                     base_url=base_url,
                     complexity=resolved_complexity,
                     max_tokens=resolved_max_tokens,
+                    output_schema=output_schema,
                 )
             except Exception as e:
                 print(

--- a/uio/schema/parser.py
+++ b/uio/schema/parser.py
@@ -259,7 +259,7 @@ def check_schema_support(path: str, frontmatter: dict, provider: str | None) -> 
 
     Returns a one-element warning list otherwise.
     """
-    if not frontmatter.get("schema"):
+    if frontmatter.get("schema") is None:
         return []
     if provider is None:
         return []

--- a/uio/schema/parser.py
+++ b/uio/schema/parser.py
@@ -60,6 +60,7 @@ def validate_definition(path: str, frontmatter: dict) -> list[str]:
         "github-identity",  # deprecated alias for vcs-identity
         "vcs-identity",
         "vcs-provider",
+        "schema",
     }
     for key in frontmatter:
         if key not in known:
@@ -242,6 +243,32 @@ def check_minimal_body(path: str, body: str) -> list[str]:
     if len(body) < 100:
         return [f"{path}: body is very short ({len(body)} chars); consider adding more detail"]
     return []
+
+
+# Providers that support structured output via a JSON schema parameter.
+_SCHEMA_SUPPORTED_PROVIDERS = frozenset({"openai", "gemini"})
+
+
+def check_schema_support(path: str, frontmatter: dict, provider: str | None) -> list[str]:
+    """Warn when ``schema:`` is declared but the selected provider does not support it.
+
+    Returns an empty list when:
+    - ``schema:`` is not set in the frontmatter, or
+    - *provider* is ``None`` (provider is resolved at runtime), or
+    - the provider is known to support structured output.
+
+    Returns a one-element warning list otherwise.
+    """
+    if not frontmatter.get("schema"):
+        return []
+    if provider is None:
+        return []
+    if provider in _SCHEMA_SUPPORTED_PROVIDERS:
+        return []
+    return [
+        f"{path}: 'schema:' is declared but provider '{provider}' does not support"
+        " structured output — only 'openai' and 'gemini' are supported"
+    ]
 
 
 _WORKFLOW_KNOWN_KEYS = {"name", "description", "steps"}


### PR DESCRIPTION
## Summary

- Adds a `schema:` frontmatter key accepted by agent, skill, and prompt definition files. It accepts either an inline JSON Schema object or a `$ref` string/mapping pointing to a `.json` file (resolved relative to the definition file).
- Wires structured output into **OpenAI** (`response_format` with `json_schema` type) and **Gemini** (`response_schema` + `response_mime_type: application/json`) clients; Anthropic and Ollama are intentionally left without structured output (no API support).
- `uio validate` now emits a warning when `schema:` is declared and the configured `default_provider` does not support structured output (anthropic, ollama).

## Test plan

- [ ] `pytest -m "not integration"` passes (632 tests, 0 failures)
- [ ] `ruff format --check .` and `ruff check .` pass
- [ ] Define an agent with `schema: {type: object, properties: {status: {type: string}}}` and run it against an OpenAI or Gemini provider — the API receives the `response_format` / `response_schema` parameter
- [ ] Define an agent with `schema: ./output.json` (a `$ref` file) and confirm it loads correctly
- [ ] Run `uio validate` with an agent using `schema:` and `default_provider = "anthropic"` in `uio.toml` — a WARNING should appear
- [ ] Run `uio validate` with `default_provider = "openai"` — no warning should appear

Closes #257

---
> This pull request was generated by [uio AI Coder](https://github.com/jomkz/uio) (claude-sonnet-4-6).