### PR TITLE
feat: add prompt step type to workflow definitions

### DIFF
--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -191,10 +191,16 @@ def test_check_workflow_steps_both_agent_and_skill():
     assert any("mutually exclusive" in w for w in warnings)
 
 
-def test_check_workflow_steps_neither_agent_nor_skill():
+def test_check_workflow_steps_no_step_type():
     fm = {"steps": [{"name": "s"}]}
     warnings = check_workflow_steps("w.workflow.md", fm)
     assert any("neither" in w for w in warnings)
+
+
+def test_check_workflow_steps_skill_and_prompt_mutually_exclusive():
+    fm = {"steps": [{"name": "s", "skill": "a", "prompt": "p"}]}
+    warnings = check_workflow_steps("w.workflow.md", fm)
+    assert any("mutually exclusive" in w for w in warnings)
 
 
 def test_check_workflow_steps_unknown_key():

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -497,7 +497,16 @@ def test_run_workflow_skill_step(tmp_path):
 
 
 def test_parse_workflow_steps_prompt_step():
-    fm = {"steps": [{"name": "summarise", "prompt": "summarise-pr", "arg": "{{ input }}", "output": "summary"}]}
+    fm = {
+        "steps": [
+            {
+                "name": "summarise",
+                "prompt": "summarise-pr",
+                "arg": "{{ input }}",
+                "output": "summary",
+            }
+        ]
+    }
     steps = parse_workflow_steps(fm)
     assert len(steps) == 1
     assert steps[0].prompt == "summarise-pr"

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -277,6 +277,7 @@ _MINIMAL_CFG: dict = {
     "dirs": {
         "agents": ".uio/agents",
         "skills": ".uio/skills",
+        "prompts": ".uio/prompts",
         "workflows": ".uio/workflows",
         "memory": None,
     },
@@ -303,6 +304,7 @@ def _make_cfg(tmp_path) -> dict:
     cfg["dirs"]["workflows"] = str(tmp_path / "workflows")
     cfg["dirs"]["agents"] = str(tmp_path / "agents")
     cfg["dirs"]["skills"] = str(tmp_path / "skills")
+    cfg["dirs"]["prompts"] = str(tmp_path / "prompts")
     return cfg
 
 
@@ -492,3 +494,56 @@ def test_run_workflow_skill_step(tmp_path):
 
     assert calls[0][0] == "summarise"
     assert ".skill.md" in calls[0][1]  # resolved as a skill, not an agent
+
+
+def test_parse_workflow_steps_prompt_step():
+    fm = {"steps": [{"name": "summarise", "prompt": "summarise-pr", "arg": "{{ input }}", "output": "summary"}]}
+    steps = parse_workflow_steps(fm)
+    assert len(steps) == 1
+    assert steps[0].prompt == "summarise-pr"
+    assert steps[0].agent is None
+    assert steps[0].skill is None
+    assert steps[0].output == "summary"
+
+
+def test_run_workflow_prompt_step(tmp_path):
+    _write_workflow(
+        tmp_path,
+        "prompt-wf",
+        textwrap.dedent("""\
+            ---
+            name: prompt-wf
+            description: D.
+            steps:
+              - name: summarise
+                prompt: summarise-pr
+                arg: "{{ input }}"
+                output: summary
+            ---
+            Body.
+        """),
+    )
+    cfg = _make_cfg(tmp_path)
+    calls: list[tuple[str, str]] = []
+
+    def fake_run_agent(name, arg, **kwargs):
+        calls.append((name, kwargs.get("definition_path", "")))
+        return "the summary"
+
+    with patch("uio.core.runner.run_agent", side_effect=fake_run_agent):
+        run_workflow("prompt-wf", "some text", cfg=cfg)
+
+    assert calls[0][0] == "summarise-pr"
+    assert ".prompt.md" in calls[0][1]  # resolved as a prompt
+
+
+def test_check_workflow_steps_prompt_step_valid():
+    fm = {"steps": [{"name": "s", "prompt": "my-prompt", "arg": "{{ input }}"}]}
+    warnings = check_workflow_steps("w.workflow.md", fm)
+    assert warnings == []
+
+
+def test_check_workflow_steps_prompt_and_agent_mutually_exclusive():
+    fm = {"steps": [{"name": "s", "agent": "a", "prompt": "p"}]}
+    warnings = check_workflow_steps("w.workflow.md", fm)
+    assert any("mutually exclusive" in w for w in warnings)

--- a/uio/core/workflow.py
+++ b/uio/core/workflow.py
@@ -18,6 +18,7 @@ class WorkflowStep:
     name: str
     agent: str | None = None
     skill: str | None = None
+    prompt: str | None = None
     arg: str | None = None
     output: str | None = None
     when: str | None = None
@@ -34,6 +35,7 @@ def parse_workflow_steps(frontmatter: dict) -> list[WorkflowStep]:
                 name=s.get("name", ""),
                 agent=s.get("agent"),
                 skill=s.get("skill"),
+                prompt=s.get("prompt"),
                 arg=s.get("arg"),
                 output=s.get("output"),
                 when=s.get("when"),
@@ -110,9 +112,12 @@ def run_workflow(
         elif step.skill:
             def_path = f"{cfg['dirs']['skills']}/{step.skill}.skill.md"
             runner_name = step.skill
+        elif step.prompt:
+            def_path = f"{cfg['dirs']['prompts']}/{step.prompt}.prompt.md"
+            runner_name = step.prompt
         else:
             print(
-                f"  [workflow] Error: step '{step.name}' has neither 'agent' nor 'skill'",
+                f"  [workflow] Error: step '{step.name}' has none of 'agent', 'skill', or 'prompt'",
                 file=sys.stderr,
             )
             sys.exit(1)

--- a/uio/schema/parser.py
+++ b/uio/schema/parser.py
@@ -272,7 +272,7 @@ def check_schema_support(path: str, frontmatter: dict, provider: str | None) -> 
 
 
 _WORKFLOW_KNOWN_KEYS = {"name", "description", "steps"}
-_STEP_KNOWN_KEYS = {"name", "agent", "skill", "arg", "output", "when"}
+_STEP_KNOWN_KEYS = {"name", "agent", "skill", "prompt", "arg", "output", "when"}
 
 
 def validate_workflow_definition(path: str, frontmatter: dict) -> list[str]:
@@ -307,10 +307,12 @@ def check_workflow_steps(path: str, frontmatter: dict) -> list[str]:
                 warnings.append(f"{path}: step {i + 1} has unrecognised key '{key}'")
         has_agent = "agent" in step
         has_skill = "skill" in step
-        if has_agent and has_skill:
+        has_prompt = "prompt" in step
+        type_count = sum([has_agent, has_skill, has_prompt])
+        if type_count > 1:
             warnings.append(
-                f"{path}: step {i + 1} defines both 'agent' and 'skill' — they are mutually exclusive"
+                f"{path}: step {i + 1} defines multiple step types ('agent', 'skill', 'prompt' are mutually exclusive)"
             )
-        elif not has_agent and not has_skill:
-            warnings.append(f"{path}: step {i + 1} has neither 'agent' nor 'skill'")
+        elif type_count == 0:
+            warnings.append(f"{path}: step {i + 1} has neither 'agent', 'skill', nor 'prompt'")
     return warnings


### PR DESCRIPTION
## Summary

- Adds `prompt: <name>` as a first-class step type in `.workflow.md` definitions, alongside the existing `agent:` and `skill:` types
- Resolves `<prompts-dir>/<name>.prompt.md` and dispatches via `run_agent()` with the same output-capture (`output:`) and variable interpolation (`{{ var }}`) semantics
- Updates `check_workflow_steps()` in `uio/schema/parser.py` to recognise `prompt:` as a valid key and enforce mutual exclusivity across all three step type fields
- Adds 4 new tests covering: parsing a `prompt:` step, executing it end-to-end, the valid `prompt:`-only case, and the `agent+prompt` mutual-exclusivity error

Closes #268. Part of #259.

## Example

```yaml
steps:
  - name: summarise
    prompt: summarise-pr
    arg: "{{ input }}"
    output: summary
```

Resolves `definitions/prompts/summarise-pr.prompt.md` and stores the output in `summary` for downstream steps.

## Test plan

- [ ] `pytest tests/test_workflow.py` — all 37 tests pass
- [ ] `uio workflow run` with a workflow containing a `prompt:` step resolves the correct `.prompt.md` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)