### PR TITLE
feat: add workflow-level cost grouping to the ledger

### DIFF
--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
 from click.testing import CliRunner
 
 from uio.cli.cost import _load_ledger, _print_cost_table, cost_cmd
@@ -179,6 +178,6 @@ def test_cost_cmd_workflow_flag_json(tmp_path):
     runner = CliRunner()
     result = runner.invoke(cost_cmd, ["--ledger", str(p), "--workflow", "wf", "--json"])
     assert result.exit_code == 0
-    lines = [l for l in result.output.strip().splitlines() if l]
+    lines = [line for line in result.output.strip().splitlines() if line]
     assert len(lines) == 1
     assert json.loads(lines[0])["agent"] == "a"

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -113,8 +113,20 @@ def test_print_cost_table_shows_workflow_column_when_any_entry_has_field(capsys)
 def test_print_cost_table_total_line(capsys):
     _print_cost_table(
         [
-            {"agent": "a", "provider": "x", "model": "m", "total_tokens": 100, "estimated_cost_usd": 0.001},
-            {"agent": "b", "provider": "x", "model": "m", "total_tokens": 200, "estimated_cost_usd": 0.002},
+            {
+                "agent": "a",
+                "provider": "x",
+                "model": "m",
+                "total_tokens": 100,
+                "estimated_cost_usd": 0.001,
+            },
+            {
+                "agent": "b",
+                "provider": "x",
+                "model": "m",
+                "total_tokens": 200,
+                "estimated_cost_usd": 0.002,
+            },
         ]
     )
     out = capsys.readouterr().out
@@ -130,8 +142,22 @@ def test_cost_cmd_workflow_flag_filters(tmp_path):
     _write_ledger(
         p,
         [
-            {"agent": "a", "workflow": "keep", "provider": "x", "model": "m", "total_tokens": 10, "estimated_cost_usd": 0.0},
-            {"agent": "b", "workflow": "drop", "provider": "x", "model": "m", "total_tokens": 20, "estimated_cost_usd": 0.0},
+            {
+                "agent": "a",
+                "workflow": "keep",
+                "provider": "x",
+                "model": "m",
+                "total_tokens": 10,
+                "estimated_cost_usd": 0.0,
+            },
+            {
+                "agent": "b",
+                "workflow": "drop",
+                "provider": "x",
+                "model": "m",
+                "total_tokens": 20,
+                "estimated_cost_usd": 0.0,
+            },
         ],
     )
     runner = CliRunner()

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -1,0 +1,158 @@
+"""Tests for uio cost CLI — _load_ledger and _print_cost_table."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from uio.cli.cost import _load_ledger, _print_cost_table, cost_cmd
+
+
+def _write_ledger(path: Path, entries: list[dict]) -> None:
+    with path.open("w") as f:
+        for e in entries:
+            f.write(json.dumps(e) + "\n")
+
+
+# --- _load_ledger ---
+
+
+def test_load_ledger_empty_when_file_missing(tmp_path):
+    result = _load_ledger(str(tmp_path / "missing.jsonl"), None, None)
+    assert result == []
+
+
+def test_load_ledger_returns_all_entries(tmp_path):
+    p = tmp_path / "ledger.jsonl"
+    _write_ledger(p, [{"agent": "a"}, {"agent": "b"}])
+    entries = _load_ledger(str(p), None, None)
+    assert len(entries) == 2
+
+
+def test_load_ledger_workflow_filter(tmp_path):
+    p = tmp_path / "ledger.jsonl"
+    _write_ledger(
+        p,
+        [
+            {"agent": "a", "workflow": "wf-a"},
+            {"agent": "b", "workflow": "wf-b"},
+            {"agent": "c", "workflow": "wf-a"},
+        ],
+    )
+    entries = _load_ledger(str(p), None, None, workflow="wf-a")
+    assert len(entries) == 2
+    assert all(e["workflow"] == "wf-a" for e in entries)
+
+
+def test_load_ledger_workflow_filter_excludes_no_workflow(tmp_path):
+    p = tmp_path / "ledger.jsonl"
+    _write_ledger(p, [{"agent": "a"}, {"agent": "b", "workflow": "wf"}])
+    entries = _load_ledger(str(p), None, None, workflow="wf")
+    assert len(entries) == 1
+    assert entries[0]["agent"] == "b"
+
+
+def test_load_ledger_workflow_filter_applied_before_tail(tmp_path):
+    p = tmp_path / "ledger.jsonl"
+    _write_ledger(
+        p,
+        [{"agent": str(i), "workflow": "wf"} for i in range(10)]
+        + [{"agent": "other", "workflow": "other"}],
+    )
+    entries = _load_ledger(str(p), None, 3, workflow="wf")
+    assert len(entries) == 3
+    assert all(e["workflow"] == "wf" for e in entries)
+
+
+def test_load_ledger_tail(tmp_path):
+    p = tmp_path / "ledger.jsonl"
+    _write_ledger(p, [{"agent": str(i)} for i in range(10)])
+    entries = _load_ledger(str(p), None, 3)
+    assert len(entries) == 3
+    assert entries[-1]["agent"] == "9"
+
+
+# --- _print_cost_table ---
+
+
+def test_print_cost_table_empty(capsys):
+    _print_cost_table([])
+    out = capsys.readouterr().out
+    assert "(no entries in ledger)" in out
+
+
+def test_print_cost_table_no_workflow_column_for_plain_entries(capsys):
+    _print_cost_table(
+        [{"agent": "a", "provider": "x", "model": "m", "total_tokens": 1, "estimated_cost_usd": 0}]
+    )
+    out = capsys.readouterr().out
+    assert "WORKFLOW" not in out
+
+
+def test_print_cost_table_shows_workflow_column_when_any_entry_has_field(capsys):
+    _print_cost_table(
+        [
+            {
+                "agent": "a",
+                "workflow": "my-wf",
+                "provider": "x",
+                "model": "m",
+                "total_tokens": 1,
+                "estimated_cost_usd": 0,
+            }
+        ]
+    )
+    out = capsys.readouterr().out
+    assert "WORKFLOW" in out
+    assert "my-wf" in out
+
+
+def test_print_cost_table_total_line(capsys):
+    _print_cost_table(
+        [
+            {"agent": "a", "provider": "x", "model": "m", "total_tokens": 100, "estimated_cost_usd": 0.001},
+            {"agent": "b", "provider": "x", "model": "m", "total_tokens": 200, "estimated_cost_usd": 0.002},
+        ]
+    )
+    out = capsys.readouterr().out
+    assert "2 run(s)" in out
+    assert "300" in out
+
+
+# --- cost_cmd via CLI runner ---
+
+
+def test_cost_cmd_workflow_flag_filters(tmp_path):
+    p = tmp_path / "ledger.jsonl"
+    _write_ledger(
+        p,
+        [
+            {"agent": "a", "workflow": "keep", "provider": "x", "model": "m", "total_tokens": 10, "estimated_cost_usd": 0.0},
+            {"agent": "b", "workflow": "drop", "provider": "x", "model": "m", "total_tokens": 20, "estimated_cost_usd": 0.0},
+        ],
+    )
+    runner = CliRunner()
+    result = runner.invoke(cost_cmd, ["--ledger", str(p), "--workflow", "keep"])
+    assert result.exit_code == 0
+    assert "keep" in result.output
+    assert "drop" not in result.output
+
+
+def test_cost_cmd_workflow_flag_json(tmp_path):
+    p = tmp_path / "ledger.jsonl"
+    _write_ledger(
+        p,
+        [
+            {"agent": "a", "workflow": "wf", "total_tokens": 5, "estimated_cost_usd": 0.0},
+            {"agent": "b", "total_tokens": 5, "estimated_cost_usd": 0.0},
+        ],
+    )
+    runner = CliRunner()
+    result = runner.invoke(cost_cmd, ["--ledger", str(p), "--workflow", "wf", "--json"])
+    assert result.exit_code == 0
+    lines = [l for l in result.output.strip().splitlines() if l]
+    assert len(lines) == 1
+    assert json.loads(lines[0])["agent"] == "a"

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -75,3 +75,45 @@ def test_write_cost_is_zero_for_ollama(tmp_path):
     write_cost_ledger("my-agent", "ollama", "qwen2.5-coder:32b", 100_000, 50_000, ledger)
     entry = json.loads(Path(ledger).read_text().strip())
     assert entry["estimated_cost_usd"] == 0.0
+
+
+def test_write_workflow_fields_included_when_set(tmp_path):
+    ledger = str(tmp_path / "cost.jsonl")
+    write_cost_ledger(
+        "coder",
+        "openai",
+        "gpt-4o",
+        100,
+        50,
+        ledger,
+        workflow="review-and-fix",
+        workflow_run_id="abc-123",
+    )
+    entry = json.loads(Path(ledger).read_text().strip())
+    assert entry["workflow"] == "review-and-fix"
+    assert entry["workflow_run_id"] == "abc-123"
+
+
+def test_write_workflow_fields_appear_before_cost_metrics(tmp_path):
+    ledger = str(tmp_path / "cost.jsonl")
+    write_cost_ledger(
+        "coder",
+        "openai",
+        "gpt-4o",
+        100,
+        50,
+        ledger,
+        workflow="my-wf",
+        workflow_run_id="run-1",
+    )
+    keys = list(json.loads(Path(ledger).read_text().strip()).keys())
+    assert keys.index("workflow") < keys.index("prompt_tokens")
+    assert keys.index("workflow_run_id") < keys.index("prompt_tokens")
+
+
+def test_write_workflow_fields_absent_when_none(tmp_path):
+    ledger = str(tmp_path / "cost.jsonl")
+    write_cost_ledger("agent", "gemini", "gemini-2.5-flash", 100, 50, ledger)
+    entry = json.loads(Path(ledger).read_text().strip())
+    assert "workflow" not in entry
+    assert "workflow_run_id" not in entry

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -191,10 +191,16 @@ def test_check_workflow_steps_both_agent_and_skill():
     assert any("mutually exclusive" in w for w in warnings)
 
 
-def test_check_workflow_steps_neither_agent_nor_skill():
+def test_check_workflow_steps_no_step_type():
     fm = {"steps": [{"name": "s"}]}
     warnings = check_workflow_steps("w.workflow.md", fm)
     assert any("neither" in w for w in warnings)
+
+
+def test_check_workflow_steps_skill_and_prompt_mutually_exclusive():
+    fm = {"steps": [{"name": "s", "skill": "a", "prompt": "p"}]}
+    warnings = check_workflow_steps("w.workflow.md", fm)
+    assert any("mutually exclusive" in w for w in warnings)
 
 
 def test_check_workflow_steps_unknown_key():

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -497,7 +497,16 @@ def test_run_workflow_skill_step(tmp_path):
 
 
 def test_parse_workflow_steps_prompt_step():
-    fm = {"steps": [{"name": "summarise", "prompt": "summarise-pr", "arg": "{{ input }}", "output": "summary"}]}
+    fm = {
+        "steps": [
+            {
+                "name": "summarise",
+                "prompt": "summarise-pr",
+                "arg": "{{ input }}",
+                "output": "summary",
+            }
+        ]
+    }
     steps = parse_workflow_steps(fm)
     assert len(steps) == 1
     assert steps[0].prompt == "summarise-pr"

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -562,3 +562,66 @@ def test_check_workflow_steps_prompt_and_agent_mutually_exclusive():
     fm = {"steps": [{"name": "s", "agent": "a", "prompt": "p"}]}
     warnings = check_workflow_steps("w.workflow.md", fm)
     assert any("mutually exclusive" in w for w in warnings)
+
+
+def test_run_workflow_passes_workflow_and_run_id_to_run_agent(tmp_path):
+    _write_workflow(
+        tmp_path,
+        "wf",
+        textwrap.dedent("""\
+            ---
+            name: wf
+            description: D.
+            steps:
+              - name: s
+                agent: my-agent
+            ---
+            Body.
+        """),
+    )
+    cfg = _make_cfg(tmp_path)
+    captured_kwargs: list[dict] = []
+
+    def fake_run_agent(name, arg, **kwargs):
+        captured_kwargs.append(kwargs)
+        return None
+
+    with patch("uio.core.runner.run_agent", side_effect=fake_run_agent):
+        run_workflow("wf", None, cfg=cfg)
+
+    assert captured_kwargs[0]["workflow"] == "wf"
+    assert "workflow_run_id" in captured_kwargs[0]
+    import uuid as _uuid
+
+    _uuid.UUID(captured_kwargs[0]["workflow_run_id"], version=4)
+
+
+def test_run_workflow_all_steps_share_same_run_id(tmp_path):
+    _write_workflow(
+        tmp_path,
+        "multi",
+        textwrap.dedent("""\
+            ---
+            name: multi
+            description: D.
+            steps:
+              - name: step-a
+                agent: agent-a
+              - name: step-b
+                agent: agent-b
+            ---
+            Body.
+        """),
+    )
+    cfg = _make_cfg(tmp_path)
+    run_ids: list[str] = []
+
+    def fake_run_agent(name, arg, **kwargs):
+        run_ids.append(kwargs.get("workflow_run_id", ""))
+        return None
+
+    with patch("uio.core.runner.run_agent", side_effect=fake_run_agent):
+        run_workflow("multi", None, cfg=cfg)
+
+    assert len(run_ids) == 2
+    assert run_ids[0] == run_ids[1], "all steps must share the same workflow_run_id"

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -277,6 +277,7 @@ _MINIMAL_CFG: dict = {
     "dirs": {
         "agents": ".uio/agents",
         "skills": ".uio/skills",
+        "prompts": ".uio/prompts",
         "workflows": ".uio/workflows",
         "memory": None,
     },
@@ -303,6 +304,7 @@ def _make_cfg(tmp_path) -> dict:
     cfg["dirs"]["workflows"] = str(tmp_path / "workflows")
     cfg["dirs"]["agents"] = str(tmp_path / "agents")
     cfg["dirs"]["skills"] = str(tmp_path / "skills")
+    cfg["dirs"]["prompts"] = str(tmp_path / "prompts")
     return cfg
 
 
@@ -492,3 +494,56 @@ def test_run_workflow_skill_step(tmp_path):
 
     assert calls[0][0] == "summarise"
     assert ".skill.md" in calls[0][1]  # resolved as a skill, not an agent
+
+
+def test_parse_workflow_steps_prompt_step():
+    fm = {"steps": [{"name": "summarise", "prompt": "summarise-pr", "arg": "{{ input }}", "output": "summary"}]}
+    steps = parse_workflow_steps(fm)
+    assert len(steps) == 1
+    assert steps[0].prompt == "summarise-pr"
+    assert steps[0].agent is None
+    assert steps[0].skill is None
+    assert steps[0].output == "summary"
+
+
+def test_run_workflow_prompt_step(tmp_path):
+    _write_workflow(
+        tmp_path,
+        "prompt-wf",
+        textwrap.dedent("""\
+            ---
+            name: prompt-wf
+            description: D.
+            steps:
+              - name: summarise
+                prompt: summarise-pr
+                arg: "{{ input }}"
+                output: summary
+            ---
+            Body.
+        """),
+    )
+    cfg = _make_cfg(tmp_path)
+    calls: list[tuple[str, str]] = []
+
+    def fake_run_agent(name, arg, **kwargs):
+        calls.append((name, kwargs.get("definition_path", "")))
+        return "the summary"
+
+    with patch("uio.core.runner.run_agent", side_effect=fake_run_agent):
+        run_workflow("prompt-wf", "some text", cfg=cfg)
+
+    assert calls[0][0] == "summarise-pr"
+    assert ".prompt.md" in calls[0][1]  # resolved as a prompt
+
+
+def test_check_workflow_steps_prompt_step_valid():
+    fm = {"steps": [{"name": "s", "prompt": "my-prompt", "arg": "{{ input }}"}]}
+    warnings = check_workflow_steps("w.workflow.md", fm)
+    assert warnings == []
+
+
+def test_check_workflow_steps_prompt_and_agent_mutually_exclusive():
+    fm = {"steps": [{"name": "s", "agent": "a", "prompt": "p"}]}
+    warnings = check_workflow_steps("w.workflow.md", fm)
+    assert any("mutually exclusive" in w for w in warnings)

--- a/uio/cli/cost.py
+++ b/uio/cli/cost.py
@@ -11,7 +11,9 @@ import click
 from uio.config import load_config
 
 
-def _load_ledger(ledger_path: str, since: str | None, tail: int | None) -> list[dict]:
+def _load_ledger(
+    ledger_path: str, since: str | None, tail: int | None, workflow: str | None = None
+) -> list[dict]:
     p = Path(ledger_path)
     if not p.exists():
         return []
@@ -44,6 +46,9 @@ def _load_ledger(ledger_path: str, since: str | None, tail: int | None) -> list[
                 filtered.append(e)
         entries = filtered
 
+    if workflow is not None:
+        entries = [e for e in entries if e.get("workflow") == workflow]
+
     if tail is not None:
         entries = entries[-tail:]
     return entries
@@ -53,18 +58,34 @@ def _print_cost_table(entries: list[dict]) -> None:
     if not entries:
         click.echo("(no entries in ledger)")
         return
-    rows = [
-        [
-            e.get("timestamp", "")[:19].replace("T", " "),
-            e.get("agent", "—"),
-            e.get("provider", "—"),
-            e.get("model", "—"),
-            str(e.get("total_tokens", 0)),
-            f"${e.get('estimated_cost_usd', 0.0):.6f}",
+    show_workflow = any("workflow" in e for e in entries)
+    if show_workflow:
+        rows = [
+            [
+                e.get("timestamp", "")[:19].replace("T", " "),
+                e.get("agent", "—"),
+                e.get("workflow", "—"),
+                e.get("provider", "—"),
+                e.get("model", "—"),
+                str(e.get("total_tokens", 0)),
+                f"${e.get('estimated_cost_usd', 0.0):.6f}",
+            ]
+            for e in entries
         ]
-        for e in entries
-    ]
-    headers = ["TIMESTAMP", "AGENT", "PROVIDER", "MODEL", "TOKENS", "COST"]
+        headers = ["TIMESTAMP", "AGENT", "WORKFLOW", "PROVIDER", "MODEL", "TOKENS", "COST"]
+    else:
+        rows = [
+            [
+                e.get("timestamp", "")[:19].replace("T", " "),
+                e.get("agent", "—"),
+                e.get("provider", "—"),
+                e.get("model", "—"),
+                str(e.get("total_tokens", 0)),
+                f"${e.get('estimated_cost_usd', 0.0):.6f}",
+            ]
+            for e in entries
+        ]
+        headers = ["TIMESTAMP", "AGENT", "PROVIDER", "MODEL", "TOKENS", "COST"]
     widths = [max(len(h), max(len(r[i]) for r in rows)) for i, h in enumerate(headers)]
     click.echo("  ".join(h.ljust(w) for h, w in zip(headers, widths)))
     click.echo("  ".join("-" * w for w in widths))
@@ -94,11 +115,18 @@ def _print_cost_table(entries: list[dict]) -> None:
     metavar="PATH",
     help="Path to the cost ledger file (default: from uio.toml or uio_cost.jsonl).",
 )
+@click.option(
+    "--workflow",
+    default=None,
+    metavar="NAME",
+    help="Filter to entries from the named workflow.",
+)
 def cost_cmd(
     tail: int | None,
     since: str | None,
     as_json: bool,
     ledger: str | None,
+    workflow: str | None,
 ) -> None:
     """Summarise AI token spend from the cost ledger.
 
@@ -108,11 +136,12 @@ def cost_cmd(
       uio cost
       uio cost --tail 20
       uio cost --since 2026-04-01
+      uio cost --workflow review-and-fix
       uio cost --json | jq '.estimated_cost_usd'
     """
     if ledger is None:
         ledger = load_config()["runtime"]["cost_ledger"]
-    entries = _load_ledger(ledger, since, tail)
+    entries = _load_ledger(ledger, since, tail, workflow)
     if as_json:
         for e in entries:
             click.echo(json.dumps(e))

--- a/uio/cli/cost.py
+++ b/uio/cli/cost.py
@@ -59,33 +59,25 @@ def _print_cost_table(entries: list[dict]) -> None:
         click.echo("(no entries in ledger)")
         return
     show_workflow = any("workflow" in e for e in entries)
+    rows = []
+    for e in entries:
+        row = [
+            e.get("timestamp", "")[:19].replace("T", " "),
+            e.get("agent", "—"),
+        ]
+        if show_workflow:
+            row.append(e.get("workflow", "—"))
+        row += [
+            e.get("provider", "—"),
+            e.get("model", "—"),
+            str(e.get("total_tokens", 0)),
+            f"${e.get('estimated_cost_usd', 0.0):.6f}",
+        ]
+        rows.append(row)
+    headers = ["TIMESTAMP", "AGENT"]
     if show_workflow:
-        rows = [
-            [
-                e.get("timestamp", "")[:19].replace("T", " "),
-                e.get("agent", "—"),
-                e.get("workflow", "—"),
-                e.get("provider", "—"),
-                e.get("model", "—"),
-                str(e.get("total_tokens", 0)),
-                f"${e.get('estimated_cost_usd', 0.0):.6f}",
-            ]
-            for e in entries
-        ]
-        headers = ["TIMESTAMP", "AGENT", "WORKFLOW", "PROVIDER", "MODEL", "TOKENS", "COST"]
-    else:
-        rows = [
-            [
-                e.get("timestamp", "")[:19].replace("T", " "),
-                e.get("agent", "—"),
-                e.get("provider", "—"),
-                e.get("model", "—"),
-                str(e.get("total_tokens", 0)),
-                f"${e.get('estimated_cost_usd', 0.0):.6f}",
-            ]
-            for e in entries
-        ]
-        headers = ["TIMESTAMP", "AGENT", "PROVIDER", "MODEL", "TOKENS", "COST"]
+        headers.append("WORKFLOW")
+    headers += ["PROVIDER", "MODEL", "TOKENS", "COST"]
     widths = [max(len(h), max(len(r[i]) for r in rows)) for i, h in enumerate(headers)]
     click.echo("  ".join(h.ljust(w) for h, w in zip(headers, widths)))
     click.echo("  ".join("-" * w for w in widths))

--- a/uio/core/ledger.py
+++ b/uio/core/ledger.py
@@ -42,19 +42,23 @@ def write_cost_ledger(
     entry: dict = {
         "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
         "agent": agent_name,
-        "provider": provider,
-        "model": model,
-        "prompt_tokens": prompt_tokens,
-        "completion_tokens": completion_tokens,
-        "total_tokens": prompt_tokens + completion_tokens,
-        "estimated_cost_usd": round(
-            estimate_cost_usd(provider, model, prompt_tokens, completion_tokens), 6
-        ),
     }
     if workflow is not None:
         entry["workflow"] = workflow
     if workflow_run_id is not None:
         entry["workflow_run_id"] = workflow_run_id
+    entry.update(
+        {
+            "provider": provider,
+            "model": model,
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+            "estimated_cost_usd": round(
+                estimate_cost_usd(provider, model, prompt_tokens, completion_tokens), 6
+            ),
+        }
+    )
     try:
         os.makedirs(os.path.dirname(os.path.abspath(ledger_path)), exist_ok=True)
         with open(ledger_path, "a") as f:

--- a/uio/core/ledger.py
+++ b/uio/core/ledger.py
@@ -36,8 +36,10 @@ def write_cost_ledger(
     prompt_tokens: int,
     completion_tokens: int,
     ledger_path: str = DEFAULT_LEDGER_PATH,
+    workflow: str | None = None,
+    workflow_run_id: str | None = None,
 ) -> None:
-    entry = {
+    entry: dict = {
         "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
         "agent": agent_name,
         "provider": provider,
@@ -49,6 +51,10 @@ def write_cost_ledger(
             estimate_cost_usd(provider, model, prompt_tokens, completion_tokens), 6
         ),
     }
+    if workflow is not None:
+        entry["workflow"] = workflow
+    if workflow_run_id is not None:
+        entry["workflow_run_id"] = workflow_run_id
     try:
         os.makedirs(os.path.dirname(os.path.abspath(ledger_path)), exist_ok=True)
         with open(ledger_path, "a") as f:

--- a/uio/core/runner.py
+++ b/uio/core/runner.py
@@ -303,6 +303,8 @@ def run_agent(
     context_max_tokens: int = 8000,
     attribution_enabled: bool = True,
     cost_callback: Callable[[str, str, str, int, int], None] | None = None,
+    workflow: str | None = None,
+    workflow_run_id: str | None = None,
 ) -> str | None:
     if definition_path is None:
         raise ValueError("definition_path must be provided")
@@ -468,6 +470,8 @@ def run_agent(
                             total_prompt,
                             total_completion,
                             ledger_path,
+                            workflow=workflow,
+                            workflow_run_id=workflow_run_id,
                         )
                         if cost_callback is not None:
                             cost_callback(
@@ -495,6 +499,8 @@ def run_agent(
                                 total_prompt,
                                 total_completion,
                                 ledger_path,
+                                workflow=workflow,
+                                workflow_run_id=workflow_run_id,
                             )
                             raise GuardrailError(
                                 f"max_cost_usd {guardrail_max_cost} exceeded"
@@ -540,6 +546,8 @@ def run_agent(
                     total_prompt,
                     total_completion,
                     ledger_path,
+                    workflow=workflow,
+                    workflow_run_id=workflow_run_id,
                 )
                 if cost_callback is not None:
                     cost_callback(

--- a/uio/core/workflow.py
+++ b/uio/core/workflow.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import re
 import sys
+import uuid
 from dataclasses import dataclass
 
 from uio.schema.parser import parse_definition_file
@@ -91,6 +92,7 @@ def run_workflow(
         print("  [workflow] No steps defined. Nothing to do.")
         return
 
+    workflow_run_id = str(uuid.uuid4())
     variables: dict[str, str] = {"input": arg or ""}
 
     print(f"\n🔄 Workflow: {fm.get('name', workflow_name)}")
@@ -145,6 +147,8 @@ def run_workflow(
                 memory_dir=cfg["dirs"]["memory"],
                 context_max_tokens=cfg["runtime"]["context_max_tokens"],
                 attribution_enabled=cfg["attribution"]["enabled"],
+                workflow=workflow_name,
+                workflow_run_id=workflow_run_id,
             )
         except GuardrailError as exc:
             print(f"\n❌ Workflow halted at step '{step.name}': guardrail — {exc}", file=sys.stderr)

--- a/uio/core/workflow.py
+++ b/uio/core/workflow.py
@@ -99,6 +99,7 @@ def run_workflow(
     print(f"   Steps: {len(steps)}")
     if arg:
         print(f"   Input: {arg}")
+    print(f"   Run ID: {workflow_run_id}")
     print()
 
     for i, step in enumerate(steps, 1):

--- a/uio/core/workflow.py
+++ b/uio/core/workflow.py
@@ -18,6 +18,7 @@ class WorkflowStep:
     name: str
     agent: str | None = None
     skill: str | None = None
+    prompt: str | None = None
     arg: str | None = None
     output: str | None = None
     when: str | None = None
@@ -34,6 +35,7 @@ def parse_workflow_steps(frontmatter: dict) -> list[WorkflowStep]:
                 name=s.get("name", ""),
                 agent=s.get("agent"),
                 skill=s.get("skill"),
+                prompt=s.get("prompt"),
                 arg=s.get("arg"),
                 output=s.get("output"),
                 when=s.get("when"),
@@ -110,9 +112,12 @@ def run_workflow(
         elif step.skill:
             def_path = f"{cfg['dirs']['skills']}/{step.skill}.skill.md"
             runner_name = step.skill
+        elif step.prompt:
+            def_path = f"{cfg['dirs']['prompts']}/{step.prompt}.prompt.md"
+            runner_name = step.prompt
         else:
             print(
-                f"  [workflow] Error: step '{step.name}' has neither 'agent' nor 'skill'",
+                f"  [workflow] Error: step '{step.name}' has none of 'agent', 'skill', or 'prompt'",
                 file=sys.stderr,
             )
             sys.exit(1)

--- a/uio/schema/parser.py
+++ b/uio/schema/parser.py
@@ -272,7 +272,7 @@ def check_schema_support(path: str, frontmatter: dict, provider: str | None) -> 
 
 
 _WORKFLOW_KNOWN_KEYS = {"name", "description", "steps"}
-_STEP_KNOWN_KEYS = {"name", "agent", "skill", "arg", "output", "when"}
+_STEP_KNOWN_KEYS = {"name", "agent", "skill", "prompt", "arg", "output", "when"}
 
 
 def validate_workflow_definition(path: str, frontmatter: dict) -> list[str]:
@@ -307,10 +307,12 @@ def check_workflow_steps(path: str, frontmatter: dict) -> list[str]:
                 warnings.append(f"{path}: step {i + 1} has unrecognised key '{key}'")
         has_agent = "agent" in step
         has_skill = "skill" in step
-        if has_agent and has_skill:
+        has_prompt = "prompt" in step
+        type_count = sum([has_agent, has_skill, has_prompt])
+        if type_count > 1:
             warnings.append(
-                f"{path}: step {i + 1} defines both 'agent' and 'skill' — they are mutually exclusive"
+                f"{path}: step {i + 1} defines multiple step types ('agent', 'skill', 'prompt' are mutually exclusive)"
             )
-        elif not has_agent and not has_skill:
-            warnings.append(f"{path}: step {i + 1} has neither 'agent' nor 'skill'")
+        elif type_count == 0:
+            warnings.append(f"{path}: step {i + 1} has neither 'agent', 'skill', nor 'prompt'")
     return warnings


### PR DESCRIPTION
Closes #269

## Summary

- `write_cost_ledger()` now accepts optional `workflow: str | None` and `workflow_run_id: str | None`; when set they are written into the JSONL entry
- `run_agent()` accepts and forwards both fields to every `write_cost_ledger()` call site (normal finish, guardrail cutoff, iteration cap)
- `run_workflow()` generates a UUID4 `workflow_run_id` once per run and passes `workflow_name` + that ID through every `run_agent()` call in the workflow; callers outside workflow context pass `None` (no behaviour change)
- `uio cost` gains a `--workflow <NAME>` filter flag; when any displayed entry contains a `workflow` field the table gains a `WORKFLOW` column

## Test plan

- [ ] `python -m pytest tests/` — all 655 tests pass
- [ ] `uio workflow run <name> <arg>` — entries in the JSONL ledger have `workflow` and `workflow_run_id` fields with a shared UUID per run
- [ ] `uio cost --workflow <name>` — shows only entries for that workflow with a `WORKFLOW` column
- [ ] `uio cost` without `--workflow` — table unchanged (no `WORKFLOW` column) for legacy entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)