### PR TITLE
feat: add extends: frontmatter key for definition inheritance

### DIFF
--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -1,0 +1,602 @@
+"""Tests for the extends: frontmatter inheritance feature."""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from uio.schema.parser import (
+    check_inheritance_cycles,
+    parse_definition_file,
+    resolve_inheritance,
+    validate_definition,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write(tmp_path, filename: str, content: str):
+    """Write *content* to *tmp_path/filename* and return the path string."""
+    f = tmp_path / filename
+    f.write_text(textwrap.dedent(content))
+    return str(f)
+
+
+# ---------------------------------------------------------------------------
+# validate_definition: extends: is a known key
+# ---------------------------------------------------------------------------
+
+
+def test_validate_extends_field_accepted(tmp_path):
+    """'extends:' must not produce an 'unrecognised key' error."""
+    f = _write(
+        tmp_path,
+        "child.agent.md",
+        """\
+        ---
+        name: Child
+        description: A child agent.
+        extends: base
+        ---
+        Child body.
+        """,
+    )
+    fm, _ = parse_definition_file(f)
+    errors = validate_definition(f, fm)
+    assert not any("extends" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# resolve_inheritance: basic single-level inheritance
+# ---------------------------------------------------------------------------
+
+
+def test_basic_inheritance_appends_body(tmp_path):
+    """Child body is appended after parent body by default."""
+    _write(
+        tmp_path,
+        "base.agent.md",
+        """\
+        ---
+        name: Base
+        description: The base agent.
+        ---
+        Parent body.
+        """,
+    )
+    child_path = _write(
+        tmp_path,
+        "child.agent.md",
+        """\
+        ---
+        name: Child
+        description: The child agent.
+        extends: base
+        ---
+        Child body.
+        """,
+    )
+    fm, body = parse_definition_file(child_path)
+    merged_fm, merged_body = resolve_inheritance(child_path, fm, body, search_dirs=[str(tmp_path)])
+
+    assert "Parent body." in merged_body
+    assert "Child body." in merged_body
+    # Parent comes first
+    assert merged_body.index("Parent body.") < merged_body.index("Child body.")
+
+
+def test_basic_inheritance_merges_frontmatter(tmp_path):
+    """Child frontmatter overrides parent; shared keys use child values."""
+    _write(
+        tmp_path,
+        "base.agent.md",
+        """\
+        ---
+        name: Base
+        description: The base agent.
+        complexity: small
+        tools:
+          - terminal
+        ---
+        Parent body.
+        """,
+    )
+    child_path = _write(
+        tmp_path,
+        "child.agent.md",
+        """\
+        ---
+        name: Child
+        description: The child agent.
+        extends: base
+        complexity: large
+        ---
+        Child body.
+        """,
+    )
+    fm, body = parse_definition_file(child_path)
+    merged_fm, _ = resolve_inheritance(child_path, fm, body, search_dirs=[str(tmp_path)])
+
+    # Child identity fields are preserved
+    assert merged_fm["name"] == "Child"
+    assert merged_fm["description"] == "The child agent."
+    # Child overrides complexity
+    assert merged_fm["complexity"] == "large"
+    # Inherited from parent
+    assert merged_fm["tools"] == ["terminal"]
+    # extends: key itself is not in the merged frontmatter
+    assert "extends" not in merged_fm
+
+
+def test_child_name_and_description_always_from_child(tmp_path):
+    """name and description are never inherited from the parent."""
+    _write(
+        tmp_path,
+        "base.agent.md",
+        """\
+        ---
+        name: Base Name
+        description: Base description.
+        ---
+        Body.
+        """,
+    )
+    child_path = _write(
+        tmp_path,
+        "child.agent.md",
+        """\
+        ---
+        name: Child Name
+        description: Child description.
+        extends: base
+        ---
+        Child.
+        """,
+    )
+    fm, body = parse_definition_file(child_path)
+    merged_fm, _ = resolve_inheritance(child_path, fm, body, search_dirs=[str(tmp_path)])
+
+    assert merged_fm["name"] == "Child Name"
+    assert merged_fm["description"] == "Child description."
+
+
+# ---------------------------------------------------------------------------
+# resolve_inheritance: # Override marker
+# ---------------------------------------------------------------------------
+
+
+def test_override_marker_replaces_parent_body(tmp_path):
+    """A child body starting with '# Override' replaces the parent body entirely."""
+    _write(
+        tmp_path,
+        "base.agent.md",
+        """\
+        ---
+        name: Base
+        description: Base.
+        ---
+        Parent body that should not appear.
+        """,
+    )
+    child_path = _write(
+        tmp_path,
+        "child.agent.md",
+        """\
+        ---
+        name: Child
+        description: Child.
+        extends: base
+        ---
+        # Override
+        Completely new body.
+        """,
+    )
+    fm, body = parse_definition_file(child_path)
+    merged_fm, merged_body = resolve_inheritance(child_path, fm, body, search_dirs=[str(tmp_path)])
+
+    assert "Parent body" not in merged_body
+    assert "Completely new body." in merged_body
+    # The marker line itself is stripped
+    assert "# Override" not in merged_body
+
+
+def test_override_marker_content_is_preserved(tmp_path):
+    """Everything after '# Override\\n' in the child body is the replacement content."""
+    _write(
+        tmp_path,
+        "base.agent.md",
+        """\
+        ---
+        name: Base
+        description: Base.
+        ---
+        Original.
+        """,
+    )
+    child_path = _write(
+        tmp_path,
+        "child.agent.md",
+        """\
+        ---
+        name: Child
+        description: Child.
+        extends: base
+        ---
+        # Override
+        Line one.
+        Line two.
+        """,
+    )
+    fm, body = parse_definition_file(child_path)
+    _, merged_body = resolve_inheritance(child_path, fm, body, search_dirs=[str(tmp_path)])
+
+    assert "Line one." in merged_body
+    assert "Line two." in merged_body
+
+
+# ---------------------------------------------------------------------------
+# resolve_inheritance: multi-level chains
+# ---------------------------------------------------------------------------
+
+
+def test_multi_level_chain(tmp_path):
+    """A -> B -> C: C's body comes first, then B's, then A's."""
+    _write(
+        tmp_path,
+        "grandparent.agent.md",
+        """\
+        ---
+        name: Grandparent
+        description: Grandparent.
+        ---
+        Grandparent body.
+        """,
+    )
+    _write(
+        tmp_path,
+        "parent.agent.md",
+        """\
+        ---
+        name: Parent
+        description: Parent.
+        extends: grandparent
+        ---
+        Parent body.
+        """,
+    )
+    child_path = _write(
+        tmp_path,
+        "child.agent.md",
+        """\
+        ---
+        name: Child
+        description: Child.
+        extends: parent
+        ---
+        Child body.
+        """,
+    )
+    fm, body = parse_definition_file(child_path)
+    _, merged_body = resolve_inheritance(child_path, fm, body, search_dirs=[str(tmp_path)])
+
+    assert "Grandparent body." in merged_body
+    assert "Parent body." in merged_body
+    assert "Child body." in merged_body
+    # Order: grandparent first, then parent, then child
+    gp_pos = merged_body.index("Grandparent body.")
+    p_pos = merged_body.index("Parent body.")
+    c_pos = merged_body.index("Child body.")
+    assert gp_pos < p_pos < c_pos
+
+
+def test_multi_level_frontmatter_merge(tmp_path):
+    """Frontmatter merges correctly across a three-level chain."""
+    _write(
+        tmp_path,
+        "grandparent.agent.md",
+        """\
+        ---
+        name: Grandparent
+        description: Grandparent.
+        complexity: small
+        tools:
+          - terminal
+        ---
+        GP body.
+        """,
+    )
+    _write(
+        tmp_path,
+        "parent.agent.md",
+        """\
+        ---
+        name: Parent
+        description: Parent.
+        extends: grandparent
+        complexity: large
+        ---
+        Parent body.
+        """,
+    )
+    child_path = _write(
+        tmp_path,
+        "child.agent.md",
+        """\
+        ---
+        name: Child
+        description: Child.
+        extends: parent
+        ---
+        Child body.
+        """,
+    )
+    fm, body = parse_definition_file(child_path)
+    merged_fm, _ = resolve_inheritance(child_path, fm, body, search_dirs=[str(tmp_path)])
+
+    # Grandparent's tools inherited through parent
+    assert merged_fm["tools"] == ["terminal"]
+    # Parent overrode complexity to large; child does not override it
+    assert merged_fm["complexity"] == "large"
+    assert merged_fm["name"] == "Child"
+
+
+# ---------------------------------------------------------------------------
+# resolve_inheritance: error cases
+# ---------------------------------------------------------------------------
+
+
+def test_missing_parent_raises_file_not_found(tmp_path):
+    """Resolving a definition that extends a non-existent parent raises FileNotFoundError."""
+    child_path = _write(
+        tmp_path,
+        "orphan.agent.md",
+        """\
+        ---
+        name: Orphan
+        description: Orphan.
+        extends: does-not-exist
+        ---
+        Body.
+        """,
+    )
+    fm, body = parse_definition_file(child_path)
+    with pytest.raises(FileNotFoundError, match="does-not-exist"):
+        resolve_inheritance(child_path, fm, body, search_dirs=[str(tmp_path)])
+
+
+def test_no_extends_returns_unchanged(tmp_path):
+    """A definition without 'extends:' is returned unchanged."""
+    path = _write(
+        tmp_path,
+        "plain.agent.md",
+        """\
+        ---
+        name: Plain
+        description: Plain.
+        ---
+        Plain body.
+        """,
+    )
+    fm, body = parse_definition_file(path)
+    merged_fm, merged_body = resolve_inheritance(path, fm, body, search_dirs=[str(tmp_path)])
+    assert merged_fm == fm
+    assert merged_body == body
+
+
+# ---------------------------------------------------------------------------
+# Cycle detection
+# ---------------------------------------------------------------------------
+
+
+def test_direct_cycle_raises(tmp_path):
+    """A extends B, B extends A → cycle is detected and raises ValueError."""
+    a_path = _write(
+        tmp_path,
+        "a.agent.md",
+        """\
+        ---
+        name: A
+        description: A.
+        extends: b
+        ---
+        A body.
+        """,
+    )
+    _write(
+        tmp_path,
+        "b.agent.md",
+        """\
+        ---
+        name: B
+        description: B.
+        extends: a
+        ---
+        B body.
+        """,
+    )
+    fm, body = parse_definition_file(a_path)
+    with pytest.raises(ValueError, match="cycle"):
+        resolve_inheritance(a_path, fm, body, search_dirs=[str(tmp_path)])
+
+
+def test_indirect_cycle_raises(tmp_path):
+    """A extends B, B extends C, C extends A → cycle is detected."""
+    a_path = _write(
+        tmp_path,
+        "a.agent.md",
+        """\
+        ---
+        name: A
+        description: A.
+        extends: b
+        ---
+        A body.
+        """,
+    )
+    _write(
+        tmp_path,
+        "b.agent.md",
+        """\
+        ---
+        name: B
+        description: B.
+        extends: c
+        ---
+        B body.
+        """,
+    )
+    _write(
+        tmp_path,
+        "c.agent.md",
+        """\
+        ---
+        name: C
+        description: C.
+        extends: a
+        ---
+        C body.
+        """,
+    )
+    fm, body = parse_definition_file(a_path)
+    with pytest.raises(ValueError, match="cycle"):
+        resolve_inheritance(a_path, fm, body, search_dirs=[str(tmp_path)])
+
+
+def test_check_inheritance_cycles_detects_cycle(tmp_path):
+    """check_inheritance_cycles returns a warning when a cycle exists."""
+    a_path = _write(
+        tmp_path,
+        "a.agent.md",
+        """\
+        ---
+        name: A
+        description: A.
+        extends: b
+        ---
+        A body.
+        """,
+    )
+    _write(
+        tmp_path,
+        "b.agent.md",
+        """\
+        ---
+        name: B
+        description: B.
+        extends: a
+        ---
+        B body.
+        """,
+    )
+    warnings = check_inheritance_cycles([a_path])
+    assert len(warnings) >= 1
+    assert any("cycle" in w.lower() for w in warnings)
+
+
+def test_check_inheritance_cycles_no_cycle(tmp_path):
+    """check_inheritance_cycles returns no warnings when chains are valid."""
+    _write(
+        tmp_path,
+        "base.agent.md",
+        """\
+        ---
+        name: Base
+        description: Base.
+        ---
+        Base body.
+        """,
+    )
+    child_path = _write(
+        tmp_path,
+        "child.agent.md",
+        """\
+        ---
+        name: Child
+        description: Child.
+        extends: base
+        ---
+        Child body.
+        """,
+    )
+    warnings = check_inheritance_cycles([child_path])
+    assert warnings == []
+
+
+def test_check_inheritance_cycles_missing_parent_warns(tmp_path):
+    """check_inheritance_cycles warns when the parent definition does not exist."""
+    child_path = _write(
+        tmp_path,
+        "orphan.agent.md",
+        """\
+        ---
+        name: Orphan
+        description: Orphan.
+        extends: nonexistent
+        ---
+        Body.
+        """,
+    )
+    warnings = check_inheritance_cycles([child_path])
+    assert len(warnings) >= 1
+    assert any("nonexistent" in w for w in warnings)
+
+
+def test_check_inheritance_cycles_skips_no_extends(tmp_path):
+    """check_inheritance_cycles is silent for definitions without extends:."""
+    plain_path = _write(
+        tmp_path,
+        "plain.agent.md",
+        """\
+        ---
+        name: Plain
+        description: Plain.
+        ---
+        Plain body.
+        """,
+    )
+    warnings = check_inheritance_cycles([plain_path])
+    assert warnings == []
+
+
+# ---------------------------------------------------------------------------
+# Skill file resolution via extends
+# ---------------------------------------------------------------------------
+
+
+def test_extends_resolves_skill_file(tmp_path):
+    """extends: can refer to a .skill.md parent."""
+    _write(
+        tmp_path,
+        "base-skill.skill.md",
+        """\
+        ---
+        name: base-skill
+        description: Base skill.
+        ---
+        ## Input
+        Base skill body.
+
+        ## Output
+        Result.
+        """,
+    )
+    child_path = _write(
+        tmp_path,
+        "child-skill.skill.md",
+        """\
+        ---
+        name: child-skill
+        description: Child skill.
+        extends: base-skill
+        ---
+        Extra child instructions.
+        """,
+    )
+    fm, body = parse_definition_file(child_path)
+    merged_fm, merged_body = resolve_inheritance(child_path, fm, body, search_dirs=[str(tmp_path)])
+    assert "Base skill body." in merged_body
+    assert "Extra child instructions." in merged_body

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -244,7 +244,7 @@ def test_override_marker_content_is_preserved(tmp_path):
 
 
 def test_multi_level_chain(tmp_path):
-    """A -> B -> C: C's body comes first, then B's, then A's."""
+    """A -> B -> C: grandparent body comes first, then parent's, then child's."""
     _write(
         tmp_path,
         "grandparent.agent.md",

--- a/uio/cli/main.py
+++ b/uio/cli/main.py
@@ -26,6 +26,7 @@ from uio.examples import EXAMPLES
 from uio.schema.parser import (
     check_heading_format,
     check_identity_env,
+    check_inheritance_cycles,
     check_minimal_body,
     check_schema_support,
     check_skill_interface_sections,
@@ -209,10 +210,12 @@ def validate_cmd(strict: bool) -> None:
     errors: list[str] = []
     warnings: list[str] = []
     total = 0
+    all_definition_paths: list[str] = []
 
     for directory, pattern in agent_skill_prompt_patterns:
         for path in sorted(glob(f"{directory}/{pattern}")):
             total += 1
+            all_definition_paths.append(path)
             try:
                 fm, body = parse_definition_file(path)
             except Exception as e:
@@ -239,6 +242,9 @@ def validate_cmd(strict: bool) -> None:
                 continue
             errors.extend(validate_workflow_definition(path, fm))
             warnings.extend(check_workflow_steps(path, fm))
+
+    # Resolve inheritance chains and warn on cycles / missing parents
+    warnings.extend(check_inheritance_cycles(all_definition_paths))
 
     if total == 0:
         click.echo("  No definition files found.")

--- a/uio/schema/parser.py
+++ b/uio/schema/parser.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import os
 import re
+from glob import glob
+from pathlib import Path
 
 import yaml
 
@@ -23,6 +25,9 @@ _STOPPING_PHRASES = re.compile(
     re.IGNORECASE,
 )
 
+# Marker that causes a child body to *replace* the parent body instead of appending.
+_OVERRIDE_MARKER = "# Override"
+
 
 def parse_frontmatter_raw(path: str) -> tuple[dict, str]:
     """Return (frontmatter_dict, body_text) for any YAML-frontmatter file."""
@@ -37,6 +42,160 @@ def parse_frontmatter_raw(path: str) -> tuple[dict, str]:
 def parse_definition_file(path: str) -> tuple[dict, str]:
     """Return (frontmatter_dict, body_text) for a definition file."""
     return parse_frontmatter_raw(path)
+
+
+# ---------------------------------------------------------------------------
+# Definition inheritance (extends: frontmatter key)
+# ---------------------------------------------------------------------------
+
+# Keys that are *not* inherited from the parent — they are always child-specific.
+_NON_INHERITED_KEYS = frozenset({"name", "description", "extends"})
+
+
+def _find_definition_by_name(name: str, search_dirs: list[str]) -> str | None:
+    """Return the path of the first definition file whose stem matches *name*.
+
+    Searches *search_dirs* in order, accepting files with any of the standard
+    definition extensions (``*.agent.md``, ``*.skill.md``, ``*.prompt.md``).
+    Returns ``None`` when no match is found.
+    """
+    extensions = ("*.agent.md", "*.skill.md", "*.prompt.md")
+    for directory in search_dirs:
+        for ext in extensions:
+            matches = glob(os.path.join(directory, ext))
+            for match in matches:
+                stem = Path(match).name.split(".")[0]
+                if stem == name:
+                    return match
+    return None
+
+
+def _collect_uio_dirs(start_path: str) -> list[str]:
+    """Return all sub-directories of the nearest ``.uio/`` tree containing *start_path*.
+
+    Walks upward from the directory containing *start_path* until it finds a
+    ``.uio/`` directory, then returns all leaf sub-directories within it (agents,
+    skills, prompts) as the search scope for parent resolution.
+
+    Falls back to just the directory containing *start_path* when no ``.uio/``
+    ancestor is found.
+    """
+    start_dir = Path(start_path).resolve().parent
+    candidate = start_dir
+    for _ in range(20):  # guard against runaway traversal
+        uio_dir = candidate / ".uio"
+        if uio_dir.is_dir():
+            # Collect all immediate sub-directories of .uio/
+            dirs = [str(uio_dir)]
+            for child in uio_dir.iterdir():
+                if child.is_dir():
+                    dirs.append(str(child))
+            return dirs
+        parent = candidate.parent
+        if parent == candidate:
+            break
+        candidate = parent
+    # No .uio/ ancestor found — fall back to the file's own directory
+    return [str(start_dir)]
+
+
+def resolve_inheritance(
+    path: str,
+    frontmatter: dict,
+    body: str,
+    *,
+    _visited: tuple[str, ...] = (),
+    search_dirs: list[str] | None = None,
+) -> tuple[dict, str]:
+    """Resolve ``extends:`` inheritance and return the merged (frontmatter, body).
+
+    Merge semantics:
+    - Frontmatter: parent values are the baseline; child values override them.
+      ``name``, ``description``, and ``extends`` are always taken from the child.
+    - Body: child body is **appended after parent body** by default.
+      If the child body starts with ``# Override``, the child body **replaces**
+      the parent body instead of appending.
+
+    Inheritance is resolved recursively so multi-level chains work correctly.
+    Cycles are detected via the *_visited* path tuple and raise ``ValueError``.
+    """
+    extends = frontmatter.get("extends")
+    if not extends:
+        return frontmatter, body
+
+    abs_path = str(Path(path).resolve())
+    if abs_path in _visited:
+        chain = " -> ".join(_visited + (abs_path,))
+        raise ValueError(f"Inheritance cycle detected: {chain}")
+
+    visited = _visited + (abs_path,)
+
+    if search_dirs is None:
+        search_dirs = _collect_uio_dirs(path)
+
+    parent_path = _find_definition_by_name(str(extends), search_dirs)
+    if parent_path is None:
+        raise FileNotFoundError(
+            f"{path}: extends: '{extends}' — no definition named '{extends}' found"
+        )
+
+    parent_fm_raw, parent_body_raw = parse_frontmatter_raw(parent_path)
+
+    # Recursively resolve the parent's own inheritance first
+    parent_fm, parent_body = resolve_inheritance(
+        parent_path,
+        parent_fm_raw,
+        parent_body_raw,
+        _visited=visited,
+        search_dirs=search_dirs,
+    )
+
+    # Merge frontmatter: parent values as baseline, child overrides (except non-inherited keys)
+    merged_fm: dict = {}
+    for k, v in parent_fm.items():
+        if k not in _NON_INHERITED_KEYS:
+            merged_fm[k] = v
+    for k, v in frontmatter.items():
+        if k != "extends":
+            merged_fm[k] = v
+
+    # Merge body
+    if body.startswith(_OVERRIDE_MARKER):
+        # Child explicitly replaces parent body; strip the marker line itself
+        after_marker = body[len(_OVERRIDE_MARKER) :].lstrip("\n")
+        merged_body = after_marker
+    else:
+        if parent_body and body:
+            merged_body = parent_body + "\n\n" + body
+        elif parent_body:
+            merged_body = parent_body
+        else:
+            merged_body = body
+
+    return merged_fm, merged_body
+
+
+def check_inheritance_cycles(paths: list[str]) -> list[str]:
+    """Return warning strings for any inheritance cycles found across *paths*.
+
+    Each element of *paths* should be the absolute or relative path to a
+    definition file.  Files without an ``extends:`` key are skipped silently.
+    """
+    warnings: list[str] = []
+    for path in paths:
+        try:
+            fm, body = parse_frontmatter_raw(path)
+        except Exception:
+            continue
+        if not fm.get("extends"):
+            continue
+        try:
+            resolve_inheritance(path, fm, body)
+        except ValueError as exc:
+            warnings.append(f"WARNING: {exc}")
+        except FileNotFoundError as exc:
+            warnings.append(f"WARNING: {exc}")
+    return warnings
 
 
 def validate_definition(path: str, frontmatter: dict) -> list[str]:
@@ -61,6 +220,7 @@ def validate_definition(path: str, frontmatter: dict) -> list[str]:
         "vcs-identity",
         "vcs-provider",
         "schema",
+        "extends",
     }
     for key in frontmatter:
         if key not in known:

--- a/uio/schema/parser.py
+++ b/uio/schema/parser.py
@@ -64,7 +64,14 @@ def _find_definition_by_name(name: str, search_dirs: list[str]) -> str | None:
         for ext in extensions:
             matches = glob(os.path.join(directory, ext))
             for match in matches:
-                stem = Path(match).name.split(".")[0]
+                name_part = Path(match).name
+                stem = None
+                for ext_suffix in (".agent.md", ".skill.md", ".prompt.md"):
+                    if name_part.endswith(ext_suffix):
+                        stem = name_part[: -len(ext_suffix)]
+                        break
+                if stem is None:
+                    stem = name_part.split(".")[0]  # fallback for unknown extension types
                 if stem == name:
                     return match
     return None
@@ -192,9 +199,9 @@ def check_inheritance_cycles(paths: list[str]) -> list[str]:
         try:
             resolve_inheritance(path, fm, body)
         except ValueError as exc:
-            warnings.append(f"WARNING: {exc}")
+            warnings.append(str(exc))
         except FileNotFoundError as exc:
-            warnings.append(f"WARNING: {exc}")
+            warnings.append(str(exc))
     return warnings
 
 


### PR DESCRIPTION
## Summary

Closes #260

Adds an `extends:` frontmatter key so agent, skill, and prompt definitions can inherit from a named parent in the same `.uio/` directory tree, eliminating copy-paste when multiple agents share a common preamble or capability set.

## Changes

- **`uio/schema/parser.py`**: Add `extends:` to known frontmatter keys (`validate_definition`). Add `resolve_inheritance()` which resolves a definition's full ancestry recursively — parent frontmatter is the baseline, child values override, and `name`/`description`/`extends` are always taken from the child. Body merge: child body is appended after parent body by default; if the child body starts with `# Override`, it replaces the parent body entirely. Add `check_inheritance_cycles()` which accepts a list of definition paths and returns warning strings for any cycle or missing-parent found.
- **`uio/cli/main.py`**: Import `check_inheritance_cycles`; call it in `validate_cmd` after scanning all definition files so `uio validate` reports inheritance problems.
- **`tests/test_inheritance.py`**: 17 new tests covering basic inheritance (body append, frontmatter merge), `# Override` replacement, multi-level chains, cycle detection (direct and indirect), missing-parent errors, and skill-file resolution.

## Test plan

- [x] `pytest` passes locally (689 tests, 0 failures)
- [x] `ruff check .` passes locally
- [x] `ruff format --check .` passes locally

## Notes for reviewers

`resolve_inheritance()` is not called automatically during `parse_definition_file()` — it is an explicit opt-in step. This keeps the existing loading path unchanged and means the runner picks up the raw (un-merged) body unless callers explicitly resolve. A follow-up can wire it into the runner if desired.

---

> This pull request was created by [AI Coder](https://github.com/apps/uio-coder) in response to issue #260.