### PR TITLE
docs: update CLI reference, frontmatter schema, README, and CLAUDE.md for recent features

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,25 +33,15 @@ it is **not** read by Claude Code. Claude Code loads MCP servers from:
 - `.mcp.json` at the project root (project-scoped)
 - `~/.claude/settings.json` under `mcpServers` (global)
 
-Neither exists in this project yet. To enable the GitHub MCP server for Claude
-Code, create `.mcp.json` at the repo root:
+A project-level `.mcp.json` exists at the repo root and configures the GitHub
+MCP server. `ToolSearch` should find GitHub MCP tools in this environment. If
+tools are not available, fall back to the `gh` CLI.
 
-```json
-{
-  "mcpServers": {
-    "github": {
-      "command": "github-mcp-server",
-      "args": ["stdio"],
-      "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "<your-pat>"
-      }
-    }
-  }
-}
+To generate or regenerate `.mcp.json` from `uio.toml`:
+
+```bash
+uio mcp init --for claude
 ```
-
-Until that file exists, `ToolSearch` will not find any GitHub MCP tools and the
-`gh` CLI fallback is the correct path.
 
 ## MCP tool path restrictions
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ for the full comparison and rationale.
 | **Agent** | A multi-turn tool-use loop that can execute shell commands and call MCP tools; defined in `*.agent.md` |
 | **Skill** | A focused, composable subtask — same loop as an agent, but user-directed via `uio skill run`; defined in `*.skill.md` |
 | **Prompt** | A single-shot LLM instruction with no tool loop; defined in `*.prompt.md` |
+| **Workflow** | A sequential pipeline of agent/skill/prompt steps with output chaining; defined in `*.workflow.md` |
 | **Tool** | An external capability the model invokes mid-loop (MCP tools, `run_command`) — agent-directed, not user-directed |
 
 See the [Glossary](docs/02-concepts.md#glossary) for precise definitions of all terms, including the skill vs tool distinction.
@@ -55,6 +56,9 @@ uio init --examples
 # Run one of the bundled examples
 uio skill run summarise "Your text here"
 uio agent run repo-health
+
+# Inspect the full system prompt before running
+uio explain agent repo-health
 
 # Interactive streaming chat
 uio chat

--- a/docs/04-frontmatter.md
+++ b/docs/04-frontmatter.md
@@ -54,6 +54,8 @@ vcs-identity: planner
 | `max_tokens` | integer | No | `16000` | Overrides `runtime.anthropic_max_tokens` for this agent; Anthropic provider only — see [`max_tokens`](#max_tokens) below |
 | `guardrails` | mapping | No | — | Cost, turn, and tool guardrails — see [`guardrails`](#guardrails) below |
 | `context` | string or list of strings | No | — | Glob pattern(s) whose matching files are injected as a `## Context` block in the system prompt; de-duplicated and truncated at `runtime.context_max_tokens` (default 8000) tokens — see [`context`](#context) below |
+| `schema` | mapping or string | No | — | JSON Schema for structured output; instructs the provider to return validated JSON — see [`schema`](#schema) below |
+| `extends` | string | No | — | Inherit frontmatter defaults and body from a named parent definition — see [`extends`](#extends) below |
 | `github-identity` | `planner` \| `coder` \| `reviewer` | No | — | **Deprecated.** Use `vcs-identity` instead. Accepted as an alias for backwards compatibility. |
 
 ### Complexity tier resolution
@@ -259,6 +261,74 @@ A single glob can also be given as a plain string:
 context: "README.md"
 ```
 
+### `schema`
+
+Instructs the provider to return structured JSON output validated against a JSON Schema. When set, the provider's native structured-output mechanism is used (OpenAI `response_format`, Gemini `response_schema`).
+
+The value can be an inline JSON Schema mapping:
+
+```yaml
+---
+name: pr-status
+description: Returns pass/fail status and a list of issues found.
+schema:
+  type: object
+  properties:
+    status:
+      type: string
+      enum: [pass, fail]
+    issues:
+      type: array
+      items:
+        type: string
+  required: [status, issues]
+---
+```
+
+Or a `$ref` to an external `.json` file (resolved relative to the project root):
+
+```yaml
+schema:
+  $ref: schemas/pr-status.json
+```
+
+`uio validate` emits a warning when `schema:` is declared but the configured provider does not support structured output. Only `openai` and `gemini` are supported; `ollama` and `anthropic` do not support this field.
+
+### `extends`
+
+Inherit frontmatter defaults and body from a named parent definition. The parent is resolved by stem name within the same `.uio/` directory tree.
+
+```yaml
+---
+name: strict-reviewer
+description: Code reviewer with extra security checks.
+extends: base-reviewer
+---
+
+## Additional checks
+
+Also flag any use of `eval()` or `exec()` with untrusted input.
+```
+
+**Merge semantics:**
+
+- **Frontmatter:** Parent values are the baseline; child values override them. `name`, `description`, and `extends` are always child-specific and never inherited.
+- **Body:** The child body is appended after the parent body by default. Start the child body with `# Override` to replace the parent body entirely instead of appending.
+
+```yaml
+---
+name: minimal-reviewer
+description: Reviewer that replaces the parent body.
+extends: base-reviewer
+---
+
+# Override
+
+Only check for security issues. Ignore style and formatting entirely.
+```
+
+`uio validate` resolves all inheritance chains and warns on cycles or unresolvable parents. Multi-level chains (A → B → C) are supported.
+
 ---
 
 ## Skill fields (`.skill.md`)
@@ -342,7 +412,7 @@ Known keys (do not produce warnings):
 
 ```
 name  description  complexity  capabilities  tools  timeout  argument-hint  invokable
-max_tokens  guardrails  context  github-identity  vcs-identity  vcs-provider
+max_tokens  guardrails  context  schema  extends  github-identity  vcs-identity  vcs-provider
 ```
 
 Any other key produces an error. This is intentional — it catches typos like `Complexity: large` (capitalised) that would silently be ignored.

--- a/docs/04-frontmatter.md
+++ b/docs/04-frontmatter.md
@@ -285,14 +285,23 @@ schema:
 ---
 ```
 
-Or a `$ref` to an external `.json` file (resolved relative to the project root):
+Or a `$ref` to an external `.json` file. The path is resolved **relative to the definition file's own directory** and must remain within that directory (paths escaping via `../` are rejected at runtime):
 
 ```yaml
+# .uio/agents/pr-status.agent.md
 schema:
-  $ref: schemas/pr-status.json
+  $ref: pr-status-schema.json   # resolves to .uio/agents/pr-status-schema.json
+```
+
+A bare string is equivalent to `{$ref: ...}` and is the shortest form:
+
+```yaml
+schema: pr-status-schema.json
 ```
 
 `uio validate` emits a warning when `schema:` is declared but the configured provider does not support structured output. Only `openai` and `gemini` are supported; `ollama` and `anthropic` do not support this field.
+
+> **Note:** `schema:` is accepted on `.skill.md` and `.prompt.md` definitions as well, with identical semantics.
 
 ### `extends`
 
@@ -328,6 +337,8 @@ Only check for security issues. Ignore style and formatting entirely.
 ```
 
 `uio validate` resolves all inheritance chains and warns on cycles or unresolvable parents. Multi-level chains (A → B → C) are supported.
+
+> **Note:** `extends:` is accepted on `.skill.md` and `.prompt.md` definitions as well, with identical semantics.
 
 ---
 

--- a/docs/05-cli.md
+++ b/docs/05-cli.md
@@ -20,6 +20,10 @@ uio
 ├── workflow
 │   ├── run <name> [arg]
 │   └── list
+├── explain
+│   ├── agent <name>
+│   ├── skill <name>
+│   └── prompt <name>
 ├── chat
 ├── cost
 ├── config
@@ -67,6 +71,13 @@ The following flags apply to `agent run`, `skill run`, and `prompt run`:
 | `--no-mcp` | flag | off | Disable GitHub MCP server even when token is set |
 | `--shell` | `bash\|sh\|zsh\|powershell\|pwsh` | auto | Shell for `run_command`; auto-detects platform (PowerShell on Windows, bash/sh on POSIX) |
 
+`agent run` also accepts two parallel-execution flags (see [`--foreach`](#foreach-and-concurrency)):
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `--foreach` | string | — | Run the agent once per item in a newline-delimited list, concurrently |
+| `--concurrency` | integer | 4 | Maximum parallel workers when `--foreach` is used |
+
 ---
 
 ## `uio agent`
@@ -87,6 +98,23 @@ uio agent run my-agent --shell pwsh    # force PowerShell on any platform
 ```
 
 Exit code: 0 on success, 1 if the definition file is not found or validation fails.
+
+#### `--foreach` and `--concurrency`
+
+Run the agent once per item in a newline-delimited list, concurrently.
+
+```bash
+# Pass items inline (one per line)
+uio agent run audit --foreach "$(gh pr list --json number -q '.[].number')"
+
+# Read items from a file
+uio agent run audit --foreach @pr-numbers.txt
+
+# Raise the concurrency cap (default: 4)
+uio agent run audit --foreach @pr-numbers.txt --concurrency 8
+```
+
+`--foreach` prints a per-item header and footer as each invocation runs, then an aggregated cost summary at the end. Exit code is 1 if any item failed. `ARG` and `--foreach` are mutually exclusive.
 
 ### `uio agent list`
 
@@ -200,6 +228,59 @@ Output columns: NAME, STEPS, DESCRIPTION
 
 ```bash
 uio workflow list
+```
+
+---
+
+## `uio explain`
+
+Renders the complete system prompt that would be sent to the provider for a given definition — preamble, attribution block (if any), injected context files, and the definition body — annotated with section markers. Use this to debug unexpected model behaviour or to understand exactly what a definition sends to the LLM.
+
+### `uio explain agent <name>`
+
+```bash
+uio explain agent my-agent
+uio explain agent my-agent --raw
+```
+
+### `uio explain skill <name>`
+
+```bash
+uio explain skill summarise
+uio explain skill summarise --raw
+```
+
+### `uio explain prompt <name>`
+
+```bash
+uio explain prompt daily-standup
+uio explain prompt daily-standup --raw
+```
+
+### Shared flag
+
+| Flag | Description |
+|---|---|
+| `--raw` | Strip section markers — plain prompt text only, suitable for copy/paste into an external playground |
+
+**Output sections** (without `--raw`):
+
+```
+--- preamble ---
+<built-in preamble block>
+
+--- attribution ---
+<vcs-identity attribution instructions, if applicable>
+
+--- context ---
+<injected context files, if context: is set in frontmatter>
+
+--- body ---
+# Agent: <name>
+<definition body>
+
+--- memory ---
+<memory files, if any exist in .uio/memory/>
 ```
 
 ---


### PR DESCRIPTION
## Summary

- **`docs/05-cli.md`** — Add `uio explain` command (full section with agent/skill/prompt subcommands, `--raw` flag, annotated output sections); add `--foreach` / `--concurrency` to `uio agent run`; add `explain` to the command tree
- **`docs/04-frontmatter.md`** — Document `schema:` (structured JSON output) and `extends:` (definition inheritance) frontmatter keys with worked examples; update the Known Keys list in the Validation section
- **`README.md`** — Add **Workflow** to the Concepts table; add `uio explain agent` to the quickstart as a debugging step
- **`CLAUDE.md`** — Fix stale note ("Neither exists in this project yet") — `.mcp.json` now exists; update guidance to use `uio mcp init --for claude`

## Context

These are the documentation gaps left after the features shipped in #265 (explain), #266 (schema), #267 (--foreach), #272 (extends), #268/#270 (workflow prompt step). Closes #255, #257, #258, #260 from the docs perspective.

## Test plan

- [ ] Read through `uio explain` section — verify flags and output section names match `uio/cli/explain.py`
- [ ] Read through `--foreach` subsection — verify flag names and defaults match `uio/cli/agent.py`
- [ ] Read through `schema:` doc — verify provider list matches `_SCHEMA_SUPPORTED_PROVIDERS` in `uio/schema/parser.py`
- [ ] Read through `extends:` doc — verify merge semantics match `resolve_inheritance()` in `uio/schema/parser.py`
- [ ] Confirm Known Keys list now matches the `known` set in `validate_definition()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)