### PR TITLE
feat: add code coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,13 @@ jobs:
       - name: Run tests
         run: pytest -m "not integration"
 
+      - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.xml
+          fail_ci_if_error: true
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
         if: matrix.python-version == '3.12'
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
           fail_ci_if_error: true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ uio = "uio.cli.main:main"
 [project.optional-dependencies]
 dev = [
     "pytest>=9.0.3",
+    "pytest-cov",
     "ruff",
     "pyinstaller",
 ]
@@ -31,6 +32,14 @@ dev = [
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["uio*"]
+
+[tool.coverage.run]
+source = ["uio"]
+omit = ["*/tests/*", "*/test_*"]
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = false
 
 [tool.ruff]
 target-version = "py311"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 testpaths = tests
 pythonpath = .
-addopts = -m "not integration"
+addopts = -m "not integration" --cov=uio --cov-report=term-missing
 markers =
     integration: marks tests as integration tests (spawn real MCP processes; slow)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 testpaths = tests
 pythonpath = .
-addopts = -m "not integration" --cov=uio --cov-report=term-missing
+addopts = -m "not integration" --cov=uio --cov-report=term-missing --cov-report=xml
 markers =
     integration: marks tests as integration tests (spawn real MCP processes; slow)


### PR DESCRIPTION
## Summary

- Add `pytest-cov` to the `dev` optional dependencies in `pyproject.toml`
- Add `[tool.coverage.run]` and `[tool.coverage.report]` configuration sections to `pyproject.toml`
- Update `pytest.ini` to pass `--cov=uio --cov-report=term-missing` automatically on every `pytest` run

## Test plan

- [ ] Install dev dependencies: `pip install -e ".[dev]"`
- [ ] Run `pytest -m "not integration"` and confirm coverage report is printed to the terminal
- [ ] Verify missing lines are shown in the report

Closes #273

---
> This pull request was generated by [uio AI Coder](https://github.com/jomkz/uio).