### PR TITLE
docs/fix: disambiguate tools vs capabilities

### DIFF
--- a/docs/02-concepts.md
+++ b/docs/02-concepts.md
@@ -111,7 +111,7 @@ Run with `uio workflow run review-and-fix "owner/repo#42"`.
 | `steps:` frontmatter | No | No | No | Yes |
 | Typical use | Multi-step workflow | Focused subtask | One-shot query | Pipeline of agents/skills |
 
-Tools (`run_command`, MCP tools) are not definition types — they are capabilities the model invokes at runtime. See the [Glossary](#glossary) for the Tool definition and the skill vs tool distinction.
+Tools (`run_command`, MCP tools) are not definition types — they are callable functions the model invokes at runtime. See the [Glossary](#glossary) for the Tool definition and the skill vs tool distinction.
 
 ---
 
@@ -164,7 +164,7 @@ The definition file is the single source of truth for behaviour. Moving, editing
 | **Agents** | `.agent.md` — autonomous decision-makers |
 | **Skills** | `.skill.md` — composable, user-directed subtasks |
 | **Prompts** | `.prompt.md` — single-shot instructions |
-| **Tools** | MCP tools + `run_command` — agent-directed capabilities |
+| **Tools** | MCP tools + `run_command` — callable functions the agent invokes at runtime |
 
 This vocabulary is intentional. **"Agentic Stack"** is the umbrella term for the workflows + agents + skills + prompts + tools model that `uio` provides. See the [Glossary](#glossary) below for precise term definitions.
 
@@ -177,7 +177,8 @@ This vocabulary is intentional. **"Agentic Stack"** is the umbrella term for the
 | **Agent** | An autonomous decision-maker that runs a multi-turn tool-use loop. Defined in `*.agent.md`. Agents decide when to call tools and how to interpret results. |
 | **Skill** | A focused, composable subtask. Runs the same tool-use loop as an agent internally, but is **user-directed**: you invoke it explicitly with `uio skill run <name>`. Skills may also be referenced by name inside agent definition bodies. Skills are small, reusable building blocks; agents are higher-level workflows. |
 | **Prompt** | A single-shot LLM instruction. The definition body is sent once and the response is printed — no tool-use loop. Defined in `*.prompt.md`. |
-| **Tool** | An external capability the **model** invokes mid-loop. Tools are agent-directed: the agent decides when and how to call them. Examples: `run_command` (built-in), MCP tools such as GitHub or filesystem access. This is the key distinction from skills — a tool is called by the model; a skill is called by you. |
+| **Capability** | A label in the `capabilities:` frontmatter field that declares which tool families an agent uses (e.g. `vcs`, `thinking`). A capability declaration is not itself callable — it documents intent and may trigger runtime preamble injection (e.g. `vcs` injects the VCS tool alias table). |
+| **Tool** | A callable function the **model** invokes mid-loop. Tools are agent-directed: the agent decides when and how to call them. Examples: `run_command` (built-in), MCP tools such as GitHub or filesystem access. This is the key distinction from skills — a tool is called by the model; a skill is called by you. Not to be confused with the `capabilities:` frontmatter field, which *declares* which tool families an agent uses but is not itself callable. |
 | **Workflow** | A deterministic pipeline that chains agents and skills sequentially. Defined in `*.workflow.md`. The structure is fixed; the runtime executes steps in order with `{{ variable }}` interpolation and optional `when:` conditions — no LLM orchestrates the sequence. |
 | **Memory** | Persistent context injected into agent runs across sessions. |
 | **Guardrails** | Per-definition constraints on cost, tool access, and iteration count. |

--- a/docs/04-frontmatter.md
+++ b/docs/04-frontmatter.md
@@ -47,7 +47,7 @@ vcs-identity: planner
 | `name` | string | Yes | — | Display name |
 | `description` | string | Yes | — | One-line summary |
 | `complexity` | `large` \| `small` | No | `small` | Model tier selection — see below |
-| `capabilities` | list of strings | No | — | Declares which capability families the agent uses. Enforced by `validate_definition()` — unknown values produce an error. Accepted values: `vcs`, `db`, `browser`, `search`, `chat`, `tracker`, `ci`, `cloud`, `docs`, `monitor`, `email`, `vector`, `container`, `fs`, `http`, `kv`, `git`, `thinking`. (`tools` is an accepted legacy alias.) |
+| `capabilities` | list of strings | No | — | Declares which tool families the agent uses. This is a *declaration*, not a callable — it does not make tools available; it documents intent and triggers runtime behaviour such as preamble injection. Enforced by `validate_definition()` — unknown values produce an error. Accepted values: `vcs`, `db`, `browser`, `search`, `chat`, `tracker`, `ci`, `cloud`, `docs`, `monitor`, `email`, `vector`, `container`, `fs`, `http`, `kv`, `git`, `thinking`. |
 | `timeout` | integer (seconds) | No | 300 | Per-command shell timeout for `run_command` calls |
 | `vcs-identity` | `planner` \| `coder` \| `reviewer` | No | — | VCS App identity to obtain for this agent's repository operations — see below |
 | `vcs-provider` | `github` \| `gitlab` | No | `github` | VCS platform targeted by `vcs-identity`; controls which MCP tool aliases are injected |
@@ -417,16 +417,9 @@ When run as `uio prompt run ask-docs "what does the cost ledger store?"`, the fi
 `uio validate` parses all definition files in the configured directories — agents, skills, prompts, and workflows (`*.workflow.md`) — and checks:
 
 - **Error** (exits non-zero): `name` or `description` is missing or empty
-- **Warning** (exits zero): an unrecognised frontmatter key is present
+- **Warning** (exits zero): a frontmatter key is not recognised by uio
 
-Known keys (do not produce warnings):
-
-```
-name  description  complexity  capabilities  tools  timeout  argument-hint  invokable
-max_tokens  guardrails  context  schema  extends  github-identity  vcs-identity  vcs-provider
-```
-
-Any other key produces an error. This is intentional — it catches typos like `Complexity: large` (capitalised) that would silently be ignored.
+Unknown keys are not errors — definition files are often shared with other tools (editors, other AI frameworks) that use their own frontmatter fields. uio reads only the keys it knows about and ignores the rest. The warning exists to surface typos in uio-specific keys (e.g. `Complexity: large` instead of `complexity: large`).
 
 In addition, `uio validate` emits a **non-fatal warning** (exits zero) when `vcs-identity` (or the deprecated `github-identity`) is declared but the corresponding `GITHUB_APP_<ROLE>_*` env vars are absent. This flags configuration drift without blocking CI pipelines that run without App credentials.
 

--- a/docs/04-frontmatter.md
+++ b/docs/04-frontmatter.md
@@ -47,7 +47,7 @@ vcs-identity: planner
 | `name` | string | Yes | — | Display name |
 | `description` | string | Yes | — | One-line summary |
 | `complexity` | `large` \| `small` | No | `small` | Model tier selection — see below |
-| `capabilities` | list of strings | No | — | Declares which tool families the agent uses. This is a *declaration*, not a callable — it does not make tools available; it documents intent and triggers runtime behaviour such as preamble injection. Enforced by `validate_definition()` — unknown values produce an error. Accepted values: `vcs`, `db`, `browser`, `search`, `chat`, `tracker`, `ci`, `cloud`, `docs`, `monitor`, `email`, `vector`, `container`, `fs`, `http`, `kv`, `git`, `thinking`. |
+| `capabilities` | list of strings | No | — | Declares which tool families the agent uses. This is a *declaration*, not a callable — it does not make tools available; it documents intent and triggers runtime behaviour such as preamble injection. Enforced by `validate_definition()` — unknown capability values produce an error. Accepted values: `vcs`, `db`, `browser`, `search`, `chat`, `tracker`, `ci`, `cloud`, `docs`, `monitor`, `email`, `vector`, `container`, `fs`, `http`, `kv`, `git`, `thinking`. |
 | `timeout` | integer (seconds) | No | 300 | Per-command shell timeout for `run_command` calls |
 | `vcs-identity` | `planner` \| `coder` \| `reviewer` | No | — | VCS App identity to obtain for this agent's repository operations — see below |
 | `vcs-provider` | `github` \| `gitlab` | No | `github` | VCS platform targeted by `vcs-identity`; controls which MCP tool aliases are injected |

--- a/docs/12-writing-definitions.md
+++ b/docs/12-writing-definitions.md
@@ -250,7 +250,7 @@ The model will call tools for steps 1 and 3, then produce the review in step 4 w
 
 When in doubt, start with `small` and move to `large` if the output quality is insufficient. The cost difference is often 4–10x.
 
-### When to add `thinking` to your agent's capabilities
+### When to declare `thinking` in `capabilities:`
 
 If the Sequential Thinking MCP server is configured (see [MCP Integration](08-mcp.md#sequential-thinking-mcp-server)), you can explicitly request it in the agent's body to externalise reasoning before acting.
 
@@ -270,14 +270,14 @@ Do **not** use sequential thinking for:
 - Single-file reads or writes
 - Agents with `complexity: small` — the overhead of externalised reasoning exceeds the benefit
 
-The tool is available via MCP whenever the server is running. Declaring `thinking` in `capabilities:` is optional but recommended for agents where sequential reasoning is central — it documents intent:
+The `mcp__sequential-thinking__sequentialthinking` tool is available via MCP whenever the server is running. Declaring `thinking` in `capabilities:` is a documentation-only declaration — it does not make the tool available, but it documents intent and is recommended for agents where sequential reasoning is central:
 
 ```yaml
 ---
 name: deep-review
 complexity: large
 capabilities:
-  - github
+  - vcs
   - thinking
 ---
 ```

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -99,8 +99,8 @@ def test_basic_inheritance_merges_frontmatter(tmp_path):
         name: Base
         description: The base agent.
         complexity: small
-        tools:
-          - terminal
+        capabilities:
+          - fs
         ---
         Parent body.
         """,
@@ -127,7 +127,7 @@ def test_basic_inheritance_merges_frontmatter(tmp_path):
     # Child overrides complexity
     assert merged_fm["complexity"] == "large"
     # Inherited from parent
-    assert merged_fm["tools"] == ["terminal"]
+    assert merged_fm["capabilities"] == ["fs"]
     # extends: key itself is not in the merged frontmatter
     assert "extends" not in merged_fm
 
@@ -303,8 +303,8 @@ def test_multi_level_frontmatter_merge(tmp_path):
         name: Grandparent
         description: Grandparent.
         complexity: small
-        tools:
-          - terminal
+        capabilities:
+          - fs
         ---
         GP body.
         """,
@@ -337,8 +337,8 @@ def test_multi_level_frontmatter_merge(tmp_path):
     fm, body = parse_definition_file(child_path)
     merged_fm, _ = resolve_inheritance(child_path, fm, body, search_dirs=[str(tmp_path)])
 
-    # Grandparent's tools inherited through parent
-    assert merged_fm["tools"] == ["terminal"]
+    # Grandparent's capabilities inherited through parent
+    assert merged_fm["capabilities"] == ["fs"]
     # Parent overrode complexity to large; child does not override it
     assert merged_fm["complexity"] == "large"
     assert merged_fm["name"] == "Child"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -7,6 +7,7 @@ from uio.schema.parser import (
     check_identity_env,
     check_schema_support,
     check_skill_references,
+    check_unknown_keys,
     parse_definition_file,
     validate_definition,
 )
@@ -17,8 +18,8 @@ def test_standard_frontmatter(tmp_path):
         ---
         name: My Agent
         description: A test agent.
-        tools:
-          - terminal
+        capabilities:
+          - fs
         ---
         # Agent: My Agent
 
@@ -29,7 +30,7 @@ def test_standard_frontmatter(tmp_path):
     fm, body = parse_definition_file(str(f))
     assert fm["name"] == "My Agent"
     assert fm["description"] == "A test agent."
-    assert fm["tools"] == ["terminal"]
+    assert fm["capabilities"] == ["fs"]
     assert "Do the task." in body
 
 
@@ -99,12 +100,30 @@ def test_validate_missing_description(tmp_path):
     assert any("description" in e for e in errors)
 
 
-def test_validate_unknown_key_warns(tmp_path):
+def test_validate_unknown_key_ignored(tmp_path):
+    """Unknown keys are not errors — validate_definition passes them through."""
     f = tmp_path / "odd.agent.md"
-    f.write_text("---\nname: Odd\ndescription: Desc.\nweird_key: value\n---\nBody.")
+    f.write_text("---\nname: Odd\ndescription: Desc.\ntools: [bash]\nweird_key: value\n---\nBody.")
     fm, _ = parse_definition_file(str(f))
-    errors = validate_definition(str(f), fm)
-    assert any("weird_key" in e for e in errors)
+    assert validate_definition(str(f), fm) == []
+
+
+def test_check_unknown_keys_warns(tmp_path):
+    """check_unknown_keys returns a warning for each key uio does not recognise."""
+    f = tmp_path / "odd.agent.md"
+    f.write_text("---\nname: Odd\ndescription: Desc.\ntools: [bash]\nweird_key: value\n---\nBody.")
+    fm, _ = parse_definition_file(str(f))
+    warnings = check_unknown_keys(str(f), fm)
+    assert any("tools" in w for w in warnings)
+    assert any("weird_key" in w for w in warnings)
+
+
+def test_check_unknown_keys_clean(tmp_path):
+    """No warnings when all frontmatter keys are known to uio."""
+    f = tmp_path / "clean.agent.md"
+    f.write_text("---\nname: Clean\ndescription: Desc.\ncomplexity: small\n---\nBody.")
+    fm, _ = parse_definition_file(str(f))
+    assert check_unknown_keys(str(f), fm) == []
 
 
 def test_validate_github_identity_valid(tmp_path):

--- a/uio/cli/agent.py
+++ b/uio/cli/agent.py
@@ -402,8 +402,8 @@ def agent_inspect_cmd(agent_name: str) -> None:
     click.echo(
         f"  Complexity:  {infer_complexity(agent_name, fm, None, cfg['large_agents']['names'])}"
     )
-    if fm.get("tools"):
-        click.echo(f"  Tools:       {', '.join(fm['tools'])}")
+    if fm.get("capabilities"):
+        click.echo(f"  Capabilities: {', '.join(fm['capabilities'])}")
     click.echo()
     lines = body.splitlines()
     for line in lines[:20]:

--- a/uio/cli/main.py
+++ b/uio/cli/main.py
@@ -243,6 +243,7 @@ def validate_cmd(strict: bool) -> None:
                 errors.append(f"{path}: could not parse: {e}")
                 continue
             errors.extend(validate_workflow_definition(path, fm))
+            warnings.extend(check_unknown_keys(path, fm))
             warnings.extend(check_workflow_steps(path, fm))
 
     # Resolve inheritance chains and warn on cycles / missing parents

--- a/uio/cli/main.py
+++ b/uio/cli/main.py
@@ -33,6 +33,7 @@ from uio.schema.parser import (
     check_skill_references,
     check_stopping_criteria,
     check_thinking_complexity,
+    check_unknown_keys,
     check_workflow_steps,
     parse_definition_file,
     validate_definition,
@@ -222,6 +223,7 @@ def validate_cmd(strict: bool) -> None:
                 errors.append(f"{path}: could not parse: {e}")
                 continue
             errors.extend(validate_definition(path, fm))
+            warnings.extend(check_unknown_keys(path, fm))
             warnings.extend(check_identity_env(path, fm))
             warnings.extend(check_heading_format(path, fm, body))
             warnings.extend(check_skill_references(path, body, skills_dir))

--- a/uio/schema/parser.py
+++ b/uio/schema/parser.py
@@ -211,28 +211,6 @@ def validate_definition(path: str, frontmatter: dict) -> list[str]:
     for field in REQUIRED_FIELDS:
         if not frontmatter.get(field):
             errors.append(f"{path}: missing required field '{field}'")
-    known = {
-        "name",
-        "description",
-        "complexity",
-        "tools",
-        "capabilities",
-        "timeout",
-        "argument-hint",
-        "invokable",
-        "max_tokens",
-        "guardrails",
-        "context",
-        "github-identity",  # deprecated alias for vcs-identity
-        "vcs-identity",
-        "vcs-provider",
-        "schema",
-        "extends",
-    }
-    for key in frontmatter:
-        if key not in known:
-            errors.append(f"{path}: unrecognised frontmatter key '{key}'")
-
     # guardrails block validation
     guardrails = frontmatter.get("guardrails")
     if guardrails is not None and not isinstance(guardrails, dict):
@@ -268,6 +246,41 @@ def validate_definition(path: str, frontmatter: dict) -> list[str]:
             )
 
     return errors
+
+
+KNOWN_FRONTMATTER_KEYS: frozenset[str] = frozenset(
+    [
+        "name",
+        "description",
+        "complexity",
+        "capabilities",
+        "timeout",
+        "argument-hint",
+        "invokable",
+        "max_tokens",
+        "guardrails",
+        "context",
+        "github-identity",
+        "vcs-identity",
+        "vcs-provider",
+        "schema",
+        "extends",
+    ]
+)
+
+
+def check_unknown_keys(path: str, frontmatter: dict) -> list[str]:
+    """Return a warning for each frontmatter key uio does not recognise.
+
+    Unknown keys are not errors — the definition file may be shared with other
+    tools that use their own frontmatter fields. The warning exists to surface
+    typos in uio-specific keys (e.g. ``Complexity`` instead of ``complexity``).
+    """
+    warnings = []
+    for key in frontmatter:
+        if key not in KNOWN_FRONTMATTER_KEYS:
+            warnings.append(f"{path}: unknown frontmatter key '{key}' (ignored by uio)")
+    return warnings
 
 
 def check_identity_env(path: str, frontmatter: dict) -> list[str]:

--- a/uio/schema/parser.py
+++ b/uio/schema/parser.py
@@ -16,6 +16,26 @@ _FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n(.*)", re.DOTALL)
 
 REQUIRED_FIELDS = ("name", "description")
 
+KNOWN_FRONTMATTER_KEYS: frozenset[str] = frozenset(
+    [
+        "name",
+        "description",
+        "complexity",
+        "capabilities",
+        "timeout",
+        "argument-hint",
+        "invokable",
+        "max_tokens",
+        "guardrails",
+        "context",
+        "github-identity",
+        "vcs-identity",
+        "vcs-provider",
+        "schema",
+        "extends",
+    ]
+)
+
 # Matches "# <Type>: <name>" H1 headings
 _H1_RE = re.compile(r"^#\s+(\w+):\s+(.+)$", re.MULTILINE)
 
@@ -246,27 +266,6 @@ def validate_definition(path: str, frontmatter: dict) -> list[str]:
             )
 
     return errors
-
-
-KNOWN_FRONTMATTER_KEYS: frozenset[str] = frozenset(
-    [
-        "name",
-        "description",
-        "complexity",
-        "capabilities",
-        "timeout",
-        "argument-hint",
-        "invokable",
-        "max_tokens",
-        "guardrails",
-        "context",
-        "github-identity",
-        "vcs-identity",
-        "vcs-provider",
-        "schema",
-        "extends",
-    ]
-)
 
 
 def check_unknown_keys(path: str, frontmatter: dict) -> list[str]:


### PR DESCRIPTION
Closes #276

## Summary

- **Docs**: stopped using "capabilities" as a synonym for "tools" throughout `02-concepts.md`, `04-frontmatter.md`, and `12-writing-definitions.md`; added a dedicated **Capability** glossary entry; fixed an invalid `github` capability value in an example (should be `vcs`)
- **Validation**: replaced the hard error on unknown frontmatter keys with a non-fatal warning via a new `check_unknown_keys()` function — foreign keys like `tools:` (used by other frameworks) are now tolerated; `KNOWN_FRONTMATTER_KEYS` is an explicit frozenset
- **CLI**: `uio agent explain` now reads `capabilities:` instead of the removed `tools:` alias path
- **Tests**: fixtures updated to use `capabilities:` with valid values; two new tests cover the warn-but-ignore behaviour

## Test plan

- [ ] `pytest tests/test_parser.py tests/test_inheritance.py` passes (71 tests)
- [ ] `uio validate` on a definition with a foreign `tools:` key emits a warning but exits zero
- [ ] `uio validate` on a definition with a misspelled uio key (e.g. `Complexity:`) emits a warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)